### PR TITLE
test(editor): enforce domain test governance and coverage for editor package

### DIFF
--- a/packages/editor/src/domain-server/aggregates/__tests__/editor-workspace.spec.ts
+++ b/packages/editor/src/domain-server/aggregates/__tests__/editor-workspace.spec.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { IdentityId } from '@dailyuse/domain-shared/shared';
 import { EditorWorkspace } from '../editor-workspace';
 import { EditorSession } from '../../entities/editor-session';
+import { ProjectType } from '@dailyuse/contracts/editor';
 
 describe('EditorWorkspace', () => {
   it('creates a default session and marks it as active', () => {
+    const identityId = IdentityId.generate();
     const workspace = EditorWorkspace.create({
-      identityId: IdentityId.generate(),
+      identityId,
       name: 'Knowledge Base',
       projectPath: '/tmp/memoflow',
     });
@@ -15,6 +17,24 @@ describe('EditorWorkspace', () => {
     expect(workspace.getActiveSession()).toBeDefined();
     expect(workspace.lastActiveSessionId).toBe(workspace.getActiveSession()?.id);
     expect(workspace.layout.isSidebarVisible).toBe(true);
+    expect(workspace.identityId).toBe(identityId);
+    expect(workspace.name).toBe('Knowledge Base');
+    expect(workspace.projectPath).toBe('/tmp/memoflow');
+    expect(workspace.description).toBeNull();
+    expect(workspace.projectType).toBe('Other');
+    expect(workspace.isActive).toBe(false);
+    expect(workspace.lastAccessedAt).toBeNull();
+  });
+
+  it('can create without default session', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Knowledge Base',
+      projectPath: '/tmp/memoflow',
+      createDefaultSession: false,
+    });
+    expect(workspace.sessions).toHaveLength(0);
+    expect(workspace.lastActiveSessionId).toBeNull();
   });
 
   it('falls back to another session when the active one is removed', () => {
@@ -37,5 +57,110 @@ describe('EditorWorkspace', () => {
 
     expect(workspace.removeSession(additionalSession.id)).toBe(true);
     expect(workspace.getActiveSession()?.id).toBe(workspace.sessions[0]?.id);
+  });
+
+  it('handles removing non-existent session', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+    expect(workspace.removeSession('non-existent' as any)).toBe(false);
+  });
+
+  it('throws error when setting non-existent session as active', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+    expect(() => workspace.setActiveSession('non-existent' as any)).toThrow(/not found/);
+  });
+
+  it('gets a specific session by id', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+    const session = workspace.sessions[0];
+    expect(workspace.getSession(session.id)).toEqual(session);
+    expect(workspace.getSession('non-existent' as any)).toBeUndefined();
+  });
+
+  it('updates simple properties', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+
+    workspace.updateName('New Name');
+    expect(workspace.name).toBe('New Name');
+
+    workspace.updateDescription('Desc');
+    expect(workspace.description).toBe('Desc');
+
+    workspace.updateProjectPath('/new/path');
+    expect(workspace.projectPath).toBe('/new/path');
+  });
+
+  it('updates layout and settings', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+
+    workspace.updateLayout({ isSidebarVisible: false });
+    expect(workspace.layout.isSidebarVisible).toBe(false);
+
+    workspace.updateSettings({ theme: 'dark' });
+    expect(workspace.settings.theme).toBe('dark');
+  });
+
+  it('handles active state', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+
+    expect(workspace.isActive).toBe(false);
+
+    workspace.activate();
+    expect(workspace.isActive).toBe(true);
+    expect(workspace.lastAccessedAt).toBeInstanceOf(Date);
+
+    workspace.deactivate();
+    expect(workspace.isActive).toBe(false);
+  });
+
+  it('converts to Server DTO', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+    workspace.activate();
+
+    const dto = workspace.toServerDTO();
+    expect(dto.id).toBe(workspace.id);
+    expect(dto.name).toBe('Workspace');
+    expect(dto.isActive).toBe(true);
+    expect(dto.sessions).toHaveLength(1);
+    expect(dto.lastAccessedAt).toBeTypeOf('number');
+  });
+
+  it('can be loaded from state', () => {
+    const workspace = EditorWorkspace.create({
+      identityId: IdentityId.generate(),
+      name: 'Workspace',
+      projectPath: '/tmp/workspace',
+    });
+
+    const loaded = EditorWorkspace.load((workspace as any));
+    expect(loaded.id).toBe(workspace.id);
+    expect(loaded.name).toBe('Workspace');
   });
 });

--- a/packages/editor/src/domain-server/services/__tests__/session-restorer.spec.ts
+++ b/packages/editor/src/domain-server/services/__tests__/session-restorer.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SessionRestorer } from '../SessionRestorer';
+import { EditorSession } from '../../entities/editor-session';
+import { EditorWorkspaceId } from '../../../domain-shared/value-objects/editor-workspace-id';
+import { IdentityId } from '@dailyuse/domain-shared/shared';
+
+describe('SessionRestorer', () => {
+  it('restores groups if provided', () => {
+    const restorer = new SessionRestorer();
+    const session = EditorSession.create({
+      workspaceId: EditorWorkspaceId.generate(),
+      identityId: IdentityId.generate(),
+      name: 'Test Session',
+    });
+
+    // Mock the restoreGroups method
+    const restoreGroupsSpy = vi.spyOn(session, 'restoreGroups').mockImplementation(() => {});
+
+    restorer.restore(session, [] as any[]);
+
+    expect(restoreGroupsSpy).toHaveBeenCalledWith([]);
+  });
+
+  it('normalizes active state if no groups provided', () => {
+    const restorer = new SessionRestorer();
+    const session = EditorSession.create({
+      workspaceId: EditorWorkspaceId.generate(),
+      identityId: IdentityId.generate(),
+      name: 'Test Session',
+    });
+
+    // Mock the normalizeActiveState method
+    const normalizeActiveStateSpy = vi.spyOn(session, 'normalizeActiveState').mockImplementation(() => {});
+
+    restorer.restore(session);
+
+    expect(normalizeActiveStateSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/index-status.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/index-status.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { IndexStatus } from '../index-status';
+
+describe('IndexStatus', () => {
+  it('validates status', () => {
+    expect(IndexStatus.isValid('Indexed')).toBe(true);
+    expect(IndexStatus.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates status of valid value', () => {
+    expect(IndexStatus.of('Indexing')).toBe('Indexing');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => IndexStatus.of('Invalid')).toThrow();
+  });
+
+  it('gets all statuses', () => {
+    expect(IndexStatus.getAll()).toEqual(['NotIndexed', 'Indexing', 'Indexed', 'Failed', 'Outdated']);
+  });
+
+  it('checks status type', () => {
+    expect(IndexStatus.isIndexed(IndexStatus.Indexed)).toBe(true);
+    expect(IndexStatus.isIndexed(IndexStatus.NotIndexed)).toBe(false);
+    expect(IndexStatus.isIndexing(IndexStatus.Indexing)).toBe(true);
+    expect(IndexStatus.isIndexing(IndexStatus.Indexed)).toBe(false);
+    expect(IndexStatus.isError(IndexStatus.Failed)).toBe(true);
+    expect(IndexStatus.isError(IndexStatus.Indexed)).toBe(false);
+    expect(IndexStatus.needsIndexing(IndexStatus.NotIndexed)).toBe(true);
+    expect(IndexStatus.needsIndexing(IndexStatus.Outdated)).toBe(true);
+    expect(IndexStatus.needsIndexing(IndexStatus.Indexed)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/linked-source-type.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/linked-source-type.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { LinkedSourceType } from '../linked-source-type';
+
+describe('LinkedSourceType', () => {
+  it('validates type', () => {
+    expect(LinkedSourceType.isValid('MarkdownLink')).toBe(true);
+    expect(LinkedSourceType.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(LinkedSourceType.of('WikiLink')).toBe('WikiLink');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => LinkedSourceType.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(LinkedSourceType.getAll()).toEqual([
+      'MarkdownLink',
+      'MarkdownImage',
+      'HtmlAnchor',
+      'HtmlImage',
+      'WikiLink',
+      'Reference',
+    ]);
+  });
+
+  it('checks type category', () => {
+    expect(LinkedSourceType.isMarkdown(LinkedSourceType.MarkdownLink)).toBe(true);
+    expect(LinkedSourceType.isMarkdown(LinkedSourceType.MarkdownImage)).toBe(true);
+    expect(LinkedSourceType.isMarkdown(LinkedSourceType.HtmlAnchor)).toBe(false);
+    expect(LinkedSourceType.isImage(LinkedSourceType.MarkdownImage)).toBe(true);
+    expect(LinkedSourceType.isImage(LinkedSourceType.HtmlImage)).toBe(true);
+    expect(LinkedSourceType.isImage(LinkedSourceType.MarkdownLink)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/linked-target-type.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/linked-target-type.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { LinkedTargetType } from '../linked-target-type';
+
+describe('LinkedTargetType', () => {
+  it('validates type', () => {
+    expect(LinkedTargetType.isValid('Resource')).toBe(true);
+    expect(LinkedTargetType.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(LinkedTargetType.of('Image')).toBe('Image');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => LinkedTargetType.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(LinkedTargetType.getAll()).toEqual([
+      'Resource',
+      'Image',
+      'Video',
+      'Audio',
+      'Archive',
+      'ExternalUrl',
+      'Anchor',
+    ]);
+  });
+
+  it('checks type category', () => {
+    expect(LinkedTargetType.isMedia(LinkedTargetType.Image)).toBe(true);
+    expect(LinkedTargetType.isMedia(LinkedTargetType.Video)).toBe(true);
+    expect(LinkedTargetType.isMedia(LinkedTargetType.Audio)).toBe(true);
+    expect(LinkedTargetType.isMedia(LinkedTargetType.Resource)).toBe(false);
+    expect(LinkedTargetType.isLocal(LinkedTargetType.ExternalUrl)).toBe(false);
+    expect(LinkedTargetType.isLocal(LinkedTargetType.Resource)).toBe(true);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/project-type.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/project-type.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { ProjectType } from '../project-type';
+
+describe('ProjectType', () => {
+  it('validates type', () => {
+    expect(ProjectType.isValid('Markdown')).toBe(true);
+    expect(ProjectType.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(ProjectType.of('Code')).toBe('Code');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => ProjectType.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(ProjectType.getAll()).toEqual(['Markdown', 'Code', 'Mixed', 'Other']);
+  });
+
+  it('checks type category', () => {
+    expect(ProjectType.isMarkdown(ProjectType.Markdown)).toBe(true);
+    expect(ProjectType.isMarkdown(ProjectType.Code)).toBe(false);
+    expect(ProjectType.isCode(ProjectType.Code)).toBe(true);
+    expect(ProjectType.isCode(ProjectType.Markdown)).toBe(false);
+    expect(ProjectType.isMixed(ProjectType.Mixed)).toBe(true);
+    expect(ProjectType.isMixed(ProjectType.Markdown)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/resource-language.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/resource-language.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { ResourceLanguage } from '../resource-language';
+
+describe('ResourceLanguage', () => {
+  it('validates type', () => {
+    expect(ResourceLanguage.isValid('Markdown')).toBe(true);
+    expect(ResourceLanguage.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(ResourceLanguage.of('Html')).toBe('Html');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => ResourceLanguage.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(ResourceLanguage.getAll()).toEqual([
+      'Markdown',
+      'Plaintext',
+      'Html',
+      'Json',
+      'Typescript',
+      'Javascript',
+      'Python',
+      'Java',
+      'Go',
+      'Rust',
+      'Other',
+    ]);
+  });
+
+  it('checks type category', () => {
+    expect(ResourceLanguage.isMarkdown(ResourceLanguage.Markdown)).toBe(true);
+    expect(ResourceLanguage.isMarkdown(ResourceLanguage.Python)).toBe(false);
+    expect(ResourceLanguage.isCode(ResourceLanguage.Python)).toBe(true);
+    expect(ResourceLanguage.isCode(ResourceLanguage.Java)).toBe(true);
+    expect(ResourceLanguage.isCode(ResourceLanguage.Markdown)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/resource-metadata.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/resource-metadata.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { ResourceMetadata } from '../resource-metadata';
+
+describe('ResourceMetadata', () => {
+  it('creates empty metadata', () => {
+    const metadata = ResourceMetadata.createEmpty();
+    expect(metadata.tags).toEqual([]);
+    expect(metadata.category).toBeNull();
+    expect(metadata.wordCount).toBeNull();
+    expect(metadata.characterCount).toBeNull();
+    expect(metadata.readingTime).toBeNull();
+    expect(metadata.encoding).toBe('utf-8');
+    expect(metadata.language).toBeNull();
+    expect(metadata.customFields).toBeNull();
+    expect(metadata.hasTags).toBe(false);
+    expect(metadata.hasCategory).toBe(false);
+    expect(metadata.wordCountFormatted).toBeNull();
+    expect(metadata.readingTimeFormatted).toBeNull();
+    expect(metadata.tagsDisplay).toBe('-');
+  });
+
+  it('adds and removes tags', () => {
+    let metadata = ResourceMetadata.createEmpty();
+    metadata = metadata.addTag('a');
+    metadata = metadata.addTag('b');
+    metadata = metadata.addTag('a'); // Should not add duplicate
+    expect(metadata.tags).toEqual(['a', 'b']);
+    expect(metadata.hasTags).toBe(true);
+    expect(metadata.tagsDisplay).toBe('a, b');
+
+    metadata = metadata.removeTag('a');
+    expect(metadata.tags).toEqual(['b']);
+  });
+
+  it('sets category', () => {
+    const metadata = ResourceMetadata.createEmpty().setCategory('Tech');
+    expect(metadata.category).toBe('Tech');
+    expect(metadata.hasCategory).toBe(true);
+  });
+
+  it('updates stats', () => {
+    const metadata = ResourceMetadata.createEmpty().updateStats(400, 2000);
+    expect(metadata.wordCount).toBe(400);
+    expect(metadata.characterCount).toBe(2000);
+    expect(metadata.readingTime).toBe(2);
+    expect(metadata.wordCountFormatted).toBe('400 字');
+    expect(metadata.readingTimeFormatted).toBe('2 分钟阅读');
+  });
+
+  it('sets custom fields', () => {
+    let metadata = ResourceMetadata.createEmpty();
+    metadata = metadata.setCustomField('author', 'John');
+    expect(metadata.customFields).toEqual({ author: 'John' });
+
+    metadata = metadata.setCustomField('status', 'draft');
+    expect(metadata.customFields).toEqual({ author: 'John', status: 'draft' });
+  });
+
+  it('converts to/from Server DTO', () => {
+    const metadata = ResourceMetadata.createEmpty();
+    const dto = metadata.toServerDTO();
+    expect(dto.tags).toEqual([]);
+
+    const metadataFromDto = ResourceMetadata.fromDTO(dto);
+    expect(metadataFromDto.tags).toEqual([]);
+
+    const metadataCreated = ResourceMetadata.create(dto);
+    expect(metadataCreated.tags).toEqual([]);
+
+    // With custom fields
+    const metadataWithCustom = ResourceMetadata.createEmpty().setCustomField('key', 'value');
+    const dto2 = metadataWithCustom.toServerDTO();
+    expect(dto2.customFields).toEqual({ key: 'value' });
+  });
+
+  it('converts to/from Persistence DTO', () => {
+    const metadata = ResourceMetadata.createEmpty();
+    const pdto = metadata.toPersistenceDTO();
+    expect(pdto.tags).toBe('[]');
+    expect(pdto.custom_fields).toBeNull();
+
+    const metadataFromPdto = ResourceMetadata.fromPersistenceDTO(pdto);
+    expect(metadataFromPdto.tags).toEqual([]);
+
+    const metadataWithCustom = ResourceMetadata.createEmpty().setCustomField('key', 'value');
+    const pdto2 = metadataWithCustom.toPersistenceDTO();
+    expect(pdto2.custom_fields).toBe('{"key":"value"}');
+
+    const metadataFromPdto2 = ResourceMetadata.fromPersistenceDTO(pdto2);
+    expect(metadataFromPdto2.customFields).toEqual({ key: 'value' });
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/session-layout.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/session-layout.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { SessionLayout } from '../session-layout';
+
+describe('SessionLayout', () => {
+  it('creates default layout', () => {
+    const layout = SessionLayout.createDefault();
+    expect(layout.splitType).toBe('Horizontal');
+    expect(layout.groupCount).toBe(1);
+    expect(layout.activeGroupIndex).toBe(0);
+    expect(layout.isSingleGroup).toBe(true);
+    expect(layout.isHorizontalSplit).toBe(true);
+    expect(layout.isVerticalSplit).toBe(false);
+    expect(layout.isGridLayout).toBe(false);
+  });
+
+  it('creates split layout', () => {
+    const layout = SessionLayout.createSplit('Vertical');
+    expect(layout.splitType).toBe('Vertical');
+    expect(layout.groupCount).toBe(2);
+    expect(layout.isVerticalSplit).toBe(true);
+  });
+
+  it('adds and removes groups', () => {
+    let layout = SessionLayout.createDefault();
+    layout = layout.addGroup();
+    expect(layout.groupCount).toBe(2);
+    expect(layout.isSingleGroup).toBe(false);
+
+    layout = layout.removeGroup();
+    expect(layout.groupCount).toBe(1);
+
+    layout = layout.removeGroup();
+    expect(layout.groupCount).toBe(1); // Should not go below 1
+  });
+
+  it('changes active group index', () => {
+    let layout = SessionLayout.createSplit('Horizontal');
+    layout = layout.setActiveGroup(1);
+    expect(layout.activeGroupIndex).toBe(1);
+
+    layout = layout.setActiveGroup(-1);
+    expect(layout.activeGroupIndex).toBe(1); // Should remain unchanged
+  });
+
+  it('changes split type', () => {
+    let layout = SessionLayout.createDefault();
+    layout = layout.setSplitType('Grid');
+    expect(layout.splitType).toBe('Grid');
+    expect(layout.isGridLayout).toBe(true);
+  });
+
+  it('adjusts active group on remove', () => {
+    let layout = SessionLayout.createSplit('Horizontal').addGroup(); // 3 groups
+    layout = layout.setActiveGroup(2);
+    layout = layout.removeGroup(); // 2 groups, active index should cap at 1
+    expect(layout.activeGroupIndex).toBe(1);
+  });
+
+  it('converts to/from Server DTO', () => {
+    const layout = SessionLayout.createDefault();
+    const dto = layout.toServerDTO();
+    expect(dto.splitType).toBe('Horizontal');
+
+    const layoutFromDto = SessionLayout.fromDTO(dto);
+    expect(layoutFromDto.splitType).toBe('Horizontal');
+
+    const layoutCreated = SessionLayout.create(dto);
+    expect(layoutCreated.splitType).toBe('Horizontal');
+  });
+
+  it('converts to/from Persistence DTO', () => {
+    const layout = SessionLayout.createDefault();
+    const pdto = layout.toPersistenceDTO();
+    expect(pdto.split_type).toBe('Horizontal');
+
+    const layoutFromPdto = SessionLayout.fromPersistenceDTO(pdto);
+    expect(layoutFromPdto.splitType).toBe('Horizontal');
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/sidebar-active-tab.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/sidebar-active-tab.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { SidebarActiveTab } from '../sidebar-active-tab';
+
+describe('SidebarActiveTab', () => {
+  it('validates type', () => {
+    expect(SidebarActiveTab.isValid('Files')).toBe(true);
+    expect(SidebarActiveTab.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(SidebarActiveTab.of('Tags')).toBe('Tags');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => SidebarActiveTab.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(SidebarActiveTab.getAll()).toEqual(['Files', 'Tags', 'Search', 'Outline', 'Resources']);
+  });
+
+  it('checks type category', () => {
+    expect(SidebarActiveTab.isNavigational(SidebarActiveTab.Files)).toBe(true);
+    expect(SidebarActiveTab.isNavigational(SidebarActiveTab.Tags)).toBe(true);
+    expect(SidebarActiveTab.isNavigational(SidebarActiveTab.Search)).toBe(false);
+    expect(SidebarActiveTab.isUtility(SidebarActiveTab.Outline)).toBe(true);
+    expect(SidebarActiveTab.isUtility(SidebarActiveTab.Search)).toBe(true);
+    expect(SidebarActiveTab.isUtility(SidebarActiveTab.Files)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/split-direction.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/split-direction.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { SplitDirection } from '../split-direction';
+
+describe('SplitDirection', () => {
+  it('validates type', () => {
+    expect(SplitDirection.isValid('Horizontal')).toBe(true);
+    expect(SplitDirection.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(SplitDirection.of('Vertical')).toBe('Vertical');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => SplitDirection.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(SplitDirection.getAll()).toEqual(['Horizontal', 'Vertical']);
+  });
+
+  it('checks type category', () => {
+    expect(SplitDirection.isHorizontal(SplitDirection.Horizontal)).toBe(true);
+    expect(SplitDirection.isHorizontal(SplitDirection.Vertical)).toBe(false);
+    expect(SplitDirection.isVertical(SplitDirection.Vertical)).toBe(true);
+    expect(SplitDirection.isVertical(SplitDirection.Horizontal)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/tab-type.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/tab-type.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { TabType } from '../tab-type';
+
+describe('TabType', () => {
+  it('validates type', () => {
+    expect(TabType.isValid('Resource')).toBe(true);
+    expect(TabType.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(TabType.of('Preview')).toBe('Preview');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => TabType.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(TabType.getAll()).toEqual(['Resource', 'Preview', 'Diff', 'Settings', 'Search', 'Welcome']);
+  });
+
+  it('checks type category', () => {
+    expect(TabType.isContent(TabType.Resource)).toBe(true);
+    expect(TabType.isContent(TabType.Preview)).toBe(true);
+    expect(TabType.isContent(TabType.Settings)).toBe(false);
+    expect(TabType.isUtility(TabType.Search)).toBe(true);
+    expect(TabType.isUtility(TabType.Settings)).toBe(true);
+    expect(TabType.isUtility(TabType.Welcome)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/tab-view-state.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/tab-view-state.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { TabViewState } from '../tab-view-state';
+
+describe('TabViewState', () => {
+  it('creates default state', () => {
+    const state = TabViewState.createDefault();
+    expect(state.scrollTop).toBe(0);
+    expect(state.scrollLeft).toBe(0);
+    expect(state.cursorPosition).toEqual({ line: 1, column: 1 });
+    expect(state.isAtTop).toBe(true);
+    expect(state.cursorLine).toBe(1);
+    expect(state.cursorColumn).toBe(1);
+    expect(state.selections).toBeNull();
+    expect(state.hasSelections).toBe(false);
+    expect(state.selectionCount).toBe(0);
+  });
+
+  it('updates scroll position', () => {
+    const state = TabViewState.createDefault().setScrollPosition(100, 50);
+    expect(state.scrollTop).toBe(100);
+    expect(state.scrollLeft).toBe(50);
+    expect(state.isAtTop).toBe(false);
+
+    const stateOnlyTop = TabViewState.createDefault().setScrollPosition(200);
+    expect(stateOnlyTop.scrollTop).toBe(200);
+    expect(stateOnlyTop.scrollLeft).toBe(0);
+  });
+
+  it('updates cursor position', () => {
+    const state = TabViewState.createDefault().setCursorPosition(10, 5);
+    expect(state.cursorPosition).toEqual({ line: 10, column: 5 });
+    expect(state.cursorLine).toBe(10);
+    expect(state.cursorColumn).toBe(5);
+  });
+
+  it('updates selections', () => {
+    let state = TabViewState.createDefault();
+    const selections = [
+      { start: { line: 1, column: 1 }, end: { line: 1, column: 10 } }
+    ];
+    state = state.setSelections(selections);
+    expect(state.selections).toEqual(selections);
+    expect(state.hasSelections).toBe(true);
+    expect(state.selectionCount).toBe(1);
+
+    state = state.clearSelections();
+    expect(state.selections).toBeNull();
+    expect(state.hasSelections).toBe(false);
+  });
+
+  it('handles null selections properly', () => {
+    const state = TabViewState.create({
+      scrollTop: 0,
+      scrollLeft: 0,
+      cursorPosition: { line: 1, column: 1 },
+      selections: null
+    });
+    expect(state.hasSelections).toBe(false);
+    expect(state.selectionCount).toBe(0);
+  });
+
+  it('converts to/from Server DTO', () => {
+    const state = TabViewState.createDefault();
+    const dto = state.toServerDTO();
+    expect(dto.scrollTop).toBe(0);
+
+    const stateFromDto = TabViewState.fromDTO(dto);
+    expect(stateFromDto.scrollTop).toBe(0);
+
+    // test with selections
+    const stateWithSelections = state.setSelections([{ start: { line: 1, column: 1 }, end: { line: 1, column: 10 } }]);
+    const dto2 = stateWithSelections.toServerDTO();
+    expect(dto2.selections).not.toBeNull();
+  });
+
+  it('converts to/from Persistence DTO', () => {
+    const state = TabViewState.createDefault();
+    const pdto = state.toPersistenceDTO();
+    expect(pdto.scroll_top).toBe(0);
+    expect(pdto.selections).toBeNull();
+
+    const stateFromPdto = TabViewState.fromPersistenceDTO(pdto);
+    expect(stateFromPdto.scrollTop).toBe(0);
+
+    const stateWithSelections = state.setSelections([{ start: { line: 1, column: 1 }, end: { line: 1, column: 10 } }]);
+    const pdto2 = stateWithSelections.toPersistenceDTO();
+    expect(pdto2.selections).not.toBeNull();
+
+    const stateFromPdto2 = TabViewState.fromPersistenceDTO(pdto2);
+    expect(stateFromPdto2.selections).toHaveLength(1);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/version-change-type.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/version-change-type.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { VersionChangeType } from '../version-change-type';
+
+describe('VersionChangeType', () => {
+  it('validates type', () => {
+    expect(VersionChangeType.isValid('Create')).toBe(true);
+    expect(VersionChangeType.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(VersionChangeType.of('Edit')).toBe('Edit');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => VersionChangeType.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(VersionChangeType.getAll()).toEqual([
+      'Create',
+      'Edit',
+      'Delete',
+      'Rename',
+      'Move',
+      'Merge',
+      'Restore',
+    ]);
+  });
+
+  it('checks type category', () => {
+    expect(VersionChangeType.isDestructive(VersionChangeType.Delete)).toBe(true);
+    expect(VersionChangeType.isDestructive(VersionChangeType.Edit)).toBe(false);
+    expect(VersionChangeType.isModification(VersionChangeType.Rename)).toBe(true);
+    expect(VersionChangeType.isModification(VersionChangeType.Edit)).toBe(true);
+    expect(VersionChangeType.isModification(VersionChangeType.Move)).toBe(true);
+    expect(VersionChangeType.isModification(VersionChangeType.Create)).toBe(false);
+    expect(VersionChangeType.isRecoverable(VersionChangeType.Create)).toBe(true);
+    expect(VersionChangeType.isRecoverable(VersionChangeType.Delete)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/view-mode.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/view-mode.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ViewMode } from '../view-mode';
+
+describe('ViewMode', () => {
+  it('validates type', () => {
+    expect(ViewMode.isValid('Editor')).toBe(true);
+    expect(ViewMode.isValid('Invalid')).toBe(false);
+  });
+
+  it('creates type of valid value', () => {
+    expect(ViewMode.of('Preview')).toBe('Preview');
+  });
+
+  it('throws on invalid value', () => {
+    expect(() => ViewMode.of('Invalid')).toThrow();
+  });
+
+  it('gets all types', () => {
+    expect(ViewMode.getAll()).toEqual(['Editor', 'Preview', 'SplitH', 'SplitV']);
+  });
+
+  it('checks type category', () => {
+    expect(ViewMode.isSplit(ViewMode.SplitH)).toBe(true);
+    expect(ViewMode.isSplit(ViewMode.SplitV)).toBe(true);
+    expect(ViewMode.isSplitHorizontal(ViewMode.SplitH)).toBe(true);
+    expect(ViewMode.isSplitVertical(ViewMode.SplitV)).toBe(true);
+    expect(ViewMode.showsEditor(ViewMode.Editor)).toBe(true);
+    expect(ViewMode.showsEditor(ViewMode.SplitH)).toBe(true);
+    expect(ViewMode.showsEditor(ViewMode.SplitV)).toBe(true);
+    expect(ViewMode.showsPreview(ViewMode.Preview)).toBe(true);
+    expect(ViewMode.showsPreview(ViewMode.SplitH)).toBe(true);
+    expect(ViewMode.showsPreview(ViewMode.SplitV)).toBe(true);
+    expect(ViewMode.showsEditor(ViewMode.Preview)).toBe(false);
+    expect(ViewMode.showsPreview(ViewMode.Editor)).toBe(false);
+  });
+});

--- a/packages/editor/src/domain-shared/value-objects/__tests__/workspace-layout.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/workspace-layout.spec.ts
@@ -30,4 +30,42 @@ describe('WorkspaceLayout', () => {
     expect(updated.isSidebarVisible).toBe(false);
     expect(updated.isPanelVisible).toBe(true);
   });
+
+  it('moves sidebar', () => {
+    let layout = WorkspaceLayout.createDefault();
+    expect(layout.isSidebarOnLeft).toBe(true);
+
+    layout = layout.moveSidebarToRight();
+    expect(layout.sidebarPosition).toBe('Right');
+    expect(layout.isSidebarOnLeft).toBe(false);
+
+    layout = layout.moveSidebarToLeft();
+    expect(layout.sidebarPosition).toBe('Left');
+  });
+
+  it('checks panel position', () => {
+    const layout = WorkspaceLayout.createDefault();
+    expect(layout.isPanelOnBottom).toBe(true);
+  });
+
+  it('converts to Server DTO', () => {
+    const layout = WorkspaceLayout.createDefault();
+    const dto = layout.toServerDTO();
+    expect(dto.sidebarPosition).toBe('Left');
+
+    const layout2 = WorkspaceLayout.create(dto);
+    expect(layout2.sidebarPosition).toBe('Left');
+
+    const layout3 = WorkspaceLayout.fromDTO(dto);
+    expect(layout3.sidebarPosition).toBe('Left');
+  });
+
+  it('converts to/from Persistence DTO', () => {
+    const layout = WorkspaceLayout.createDefault();
+    const dto = layout.toPersistenceDTO();
+    expect(dto.sidebar_position).toBe('Left');
+
+    const layout2 = WorkspaceLayout.fromPersistenceDTO(dto);
+    expect(layout2.sidebarPosition).toBe('Left');
+  });
 });

--- a/packages/editor/src/domain-shared/value-objects/__tests__/workspace-settings.spec.ts
+++ b/packages/editor/src/domain-shared/value-objects/__tests__/workspace-settings.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { WorkspaceSettings } from '../workspace-settings';
+
+describe('WorkspaceSettings', () => {
+  it('creates default settings', () => {
+    const settings = WorkspaceSettings.createDefault();
+    expect(settings.theme).toBe('default');
+    expect(settings.fontSize).toBe(14);
+    expect(settings.fontFamily).toBe('Consolas, "Courier New", monospace');
+    expect(settings.lineHeight).toBe(1.5);
+    expect(settings.tabSize).toBe(2);
+    expect(settings.wordWrap).toBe(true);
+    expect(settings.lineNumbers).toBe(true);
+    expect(settings.minimap).toBe(true);
+    expect(settings.hasCustomTheme).toBe(false);
+  });
+
+  it('toggles settings', () => {
+    let settings = WorkspaceSettings.createDefault();
+    settings = settings.toggleWordWrap();
+    expect(settings.wordWrap).toBe(false);
+    settings = settings.toggleMinimap();
+    expect(settings.minimap).toBe(false);
+  });
+
+  it('updates simple fields', () => {
+    let settings = WorkspaceSettings.createDefault();
+    settings = settings.setTheme('dark');
+    expect(settings.theme).toBe('dark');
+    expect(settings.hasCustomTheme).toBe(true);
+
+    settings = settings.setFontSize(16);
+    expect(settings.fontSize).toBe(16);
+  });
+
+  it('updates auto save', () => {
+    let settings = WorkspaceSettings.createDefault();
+    expect(settings.autoSaveFormatted).toBe('每 30 秒');
+
+    settings = settings.disableAutoSave();
+    expect(settings.isAutoSaveEnabled).toBe(false);
+    expect(settings.autoSaveFormatted).toBe('已禁用');
+
+    settings = settings.enableAutoSave(60);
+    expect(settings.isAutoSaveEnabled).toBe(true);
+    expect(settings.autoSave?.interval).toBe(60);
+    expect(settings.autoSaveFormatted).toBe('每 60 秒');
+  });
+
+  it('converts to/from Server DTO', () => {
+    const settings = WorkspaceSettings.createDefault();
+    const dto = settings.toServerDTO();
+    expect(dto.theme).toBe('default');
+
+    const settingsFromDto = WorkspaceSettings.fromDTO(dto);
+    expect(settingsFromDto.theme).toBe('default');
+
+    const settingsCreated = WorkspaceSettings.create(dto);
+    expect(settingsCreated.theme).toBe('default');
+  });
+
+  it('converts to/from Persistence DTO', () => {
+    const settings = WorkspaceSettings.createDefault();
+    const dto = settings.toPersistenceDTO();
+    expect(dto.theme).toBe('default');
+
+    const parsedSettings = WorkspaceSettings.fromPersistenceDTO(dto);
+    expect(parsedSettings.theme).toBe('default');
+  });
+
+  it('handles null values in DTOs', () => {
+    const settings = WorkspaceSettings.fromDTO({
+      theme: null,
+      fontSize: null,
+      fontFamily: null,
+      lineHeight: null,
+      tabSize: null,
+      wordWrap: null,
+      lineNumbers: null,
+      minimap: null,
+      autoSave: null,
+    });
+    expect(settings.theme).toBeNull();
+    expect(settings.autoSave).toBeNull();
+    expect(settings.hasCustomTheme).toBe(false);
+
+    const pdto = settings.toPersistenceDTO();
+    expect(pdto.auto_save).toBeNull();
+
+    const settingsFromPdto = WorkspaceSettings.fromPersistenceDTO(pdto);
+    expect(settingsFromPdto.autoSave).toBeNull();
+  });
+});


### PR DESCRIPTION
Implementation for the `editor` domain test coverage as specified in the configuration and domain test governance convergence plan (`2026-04-26-configuration-and-domain-test-governance.md`).

This PR fulfills the final major missing piece of the structural and numerical test governance mandate.

**Changes:**
1. Created Vitest spec files for all value objects inside `packages/editor/src/domain-shared/value-objects/__tests__/` (e.g., `index-status`, `workspace-layout`, `session-layout`, `resource-metadata`, `tab-view-state`, `workspace-settings`, etc).
2. Added comprehensive tests for the `EditorWorkspace` aggregate root and the `SessionRestorer` domain service.
3. Successfully met and exceeded all numerical TDD governance thresholds (Statements: 80%, Lines: 80%, Functions: 80%, Branches: 70%) for the `editor` package.
4. Validated functionality using `pnpm nx run editor:test:coverage` and overall test target governance scripts.

---
*PR created automatically by Jules for task [3852785600770110121](https://jules.google.com/task/3852785600770110121) started by @BakerSean168*