### PR TITLE
Refactor contract enum types to standard pattern

### DIFF
--- a/packages/contracts/src/modules/account/value-objects/account-status.ts
+++ b/packages/contracts/src/modules/account/value-objects/account-status.ts
@@ -4,4 +4,4 @@ export const AccountStatus = {
   DEACTIVATED: 'DEACTIVATED',
 } as const;
 
-export type AccountStatus = typeof AccountStatus[keyof typeof AccountStatus];
+export type AccountStatus = (typeof AccountStatus)[keyof typeof AccountStatus];

--- a/packages/contracts/src/modules/authentication/value-objects/credential-type.ts
+++ b/packages/contracts/src/modules/authentication/value-objects/credential-type.ts
@@ -2,5 +2,7 @@ export const CredentialType = {
   PASSWORD: 'PASSWORD',
   MAGIC_LINK: 'MAGIC_LINK',
   OAUTH: 'OAUTH',
+  PHONE: 'PHONE',
 } as const;
+
 export type CredentialType = (typeof CredentialType)[keyof typeof CredentialType];

--- a/packages/contracts/src/modules/authentication/value-objects/device-type.ts
+++ b/packages/contracts/src/modules/authentication/value-objects/device-type.ts
@@ -10,4 +10,4 @@ export const DeviceType = {
 
 // 2. 提取类型 (自动生成联合类型)
 // 结果等同于: 'DESKTOP' | 'MOBILE' | 'TABLET' ...
-export type DeviceType = typeof DeviceType[keyof typeof DeviceType];
+export type DeviceType = (typeof DeviceType)[keyof typeof DeviceType];

--- a/packages/contracts/src/modules/authentication/value-objects/oauth-provider.ts
+++ b/packages/contracts/src/modules/authentication/value-objects/oauth-provider.ts
@@ -7,4 +7,4 @@ export const OAuthProvider = {
     WEIBO: 'WEIBO'
 } as const;
 
-export type OAuthProvider = typeof OAuthProvider[keyof typeof OAuthProvider];
+export type OAuthProvider = (typeof OAuthProvider)[keyof typeof OAuthProvider];

--- a/packages/contracts/src/modules/authentication/value-objects/session-status.ts
+++ b/packages/contracts/src/modules/authentication/value-objects/session-status.ts
@@ -8,4 +8,4 @@ export const SessionStatus = {
   REVOKED: 'REVOKED'    // 被撤销 (踢下线/登出/改密强制下线)
 } as const;
 
-export type SessionStatus = typeof SessionStatus[keyof typeof SessionStatus];
+export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];


### PR DESCRIPTION
Refactored TypeScript enum patterns in `packages/contracts` to use `(typeof Object)[keyof typeof Object]` for better consistency and correctness. Also fixed a missing `PHONE` key in `CredentialType` to resolve build errors.

---
*PR created automatically by Jules for task [6505700691845656104](https://jules.google.com/task/6505700691845656104) started by @BakerSean168*