### PR TITLE
fix: prevent crash in `createIdType` on undefined values

### DIFF
--- a/packages/utils/src/domain/create-id-type.ts
+++ b/packages/utils/src/domain/create-id-type.ts
@@ -14,7 +14,7 @@ export function createIdType<T extends string>(prefix: string) {
     // 自动获得还原能力
     of(value: string): T {
       // 自动校验前缀 (可选，增加安全性)
-      if (!value.startsWith(prefix + '_')) {
+      if (!value || typeof value !== 'string' || !value.startsWith(prefix + '_')) {
         console.warn(`ID ${value} does not start with expected prefix ${prefix}`);
       }
       return value as T;


### PR DESCRIPTION
Added a safety check to `packages/utils/src/domain/create-id-type.ts`'s `of()` method so it handles `undefined` or non-string values gracefully, preventing runtime crashes in `task-client-service.ts` mapping logic when processing DTOs missing an `identityId`. Verified by running unit tests in the `utils` package.

---
*PR created automatically by Jules for task [2260625883587341074](https://jules.google.com/task/2260625883587341074) started by @BakerSean168*