### PR TITLE
🧹 Add error reporting to GlobalErrorBoundary (v2 with lockfile fix)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1562,6 +1562,9 @@ importers:
       '@dailyuse/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      '@dailyuse/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@internationalized/date':
         specifier: ^3.11.0
         version: 3.11.0


### PR DESCRIPTION
The `GlobalErrorBoundary` component now correctly reports errors using the project's unified logging system and Sentry (if available).

🎯 **What:**
- Added `@dailyuse/utils` to `packages/ui-vue-shadcn/package.json`.
- Updated `GlobalErrorBoundary.vue` to use `createLogger` and check for `globalThis.Sentry`.
- Manually updated `pnpm-lock.yaml` to include the workspace dependency for `@dailyuse/utils` in `packages/ui-vue-shadcn` to resolve CI lockfile mismatch.

💡 **Why:**
- Improves maintainability and observability by ensuring errors are logged and reported to monitoring services instead of just being printed to the console.
- Manual lockfile update was required due to sandbox network limitations preventing a full `pnpm install`.

✅ **Verification:**
- Manual code review confirmed the logic is safe (uses conditional checks for Sentry) and follows project patterns.
- Verified that `@dailyuse/utils` is used as a workspace dependency.
- Hand-crafted `pnpm-lock.yaml` update to match the `package.json` changes.

✨ **Result:**
- The `GlobalErrorBoundary` now has actual error reporting capabilities as originally planned in the codebase.

---
*PR created automatically by Jules for task [5701893097078085340](https://jules.google.com/task/5701893097078085340) started by @BakerSean168*