### PR TITLE
fix: resolve guest id validation error and update logout warning

### DIFF
--- a/apps/desktop/src/main/modules/authentication/application/AuthDesktopApplicationService.ts
+++ b/apps/desktop/src/main/modules/authentication/application/AuthDesktopApplicationService.ts
@@ -1213,7 +1213,7 @@ export class AuthDesktopApplicationService {
     identityId: string,
     tokenData: TokenStorageData | null,
   ): AuthMode {
-    if (this.isGuestIdentityId(identityId)) {
+    if (this.isGuestTokenData(tokenData)) {
       return AuthMode.GUEST;
     }
 
@@ -1224,8 +1224,14 @@ export class AuthDesktopApplicationService {
     return tokenData ? AuthMode.ONLINE_USER : AuthMode.OFFLINE_USER;
   }
 
-  private isGuestIdentityId(identityId: string | null | undefined): identityId is string {
-    return Boolean(identityId?.startsWith('GuestIdentity_'));
+  private isGuestTokenData(tokenData: TokenStorageData | null): boolean {
+    if (!tokenData) {
+      return false;
+    }
+    return (
+      tokenData.accessToken === 'guest-local-token' &&
+      tokenData.refreshToken === 'guest-local-token'
+    );
   }
 
   private isLocalOnlyTokenData(tokenData: TokenStorageData | null): boolean {
@@ -1234,18 +1240,13 @@ export class AuthDesktopApplicationService {
     }
 
     return (
-      (tokenData.accessToken === 'local-token' && tokenData.refreshToken === 'local-token') ||
-      (tokenData.accessToken === 'guest-local-token' &&
-        tokenData.refreshToken === 'guest-local-token')
+      tokenData.accessToken === 'local-token' && tokenData.refreshToken === 'local-token'
     );
   }
 
   private getProjectionFallbackEmail(identityId: string): string | null {
-    // Guest 身份不使用 fallback email，避免创建带有无效邮箱的 Account
-    if (this.isGuestIdentityId(identityId)) {
-      return null;
-    }
-
+    // 无法直接通过 id 判断访客（已使用标准 IdentityId）
+    // 当前业务中访客和未同步账号都没有有效邮箱，默认返回 null 即可。
     return null;
   }
 

--- a/apps/desktop/src/main/modules/authentication/infrastructure/SessionManager.ts
+++ b/apps/desktop/src/main/modules/authentication/infrastructure/SessionManager.ts
@@ -70,7 +70,7 @@ export interface SessionStatus extends Omit<SessionStatusDTO, 'device'> {
  */
 export class SessionManager {
   private static instance: SessionManager | null = null;
-  private static readonly GUEST_ID_PREFIX = 'GuestIdentity';
+  private static readonly GUEST_ID_PREFIX = 'IdentityId';
   private static readonly LOCAL_ACCESS_TOKEN = 'local-token';
   private static readonly GUEST_ACCESS_TOKEN = 'guest-local-token';
 
@@ -862,8 +862,9 @@ export class SessionManager {
    * Can be cleared via clearGuestIdentity() when the user upgrades to a cloud account.
    */
   async getOrCreateGuestIdentity(): Promise<string> {
-    const cachedGuestId = this.tokenManager.getCachedTokenData()?.identityId;
-    if (cachedGuestId && this.isGuestIdentity(cachedGuestId)) {
+    const tokenData = this.tokenManager.getCachedTokenData();
+    const cachedGuestId = tokenData?.identityId;
+    if (cachedGuestId && this.isGuestToken(tokenData)) {
       const existingGuestSessions = await this.sessionRepository.findByIdentityId(
         cachedGuestId as unknown as IdentityId,
       );
@@ -917,8 +918,9 @@ export class SessionManager {
 
   /** Clear guest identity (called when user upgrades to a cloud account). */
   async clearGuestIdentity(): Promise<void> {
-    const cachedGuestId = this.tokenManager.getCachedTokenData()?.identityId;
-    if (cachedGuestId && this.isGuestIdentity(cachedGuestId)) {
+    const tokenData = this.tokenManager.getCachedTokenData();
+    const cachedGuestId = tokenData?.identityId;
+    if (cachedGuestId && this.isGuestToken(tokenData)) {
       const guestSessions = await this.sessionRepository.findByIdentityId(
         cachedGuestId as unknown as IdentityId,
       );
@@ -930,8 +932,12 @@ export class SessionManager {
     this.logger.info('Guest identity cleared');
   }
 
-  private isGuestIdentity(identityId: string | null | undefined): identityId is string {
-    return Boolean(identityId?.startsWith(`${SessionManager.GUEST_ID_PREFIX}_`));
+  private isGuestToken(tokenData: { accessToken?: string; refreshToken?: string } | null): boolean {
+    if (!tokenData) return false;
+    return (
+      tokenData.accessToken === SessionManager.GUEST_ACCESS_TOKEN &&
+      tokenData.refreshToken === SessionManager.GUEST_ACCESS_TOKEN
+    );
   }
 
   // ============ Private Methods ============

--- a/packages/app-vue/src/locales/en-US.ts
+++ b/packages/app-vue/src/locales/en-US.ts
@@ -599,7 +599,7 @@ export default {
     logoutHint: 'You can safely sign out here and return to the login page right away.',
     logoutConfirm: {
       title: 'Log out of your account?',
-      description: 'You will return to the sign-in page and need to log in again to continue.',
+      description: 'You will return to the sign-in page, and all unsynced local data will be permanently deleted. You need to log in again to continue.',
       confirmText: 'Log Out',
       cancelText: 'Cancel',
     },

--- a/packages/app-vue/src/locales/zh-CN.ts
+++ b/packages/app-vue/src/locales/zh-CN.ts
@@ -588,7 +588,7 @@ export default {
     logoutHint: '你可以在这里安全退出当前账户，会立即返回登录页。',
     logoutConfirm: {
       title: '确认退出登录？',
-      description: '退出后将返回登录页，如需继续使用需要重新登录。',
+      description: '退出后将返回登录页，并清除所有未同步的本地数据，此操作无法恢复。如需继续使用需要重新登录。',
       confirmText: '退出登录',
       cancelText: '取消',
     },


### PR DESCRIPTION
This PR addresses the user-reported issues with the Guest Mode:

1. **Guest ID Validation Error:**
The application was throwing `create-id-type.ts:46 ID GuestIdentity_... does not start with expected prefix IdentityId`. To fix this, the `GUEST_ID_PREFIX` in `SessionManager` was updated from `GuestIdentity` to `IdentityId`. Since we can no longer rely on the ID string itself to determine if a user is a guest, the logic in `SessionManager` and `AuthDesktopApplicationService` was refactored to verify guest status by checking if the cached token is the hardcoded `'guest-local-token'`.

2. **Logout Data Loss Clarity:**
When users log out, the local PowerSync database is wiped (`disconnectAndClear()`). While this behavior is intended (especially when transitioning between cloud accounts or guest modes for privacy and sync integrity), it was confusing for users. Added explicit warnings to the Vue localization files (`en-US.ts` and `zh-CN.ts`) stating that logging out will permanently delete all unsynced local data.

---
*PR created automatically by Jules for task [10611036000930412124](https://jules.google.com/task/10611036000930412124) started by @BakerSean168*