### PR TITLE
fix: resolve disabled new note button and unresponsive note opening

### DIFF
--- a/packages/app-vue/src/modules/editor/services/editorDesktop.service.ts
+++ b/packages/app-vue/src/modules/editor/services/editorDesktop.service.ts
@@ -15,6 +15,33 @@ function getElectronApi() {
   return typeof window !== 'undefined' ? window.electronAPI : undefined;
 }
 
+export async function createEditorWorkspace(workspaceId: string): Promise<boolean> {
+  const api = getElectronApi();
+  if (!api) {
+    return false;
+  }
+
+  const result = (await api.invoke(EditorChannels.WORKSPACE_CREATE, {
+    workspaceId,
+  })) as { ok?: boolean };
+
+  return Boolean(result?.ok);
+}
+
+export async function getEditorWorkspace(workspaceId: string): Promise<{ id: string } | null> {
+  const api = getElectronApi();
+  if (!api) {
+    return null;
+  }
+
+  const result = (await api.invoke(EditorChannels.WORKSPACE_GET, workspaceId)) as {
+    ok?: boolean;
+    data?: { id: string } | null;
+  };
+
+  return result?.ok ? (result.data ?? null) : null;
+}
+
 export async function listEditorSessions(workspaceId: string): Promise<EditorSessionClientDTO[]> {
   const api = getElectronApi();
   if (!api) {

--- a/packages/app-vue/src/modules/editor/stores/editorWorkspaceStore.ts
+++ b/packages/app-vue/src/modules/editor/stores/editorWorkspaceStore.ts
@@ -8,6 +8,8 @@ import {
   deleteEditorTab,
   updateEditorTab,
   firstGroup,
+  createEditorWorkspace,
+  getEditorWorkspace,
 } from '../services/editorDesktop.service';
 
 export interface EditorWorkspaceState {
@@ -131,10 +133,17 @@ export const useEditorWorkspaceStore = defineStore('editor-workspace', {
       }
 
       this.workspaceId = workspaceId;
+
+      let workspace = await getEditorWorkspace(workspaceId);
+      if (!workspace) {
+        await createEditorWorkspace(workspaceId);
+        workspace = await getEditorWorkspace(workspaceId);
+      }
+
       const sessions = await listEditorSessions(workspaceId);
       this.setSessions(sessions);
 
-      if (this.sessions.length === 0) {
+      if (this.sessions.length === 0 && workspace) {
         const created = await createEditorSession(workspaceId, 'Main');
         if (created) {
           this.setSessions([created]);

--- a/packages/app-vue/src/modules/repository/components/TypedFileTree.vue
+++ b/packages/app-vue/src/modules/repository/components/TypedFileTree.vue
@@ -13,7 +13,7 @@
         size="icon"
         class="h-8 w-8"
         :title="t('repository.workspace.createNote')"
-        :disabled="rootNoteFolderId === null"
+        :disabled="isLoading"
         @click="$emit('create-note')"
       >
         <FilePlus class="h-4 w-4" />
@@ -304,7 +304,6 @@ function getGroupActions(groupKey: string): MenuAction[] {
         key: 'create-note',
         label: t('repository.workspace.createNote'),
         icon: FilePlus,
-        disabled: rootNoteFolderId.value === null,
         handler: () => emit('create-note'),
       },
       {

--- a/packages/app-vue/src/modules/repository/composables/useRepositoryResourceCommands.ts
+++ b/packages/app-vue/src/modules/repository/composables/useRepositoryResourceCommands.ts
@@ -43,12 +43,12 @@ export function useRepositoryResourceCommands(activeResource: Ref<ResourceClient
 
   async function handleCreateNote() {
     const noteFolderId = findNotesFolderId(repository.treeNodes.value);
-    if (!noteFolderId) {
-      toast.error(t('repository.workspace.createNoteFailed'));
-      return;
-    }
 
-    const note = await repository.createMarkdownNote(undefined, '', noteFolderId);
+    const note = await repository.createMarkdownNote(
+      undefined,
+      '',
+      noteFolderId ?? undefined,
+    );
     if (!note) {
       toast.error(t('repository.workspace.createNoteFailed'));
       return;


### PR DESCRIPTION
This submission fixes two critical bugs in the repository and editor modules:
1.  **Disabled "New Note" Button:** The button in `TypedFileTree.vue` was erroneously checking for the existence of a specific `/notes` folder and disabling itself if it wasn't found. This has been fixed to allow notes to be created in the repository root (by passing `undefined` as the `folderId`) when a specific folder doesn't exist.
2.  **Unresponsive Note Opening:** Double-clicking or clicking an existing note failed to open it in the editor. This was caused by the `editorWorkspaceStore` attempting to create a session for an Editor Workspace that didn't exist in the backend yet. Without a workspace, the session creation returned an empty array, which eventually led to `createTab` failing. This has been resolved by verifying and explicitly creating the Editor Workspace via new IPC bindings before attempting to load or create sessions.

---
*PR created automatically by Jules for task [9007389387631368286](https://jules.google.com/task/9007389387631368286) started by @BakerSean168*