### PR TITLE
fix: 修复 PR #161 遗留的 main 破损（RuleId / contracts DTS / lint / mobile eslint）

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,10 +1,17 @@
 // https://docs.expo.dev/guides/using-eslint/
+// 本地配置以根 eslint.config.ts 为基线（见 docs/governance/configuration-governance.md），
+// 再叠加 Expo / React Native 生态需要的规则；不复制根规则，只保留最小例外。
+const { createJiti } = require('jiti');
 const { defineConfig } = require('eslint/config');
-const expoConfig = require("eslint-config-expo/flat");
+const expoConfig = require('eslint-config-expo/flat');
+
+const jiti = createJiti(__filename);
+const rootConfig = jiti('../../eslint.config.ts').default;
 
 module.exports = defineConfig([
+  ...rootConfig,
   expoConfig,
   {
-    ignores: ["dist/*"],
-  }
+    ignores: ['dist/*'],
+  },
 ]);

--- a/packages/app-vue/src/modules/governance/composables/useGovernance.ts
+++ b/packages/app-vue/src/modules/governance/composables/useGovernance.ts
@@ -20,6 +20,7 @@ import { useStrictInject } from '../../../shared/utils/useStrictInject';
 import type {
   CreateRuleReq,
   RuleClientDTO,
+  RuleId,
   RuleRevisionClientDTO,
   RuleSeverity,
   RuleStatus,
@@ -76,7 +77,7 @@ export function useGovernance() {
         return cached;
       }
 
-      const result = await service.getRule({ id });
+      const result = await service.getRule({ id: id as RuleId });
       if (result.ok) {
         store.setCurrentRule(result.data);
         return result.data;
@@ -126,7 +127,7 @@ export function useGovernance() {
     savingId.value = id;
     store.setError(null);
     try {
-      const result = await service.deleteRule({ id });
+      const result = await service.deleteRule({ id: id as RuleId });
       if (result.ok) {
         store.removeRule(id);
         return true;

--- a/packages/app-vue/src/modules/governance/types.ts
+++ b/packages/app-vue/src/modules/governance/types.ts
@@ -9,6 +9,8 @@ export type { RuleClientDTO, RuleRevisionClientDTO } from '@dailyuse/contracts/g
 
 export type { RuleStatus, RuleSeverity } from '@dailyuse/contracts/governance';
 
+export type { RuleId } from '@dailyuse/contracts/governance';
+
 export type {
   CreateRuleReq,
   UpdateRuleReq,

--- a/packages/contracts/src/mocks/governance.mock.ts
+++ b/packages/contracts/src/mocks/governance.mock.ts
@@ -4,18 +4,10 @@
  */
 
 import { faker } from '@faker-js/faker';
-import type {
-  CodeSnippetId,
-  IdentityId,
-  RuleId,
-  RuleRevisionId,
-} from '@dailyuse/contracts/primitives';
-import type {
-  CodeSnippetDTO,
-  RuleClientDTO,
-  RuleRevisionClientDTO,
-  RuleTagDTO,
-} from '@dailyuse/contracts/governance';
+import type { CodeSnippetId, IdentityId, RuleId, RuleRevisionId } from '../primitives';
+import type { CodeSnippetDTO, RuleTagDTO } from '../modules/governance/value-objects';
+import type { RuleClientDTO } from '../modules/governance/aggregates';
+import type { RuleRevisionClientDTO } from '../modules/governance/entities';
 
 function createMockRuleTag(value?: string): RuleTagDTO {
   return {

--- a/packages/contracts/src/modules/governance/aggregates/rule-client.ts
+++ b/packages/contracts/src/modules/governance/aggregates/rule-client.ts
@@ -3,7 +3,7 @@
  * 规则聚合根 - 客户端契约
  */
 
-import type { TransferDate, IdentityId } from '@dailyuse/contracts/primitives';
+import type { TransferDate, IdentityId } from '../../../primitives';
 import type { RuleId } from '../primitives/ids';
 import type { RuleTagDTO } from '../value-objects/rule-tag';
 import type { RuleStatus } from '../value-objects/rule-status';

--- a/packages/contracts/src/modules/governance/aggregates/rule-server.ts
+++ b/packages/contracts/src/modules/governance/aggregates/rule-server.ts
@@ -31,7 +31,7 @@
  * 参见：docs/standards/值对象里的时间使用number时间戳-毫秒.md
  */
 
-import type { TransferDate, IdentityId } from '@dailyuse/contracts/primitives';
+import type { TransferDate, IdentityId } from '../../../primitives';
 import type { RuleId } from '../primitives/ids';
 import type { RuleTagDTO } from '../value-objects/rule-tag';
 import type { RuleStatus } from '../value-objects/rule-status';

--- a/packages/contracts/src/modules/governance/api/rule-revisions.ts
+++ b/packages/contracts/src/modules/governance/api/rule-revisions.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from 'zod';
-import { brandedId } from '@dailyuse/contracts/primitives';
+import { brandedId } from '../../../primitives';
 import type { RuleId, RuleRevisionId } from '../primitives/ids';
 import type { RuleRevisionClientDTO } from '../entities/rule-revision-client';
 import { PaginationSchema } from './rules';

--- a/packages/contracts/src/modules/governance/api/rules.ts
+++ b/packages/contracts/src/modules/governance/api/rules.ts
@@ -28,7 +28,7 @@
  */
 
 import { z } from 'zod';
-import { brandedId } from '@dailyuse/contracts/primitives';
+import { brandedId } from '../../../primitives';
 import type { RuleId } from '../primitives/ids';
 import type { RuleClientDTO } from '../aggregates/rule-client';
 import { RuleStatus } from '../value-objects/rule-status';

--- a/packages/contracts/src/modules/governance/domain/events/rule-created.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-created.event.ts
@@ -25,7 +25,7 @@
  * - 审计日志：记录规则创建历史
  */
 import type { RuleSeverity } from '../../value-objects/rule-severity';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleCreatedEvent {
   /** Rule code (e.g. DDD-001). 规则编码（例如：DDD-001）。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-deleted.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-deleted.event.ts
@@ -18,7 +18,7 @@
  *   缓存失效：清除缓存的规则数据。
  */
 import type { RuleId } from '../../primitives/ids';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleDeletedEvent {
   /** Rule ID of the deleted rule. 被删除规则的 ID。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-deprecated.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-deprecated.event.ts
@@ -12,7 +12,7 @@
  * - 审计日志：记录规则废弃历史
  */
 import type { RuleId } from '../../primitives/ids';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleDeprecatedEvent {
   /** Rule ID. 规则 ID。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-reactivated.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-reactivated.event.ts
@@ -12,7 +12,7 @@
  * - 审计日志：记录规则激活历史
  */
 import type { RuleId } from '../../primitives/ids';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleReactivatedEvent {
   /** Rule ID. 规则 ID。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-severity-changed.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-severity-changed.event.ts
@@ -13,7 +13,7 @@
  */
 import type { RuleId } from '../../primitives/ids';
 import type { RuleSeverity } from '../../value-objects/rule-severity';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleSeverityChangedEvent {
   /** Rule ID. 规则 ID。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-status-changed.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-status-changed.event.ts
@@ -15,7 +15,7 @@
  */
 import type { RuleId } from '../../primitives/ids';
 import type { RuleStatus } from '../../value-objects/rule-status';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleStatusChangedEvent {
   /** Rule ID. 规则 ID。 */

--- a/packages/contracts/src/modules/governance/domain/events/rule-updated.event.ts
+++ b/packages/contracts/src/modules/governance/domain/events/rule-updated.event.ts
@@ -15,7 +15,7 @@
  * - 缓存服务：清除规则缓存
  */
 import type { RuleId } from '../../primitives/ids';
-import type { IdentityId } from '@dailyuse/contracts/primitives';
+import type { IdentityId } from '../../../../primitives';
 
 export interface RuleUpdatedEvent {
   /** Rule ID. 规则 ID。 */

--- a/packages/contracts/src/modules/governance/entities/rule-revision-client.ts
+++ b/packages/contracts/src/modules/governance/entities/rule-revision-client.ts
@@ -8,7 +8,7 @@
  * - 提供用户友好的变更摘要
  */
 
-import type { TransferDate, IdentityId } from '@dailyuse/contracts/primitives';
+import type { TransferDate, IdentityId } from '../../../primitives';
 import type { RuleRevisionId, RuleId } from '../primitives/ids';
 import type { ChangeType } from '../value-objects/change-type';
 

--- a/packages/contracts/src/modules/governance/entities/rule-revision-server.ts
+++ b/packages/contracts/src/modules/governance/entities/rule-revision-server.ts
@@ -8,7 +8,7 @@
  * - 内部实现细节
  */
 
-import type { TransferDate, IdentityId } from '@dailyuse/contracts/primitives';
+import type { TransferDate, IdentityId } from '../../../primitives';
 import type { RuleRevisionId, RuleId } from '../primitives/ids';
 import type { ChangeType } from '../value-objects/change-type';
 

--- a/packages/dashboard/tsup.config.ts
+++ b/packages/dashboard/tsup.config.ts
@@ -2,8 +2,21 @@ import { baseLibraryConfig, createLocalOnlyDtsPaths } from '../../tools/build/ts
 
 const config = baseLibraryConfig('@dailyuse/dashboard');
 
+const dtsConfig = createLocalOnlyDtsPaths();
+
 export default {
   ...config,
   entry: ['src/index.ts'],
-  dts: createLocalOnlyDtsPaths(),
+  // 固定 DTS 编译根为 ./src。dashboard 再导出 @dailyuse/contracts/dashboard，其产物
+  // 里 dashboard-data.dto → ../../goal/value-objects/goal-status 是跨子路径相对 import，
+  // rollup-plugin-dts 追进去后无法定位 contracts package.json export map 的根，报
+  // TS2209「project root is ambiguous」。显式 rootDir 消歧（仅本包需要，不放进共享 helper
+  // 以免影响 DTS 会追进 workspace 源码的包，如 schedule-orchestration）。
+  dts: {
+    ...dtsConfig,
+    compilerOptions: {
+      ...dtsConfig.compilerOptions,
+      rootDir: './src',
+    },
+  },
 };

--- a/tools/build/tsup.base.config.ts
+++ b/tools/build/tsup.base.config.ts
@@ -49,6 +49,11 @@ export function createLocalOnlyDtsPaths(
 
   return {
     compilerOptions: {
+      // 固定 DTS 编译的项目根为 ./src。缺省时，若某个包再导出的 workspace 依赖
+      // 在其构建产物中含跨子路径的相对 import（如 contracts 内 dashboard → goal），
+      // rollup-plugin-dts 追进去后无法定位 package.json export map 的根，报
+      // TS2209「project root is ambiguous」。显式给出 rootDir 即可消歧。
+      rootDir: './src',
       ...(baseUrl ? { baseUrl } : {}),
       paths: {
         '@/*': ['./src/*'],

--- a/tools/build/tsup.base.config.ts
+++ b/tools/build/tsup.base.config.ts
@@ -49,11 +49,6 @@ export function createLocalOnlyDtsPaths(
 
   return {
     compilerOptions: {
-      // 固定 DTS 编译的项目根为 ./src。缺省时，若某个包再导出的 workspace 依赖
-      // 在其构建产物中含跨子路径的相对 import（如 contracts 内 dashboard → goal），
-      // rollup-plugin-dts 追进去后无法定位 package.json export map 的根，报
-      // TS2209「project root is ambiguous」。显式给出 rootDir 即可消歧。
-      rootDir: './src',
       ...(baseUrl ? { baseUrl } : {}),
       paths: {
         '@/*': ['./src/*'],


### PR DESCRIPTION
## 背景

PR #161 (governance-reference-module) 合入后，`main` 在全图 typecheck / lint / governance-check 上处于红态。这些破损与事件总线重构无关，独立成本 PR，作为 PR-1 / PR-2 全图验证的前置。

## 改动

1. **RuleId 品牌类型缺口**（app-vue）— `useGovernance.ts` 的 `getRule`/`deleteRule` 把 `id: string` 收窄为 branded `RuleId`（匹配 task 模块 `as GoalId` 约定），`types.ts` 补充再导出 `RuleId`。
2. **contracts DTS `TS2209`「project root is ambiguous」**（dashboard 构建）— 根因：dashboard 再导出 `@dailyuse/contracts/dashboard`，其产物里 `dashboard-data.dto → ../../goal/value-objects/goal-status` 是跨子路径相对 import，rollup-plugin-dts 追进去后无法定位 contracts package.json export map 的根。仅在 `dashboard/tsup.config.ts` 覆写 `rootDir: './src'` 消歧（**不放进共享 helper**，否则会打断 DTS 会追进 workspace 源码的包如 schedule-orchestration，报 `TS6059`）。
3. **contracts:lint 15 error**（governance 契约包内用包名自引用）— 按仓库约定改为包内相对导入（`../../../primitives` 等）。
4. **mobile eslint 未继承根配置** — `apps/mobile/eslint.config.js` 改为 jiti 加载根 `eslint.config.ts` 后叠加 Expo 规则，满足 configuration-governance。

## 验证

- `contracts` lint + typecheck 全绿；`governance` build/lint/typecheck 全绿。
- `dashboard` 与 `schedule-orchestration` 全新构建通过（DTS 不再 `TS2209`/`TS6059`）。
- `dashboard` / `app-vue` / `web` / `desktop` / `api` typecheck 全绿。
- `daily-use:governance-check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)