### PR TITLE
Refactor EditorTab type in useEditor composable

### DIFF
--- a/apps/web/src/modules/editor/presentation/composables/useEditor.ts
+++ b/apps/web/src/modules/editor/presentation/composables/useEditor.ts
@@ -4,8 +4,9 @@
  */
 
 import { ref, computed } from 'vue';
-// import type { EditorTab } from '../components/EditorTabBar.vue';
-type EditorTab = any; // TODO: Define proper type
+import type { SimpleEditorTab } from '@dailyuse/contracts/shared';
+
+type EditorTab = SimpleEditorTab;
 
 /**
  * 编辑器实例引用


### PR DESCRIPTION
Replaced `type EditorTab = any` with `type EditorTab = SimpleEditorTab` in `apps/web/src/modules/editor/presentation/composables/useEditor.ts`.
Imported `SimpleEditorTab` from `@dailyuse/contracts/shared`.
This addresses the requirement to define a proper type for `EditorTab` instead of using `any`.
Verified type definition in `packages/contracts/src/shared/ui-components.ts` and confirmed it matches usage.
Ran `vue-tsc` to ensure no type errors in the modified file (after building contracts).

---
*PR created automatically by Jules for task [8664793792690979839](https://jules.google.com/task/8664793792690979839) started by @BakerSean168*