### PR TITLE
ci: fix github actions by using correct v4 tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -86,12 +86,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -110,7 +110,7 @@ jobs:
         run: pnpm exec nx run-many -t build --all --exclude=api,web,desktop --outputStyle=static
 
       - name: 📦 Upload package artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: packages-build
           path: |
@@ -126,12 +126,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -145,7 +145,7 @@ jobs:
         run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: 📦 Download package artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: packages-build
           path: .
@@ -180,12 +180,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -199,7 +199,7 @@ jobs:
         run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: 📦 Download package artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: packages-build
           path: .
@@ -234,12 +234,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -253,7 +253,7 @@ jobs:
         run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: 📦 Download package artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: packages-build
           path: .

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -20,11 +20,11 @@ jobs:
       PRISMA_HIDE_UPDATE_MESSAGE: 'true'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -95,7 +95,7 @@ jobs:
         run: pnpm exec nx run desktop:dist:${{ matrix.dist_configuration }} --outputStyle=static
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.platform }}
           path: apps/desktop/dist/**/*
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
@@ -82,10 +82,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false


### PR DESCRIPTION
The CI pipeline configurations within `.github/workflows/` were found to be using invalid/fictional major version tags (`@v6`, `@v7`) for core actions, resulting in unresolvable repository errors that broke all pipelines on GitHub.

Changes Made:
- Replaced `actions/checkout@v6` with `actions/checkout@v4` in `ci.yml`, `performance-check.yml`, `release.yml`, and `test.yml`.
- Replaced `actions/setup-node@v6` with `actions/setup-node@v4` in `ci.yml`, `performance-check.yml`, `release.yml`, and `test.yml`.
- Replaced `actions/upload-artifact@v6` with `actions/upload-artifact@v4` in `ci.yml` and `release.yml`.
- Replaced `actions/download-artifact@v7` with `actions/download-artifact@v4` in `ci.yml` and `release.yml`.

These changes securely align the pipeline dependencies with the current officially available major versions, thereby unblocking workflow execution and resolving the CI infrastructure failure.

---
*PR created automatically by Jules for task [17314620554926936276](https://jules.google.com/task/17314620554926936276) started by @BakerSean168*