### PR TITLE
🔒 [security fix] Sanitize Markdown-generated HTML in Vue components

### DIFF
--- a/packages/app-vue/src/modules/editor/components/EditorPreview.vue
+++ b/packages/app-vue/src/modules/editor/components/EditorPreview.vue
@@ -13,6 +13,7 @@
 import { nextTick, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import MarkdownIt from 'markdown-it';
+import { sanitizeHtml } from '@dailyuse/utils';
 import type Token from 'markdown-it/lib/token.mjs';
 import { useRepositoryResourceGateway } from '../../repository/services/repositoryResourceGateway';
 import { resolveMarkdownResourceReferences } from '../utils/markdownResourceReferences';
@@ -196,7 +197,7 @@ async function renderMarkdown() {
       }
     }
 
-    renderedHtml.value = template.innerHTML;
+    renderedHtml.value = sanitizeHtml(template.innerHTML);
     await nextTick();
 
     if (currentRunId !== renderRunId) {

--- a/packages/app-vue/src/modules/repository/components/AIKnowledgeGeneratorDialog.vue
+++ b/packages/app-vue/src/modules/repository/components/AIKnowledgeGeneratorDialog.vue
@@ -132,6 +132,7 @@
 import { ref, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { marked } from 'marked';
+import { sanitizeHtml } from '@dailyuse/utils';
 import {
   Sparkles,
   Folder,
@@ -207,9 +208,10 @@ const savePath = computed(() => {
 
 const renderedContent = computed(() => {
   try {
-    return marked(generatedContent.value);
+    const html = marked(generatedContent.value) as string;
+    return sanitizeHtml(html);
   } catch {
-    return generatedContent.value;
+    return '';
   }
 });
 

--- a/packages/app-vue/src/modules/repository/components/LinkPreviewPopover.vue
+++ b/packages/app-vue/src/modules/repository/components/LinkPreviewPopover.vue
@@ -68,6 +68,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { marked } from 'marked';
+import { sanitizeHtml } from '@dailyuse/utils';
 import { FileText, Image as ImageIcon, Music, Video, FileType } from 'lucide-vue-next';
 import { Button } from '@dailyuse/ui-vue-shadcn';
 
@@ -104,9 +105,10 @@ const renderedExcerpt = computed(() => {
   if (!props.content?.excerpt) return '';
   try {
     const excerpt = props.content.excerpt.slice(0, 500);
-    return marked(excerpt);
+    const html = marked(excerpt) as string;
+    return sanitizeHtml(html);
   } catch {
-    return props.content.excerpt;
+    return '';
   }
 });
 

--- a/packages/app-vue/src/modules/repository/components/ObsidianEditor.vue
+++ b/packages/app-vue/src/modules/repository/components/ObsidianEditor.vue
@@ -160,6 +160,7 @@ import { ref, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useDebounceFn } from '@vueuse/core';
 import { marked } from 'marked';
+import { sanitizeHtml } from '@dailyuse/utils';
 import {
   Upload,
   ChevronLeft,
@@ -256,7 +257,8 @@ const displayFileName = computed(() => {
 
 const renderedContent = computed(() => {
   try {
-    return marked(markdownBody.value || '');
+    const html = marked(markdownBody.value || '') as string;
+    return sanitizeHtml(html);
   } catch {
     return `<p>${t('repository.editor.renderError')}</p>`;
   }

--- a/packages/utils/src/frontend/index.ts
+++ b/packages/utils/src/frontend/index.ts
@@ -22,3 +22,6 @@ export {
 
 // 加载状态管理
 export * from './loadingState';
+
+// HTML 脱敏工具
+export * from './sanitizer';

--- a/packages/utils/src/frontend/sanitizer.spec.ts
+++ b/packages/utils/src/frontend/sanitizer.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sanitizeHtml } from './sanitizer';
+
+describe('sanitizeHtml', () => {
+  it('should return an empty string if input is empty', () => {
+    expect(sanitizeHtml('')).toBe('');
+    expect(sanitizeHtml(null as any)).toBe('');
+  });
+
+  it('should return an empty string if DOMParser is unavailable', () => {
+    const originalDOMParser = globalThis.DOMParser;
+    delete (globalThis as any).DOMParser;
+    expect(sanitizeHtml('<p>Hello</p>')).toBe('');
+    globalThis.DOMParser = originalDOMParser;
+  });
+
+  describe('with DOMParser', () => {
+    it('should keep allowed tags and attributes', () => {
+      const input = '<p class="text-bold">Hello <strong>world</strong></p>';
+      const output = sanitizeHtml(input);
+      expect(output).toBe('<p class="text-bold">Hello <strong>world</strong></p>');
+    });
+
+    it('should remove disallowed tags but keep their text content', () => {
+      const input = '<div>Hello <unknown>tag</unknown><span>there</span></div>';
+      const output = sanitizeHtml(input);
+      expect(output).toContain('Hello tag');
+      expect(output).toContain('there');
+      expect(output).not.toContain('<unknown>');
+    });
+
+    it('should discard dangerous tags and their content', () => {
+      const input = '<div>Hello <script>alert("xss")</script><span>there</span></div>';
+      const output = sanitizeHtml(input);
+      expect(output).toContain('Hello');
+      expect(output).toContain('there');
+      expect(output).not.toContain('<script>');
+      expect(output).not.toContain('alert("xss")');
+    });
+
+    it('should remove disallowed attributes', () => {
+      const input = '<p onclick="alert(1)" class="safe">Text</p>';
+      const output = sanitizeHtml(input);
+      expect(output).toBe('<p class="safe">Text</p>');
+      expect(output).not.toContain('onclick');
+    });
+
+    it('should block dangerous protocols in href and src', () => {
+      const input = '<a href="javascript:alert(1)">Click me</a><img src="data:image/png;base64,..." />';
+      const output = sanitizeHtml(input);
+      expect(output).toBe('<a>Click me</a><img src="data:image/png;base64,...">');
+      // wait, data:image/png is allowed in my v2.
+      // let's re-verify protocol regex: /^(https?|mailto|tel|#|data:image\/)/i
+      expect(output).toContain('src="data:image/png');
+    });
+
+    it('should block dangerous data protocols', () => {
+        const input = '<a href="data:text/html,<html>...">Link</a>';
+        const output = sanitizeHtml(input);
+        expect(output).toBe('<a>Link</a>');
+        expect(output).not.toContain('href');
+    });
+
+    it('should allow safe protocols in href and src', () => {
+      const input = '<a href="https://example.com">Link</a><img src="/path/to/img.png" />';
+      const output = sanitizeHtml(input);
+      expect(output).toContain('href="https://example.com"');
+      expect(output).toContain('src="/path/to/img.png"');
+    });
+
+    it('should handle complex nested structures', () => {
+      const input = `
+        <div class="container">
+          <h1>Title</h1>
+          <ul>
+            <li>Item 1</li>
+            <li><a href="/test">Item 2</a></li>
+          </ul>
+          <table>
+            <thead><tr><th>Header</th></tr></thead>
+            <tbody><tr><td>Cell</td></tr></tbody>
+          </table>
+        </div>
+      `.trim();
+      const output = sanitizeHtml(input);
+      expect(output).toContain('<div class="container">');
+      expect(output).toContain('<h1>Title</h1>');
+      expect(output).toContain('<ul>');
+      expect(output).toContain('<li>Item 1</li>');
+      expect(output).toContain('<a href="/test">Item 2</a>');
+      expect(output).toContain('<table>');
+      expect(output).toContain('<thead>');
+      expect(output).toContain('<th>Header</th>');
+    });
+  });
+});

--- a/packages/utils/src/frontend/sanitizer.ts
+++ b/packages/utils/src/frontend/sanitizer.ts
@@ -1,0 +1,133 @@
+/**
+ * Robust HTML sanitization utility using DOMParser.
+ * Follows a whitelist approach for tags and attributes.
+ * Fail-closed: returns an empty string if DOMParser is unavailable or if an error occurs.
+ */
+
+const ALLOWED_TAGS = new Set([
+  'p', 'br', 'span', 'div', 'strong', 'em', 'b', 'i', 'u', 's', 'del', 'ins', 'mark',
+  'sub', 'sup', 'small', 'blockquote', 'q', 'cite', 'abbr', 'address',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption', 'colgroup', 'col',
+  'code', 'pre', 'kbd', 'samp', 'var',
+  'a', 'img', 'hr'
+]);
+
+const ALLOWED_ATTRIBUTES: Record<string, string[]> = {
+  '*': ['class', 'title', 'dir', 'lang'],
+  'a': ['href', 'target', 'rel', 'data-title', 'data-section'],
+  'img': ['src', 'alt', 'width', 'height', 'data-repository-destination'],
+  'th': ['colspan', 'rowspan', 'scope'],
+  'td': ['colspan', 'rowspan', 'scope'],
+  'ol': ['start', 'type', 'reversed'],
+};
+
+// Use whitelist for protocols instead of blacklist
+const ALLOWED_PROTOCOLS = /^(https?|mailto|tel|#|data:image\/)/i;
+
+// Tags that should be completely discarded including their content
+const DISCARD_TAGS = new Set(['script', 'style', 'iframe', 'object', 'embed', 'head', 'base']);
+
+/**
+ * Sanitizes an HTML string.
+ * @param html The HTML string to sanitize.
+ * @returns The sanitized HTML string.
+ */
+export function sanitizeHtml(html: string): string {
+  if (!html) return '';
+
+  if (typeof window === 'undefined' || typeof DOMParser === 'undefined') {
+    // Fail-closed in non-browser environments
+    return '';
+  }
+
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const body = doc.body;
+
+    if (!body) return '';
+
+    // Create a wrapper element to hold the sanitized content
+    const container = document.createElement('div');
+
+    // Sanitize children of body and append to container
+    for (let i = 0; i < body.childNodes.length; i++) {
+      const sanitizedChild = sanitizeNode(body.childNodes[i]);
+      if (sanitizedChild) {
+        container.appendChild(sanitizedChild);
+      }
+    }
+
+    return container.innerHTML;
+  } catch (error) {
+    console.error('HTML sanitization error:', error);
+    return '';
+  }
+}
+
+function sanitizeNode(node: Node): Node | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.cloneNode(true);
+  }
+
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement;
+    const tagName = element.tagName.toLowerCase();
+
+    // If tag is in discard list, return null to discard the whole subtree
+    if (DISCARD_TAGS.has(tagName)) {
+      return null;
+    }
+
+    if (ALLOWED_TAGS.has(tagName)) {
+      const sanitizedElement = document.createElement(tagName);
+
+      // Sanitize attributes
+      const allowedAttrs = ALLOWED_ATTRIBUTES[tagName] || [];
+      const globalAttrs = ALLOWED_ATTRIBUTES['*'] || [];
+      const allAllowedAttrs = [...allowedAttrs, ...globalAttrs];
+
+      for (let i = 0; i < element.attributes.length; i++) {
+        const attr = element.attributes[i];
+        const attrName = attr.name.toLowerCase();
+
+        if (allAllowedAttrs.includes(attrName)) {
+          const attrValue = attr.value;
+
+          // Special handling for href and src to block dangerous protocols
+          if (attrName === 'href' || attrName === 'src') {
+            if (!ALLOWED_PROTOCOLS.test(attrValue.trim())) {
+              continue;
+            }
+          }
+
+          sanitizedElement.setAttribute(attrName, attrValue);
+        }
+      }
+
+      // Recursively sanitize children
+      for (let i = 0; i < element.childNodes.length; i++) {
+        const child = element.childNodes[i];
+        const sanitizedChild = sanitizeNode(child);
+        if (sanitizedChild) {
+          sanitizedElement.appendChild(sanitizedChild);
+        }
+      }
+
+      return sanitizedElement;
+    }
+  }
+
+  // If node is not allowed but not in discard list, return its sanitized children (stripping the tag)
+  const fragment = document.createDocumentFragment();
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = node.childNodes[i];
+    const sanitizedChild = sanitizeNode(child);
+    if (sanitizedChild) {
+      fragment.appendChild(sanitizedChild);
+    }
+  }
+  return fragment;
+}


### PR DESCRIPTION
🎯 **What:** Fixed multiple XSS vulnerabilities where Markdown-generated HTML was rendered using `v-html` without sanitization.

⚠️ **Risk:** Maliciously crafted Markdown (either AI-generated or user-provided) could execute arbitrary JavaScript in the user's browser, leading to data theft or unauthorized actions.

🛡️ **Solution:** 
- Created a `sanitizeHtml` utility in `packages/utils/src/frontend/sanitizer.ts` that uses a whitelist-based approach with `DOMParser`.
- It completely discards dangerous tags (`script`, `style`, `iframe`, etc.) and their content.
- It strips non-whitelisted tags while preserving their text content.
- It enforces a strict attribute and protocol whitelist (allowing `http`, `https`, `mailto`, `tel`, and `data:image/`).
- It prevents DOM Clobbering by excluding the `id` attribute.
- Integrated this utility into all identified `v-html` call sites rendering Markdown.

---
*PR created automatically by Jules for task [5803905734752979274](https://jules.google.com/task/5803905734752979274) started by @BakerSean168*