### PR TITLE
fix: use valid IdentityId format for guest account mock profile

### DIFF
--- a/packages/app-vue/src/modules/account/composables/useAccount.ts
+++ b/packages/app-vue/src/modules/account/composables/useAccount.ts
@@ -43,7 +43,7 @@ export function useAccount() {
     if (authStore.authMode === AuthMode.GUEST) {
       // Create a mock profile for guest
       accountStore.setCurrentAccount({
-        id: 'guest',
+        id: authStore.currentIdentity?.id as any,
         email: null,
         profile: {
           nickname: '本地访客',


### PR DESCRIPTION
This pull request addresses an issue where entering guest mode in the desktop application incorrectly redirected users back to the login screen. 

The bug was caused by a recent change that updated the format of guest IDs to use the `IdentityId_xxxx` prefix. However, `useAccount.ts` was still hardcoding the guest account's `id` as the literal string `'guest'`. This mismatch triggered a Zod validation failure during state updates.

This PR updates the mock profile creation to dynamically retrieve and use the generated `IdentityId` from the auth store, ensuring the `id` field is valid and resolving the redirect issue.

---
*PR created automatically by Jules for task [14816920155418999755](https://jules.google.com/task/14816920155418999755) started by @BakerSean168*