### PR TITLE
fix(ci): configure node-gyp to use VS 2022 explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,15 @@ jobs:
         with:
           python-version-file: apps/desktop/.python-version
 
-      - name: Setup MSBuild (Windows)
+      - name: Setup Visual Studio Build Tools (Windows)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
+
+      - name: Configure node-gyp for VS 2022 (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          npm config set msvs_version 2022
+          npm config set node_gyp_force_process_config 1
 
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,16 +83,6 @@ jobs:
         with:
           python-version-file: apps/desktop/.python-version
 
-      - name: Setup Visual Studio Build Tools (Windows)
-        if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Configure node-gyp for VS 2022 (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          npm config set msvs_version 2022
-          npm config set node_gyp_force_process_config 1
-
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'
         run: |
@@ -127,6 +117,7 @@ jobs:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
           PYTHON: ${{ env.pythonLocation }}/python
           npm_config_python: ${{ env.pythonLocation }}/python
+          npm_config_msvs_version: 2022
         # desktop:build already pulls its Nx build dependencies, so this stays
         # focused on the desktop release path and avoids unrelated apps such as
         # the Python ai-service.
@@ -138,6 +129,7 @@ jobs:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
           PYTHON: ${{ env.pythonLocation }}/python
           npm_config_python: ${{ env.pythonLocation }}/python
+          npm_config_msvs_version: 2022
         run: pnpm nx run desktop:dist:${{ matrix.dist_configuration }} --outputStyle=static
 
       - name: Upload build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,10 @@ jobs:
         with:
           python-version-file: apps/desktop/.python-version
 
+      - name: Setup MSBuild (Windows)
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Adds explicit VS 2022 configuration for node-gyp to fix Windows native module compilation.

## Root Cause
`microsoft/setup-msbuild` only adds MSBuild to PATH, but node-gyp's `findVisualStudio()` couldn't detect the preinstalled VS 2022 on GitHub Actions Windows runners.

## Solution
Explicitly tell node-gyp to use VS 2022:
```
npm config set msvs_version 2022
npm config set node_gyp_force_process_config 1
```

## References
- GitHub Actions Windows runners have VS 2022 preinstalled
- node-gyp needs explicit version hint to locate it