### PR TITLE
fix(ci): add MSBuild setup for Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,10 @@ jobs:
         with:
           python-version-file: apps/desktop/.python-version
 
+      - name: Setup MSBuild (Windows)
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Fixes v0.8.0 release Windows build failure by installing Visual Studio Build Tools.

## Problem
The Windows release build failed at the `desktop:native-rebuild` step because `electron-rebuild` couldn't find Visual Studio installation to compile native modules (`argon2`, `better-sqlite3`).

## Solution
Added `microsoft/setup-msbuild@v2` step to install MSBuild tools on Windows runners.

## Impact
- Fixes Windows native module compilation in release workflow
- No impact on Linux builds
- Ready to re-trigger v0.8.0 release after merge