### PR TITLE
🧹 Add error reporting to GlobalErrorBoundary

### DIFF
--- a/packages/ui-vue-shadcn/package.json
+++ b/packages/ui-vue-shadcn/package.json
@@ -21,6 +21,7 @@
     "@codemirror/state": "6.5.4",
     "@codemirror/view": "6.39.14",
     "@dailyuse/ui-core": "workspace:*",
+    "@dailyuse/utils": "workspace:*",
     "@internationalized/date": "^3.11.0",
     "@radix-icons/vue": "1.0.0",
     "@unovis/ts": "1.6.4",

--- a/packages/ui-vue-shadcn/src/components/custom/application/GlobalErrorBoundary.vue
+++ b/packages/ui-vue-shadcn/src/components/custom/application/GlobalErrorBoundary.vue
@@ -11,6 +11,9 @@
  *   </GlobalErrorBoundary>
  */
 import { ref, onErrorCaptured } from 'vue';
+import { createLogger } from '@dailyuse/utils';
+
+const logger = createLogger('GlobalErrorBoundary');
 
 const hasError = ref(false);
 const errorMessage = ref('');
@@ -21,8 +24,15 @@ onErrorCaptured((err: Error) => {
   errorMessage.value = err.message || '发生了未知错误';
   errorStack.value = err.stack || '';
 
-  // TODO: 如果接入了 Sentry / 错误监控，可以在这里上报
-  console.error('[GlobalErrorBoundary]', err);
+  // 使用统一日志系统记录错误
+  logger.error('Captured global error', err);
+
+  // 如果接入了 Sentry，进行上报
+  // @ts-ignore - Sentry 可能是通过 CDN 或外部脚本全局注入的
+  if (globalThis.Sentry) {
+    // @ts-ignore
+    globalThis.Sentry.captureException(err);
+  }
 
   // 返回 false 阻止错误继续向上传播
   return false;


### PR DESCRIPTION
The `GlobalErrorBoundary` component now correctly reports errors using the project's unified logging system and Sentry (if available). 

🎯 **What:** 
- Added `@dailyuse/utils` to `packages/ui-vue-shadcn/package.json`.
- Updated `GlobalErrorBoundary.vue` to use `createLogger` and check for `globalThis.Sentry`.

💡 **Why:** 
- Improves maintainability and observability by ensuring errors are logged and reported to monitoring services instead of just being printed to the console.

✅ **Verification:** 
- Manual code review confirmed the logic is safe (uses conditional checks for Sentry) and follows project patterns.
- Verified that `@dailyuse/utils` is used as a workspace dependency.

✨ **Result:** 
- The `GlobalErrorBoundary` now has actual error reporting capabilities as originally planned in the codebase.

---
*PR created automatically by Jules for task [5701893097078085340](https://jules.google.com/task/5701893097078085340) started by @BakerSean168*