### PR TITLE
refactor(event-bus): 收敛 mitt-RPC、隔离 send、修复 flush 一致性 (PR-1)

### DIFF
--- a/docs/architecture/adr/ADR-033-cross-module-communication-patterns.md
+++ b/docs/architecture/adr/ADR-033-cross-module-communication-patterns.md
@@ -1,0 +1,102 @@
+# ADR-033: Cross-Module Communication Patterns
+
+**Status:** Accepted
+**Date:** 2026-07-10
+**Context:** Monorepo module coupling, event bus scope, plugin-style composability.
+
+## Context
+
+随着 feature 数量增长（Goal↔Task、Setting↔Repository、AI↔多模块、后续更多联动），我们需要一份**明确的判定规则**来回答：两个模块要协作时，该走哪种通信机制？
+
+历史上，`CrossPlatformEventBus`（`packages/utils/src/domain/cross-platform-event-bus.ts`）在同一个类里同时提供 `send`/`on`（事件）与 `invoke`/`handle`（RPC）。前者被 13+ 个 feature 使用、支撑 DDD 领域事件传播；后者**全仓零生产调用**——真实的请求-响应需求要么走 Port（同进程）、要么走 Electron IPC / HTTP（跨进程），从未落到 mitt-RPC 上。
+
+同时，Goal↔Task 的"任务完成 → 更新 KR 进度"逻辑目前只在 `apps/desktop/src/main/events/initialize-event-listeners.ts` 实现，API 后端未挂载同款监听器；handler 还回头查了 Task 的 repository（隐性耦合）。这反映了我们缺少统一的跨模块协作范式。
+
+本 ADR 固化范式选择，替代零散约定。
+
+## Decision
+
+跨模块协作按**语义**（不是按"想不想拿返回值"这种表层需求）分为三种，对应三种落地机制。**禁止**用同进程消息式 RPC（mitt-invoke）作为通用手段。
+
+### 判定表
+
+| # | 语义 | 是否需要返回值 | 是否跨进程/网络 | 选用机制 |
+| --- | --- | --- | --- | --- |
+| 1 | 通知式反应 | 否 | 否 | **事件总线 `send`/`on`**（`@dailyuse/utils/domain` 的 typed publisher/subscriber） |
+| 2 | 查询 / 命令回执 | 是 | 否 | **Port（依赖倒置）+ 宿主组装注入** |
+| 3 | 跨进程 / 网络请求 | 是 | 是 | **Electron IPC（`@dailyuse/ipc-client`）或 HTTP** |
+
+对应到范式：
+
+### 范式 A — 事件（Pub/Sub）
+
+- 用于领域事件传播、"某事发生 → 别处反应"的联动。
+- 发布方**不关心也不等待**订阅方的返回。
+- 事件形状在 `@dailyuse/contracts/<module>/protocol/*-event-map.ts` 集中声明。
+- 生产代码通过 `createTypedEventPublisher` / `createTypedEventSubscriber` 收窄类型面（见 raw-event-bus-audit）。
+- **Payload 自包含**：订阅方不应因为处理事件而回头查发布方的 repository，需要的字段应放进 payload。
+
+**代表用例：** 任务完成 → 更新关联 KR 进度（`task:instance-completed`）。
+
+### 范式 B — Port（同进程请求-响应）
+
+模块声明"**我需要什么**"的接口（inbound Port），另一模块（或基础设施）**实现**该接口，**宿主**在组装根注入具体实现。依赖方向永远指向抽象。
+
+- Port 定义在**需要方**的 `application-server/ports/` 下（依赖倒置：调用方拥有抽象）。
+- 实现方作为 adapter 提供 —— 通常在实现方包的 infrastructure 层或独立适配器包。
+- 宿主（`apps/api`、`apps/desktop`）通过 `createXxxModule({...ports})` 工厂完成组装（见 ADR-025 Module Composition Pattern）。
+- 调用即普通 `await port.method(...)`，返回 `Result<T>`（见 ADR-030）。类型、堆栈、事务、mock 全部保留。
+
+**代表用例：** `createAIApiModule` 声明 `IAnalyticsReadPort` / `IKnowledgeNotePersistencePort` / `IKnowledgeSourcePort`，由 `apps/api/src/main.ts` 用 `RepositoryKnowledgeSourceAdapter` 等注入。Setting 改字体 → Repository 应用 → 回执，同构。
+
+### 范式 C — 跨进程 / 网络（消息式 RPC）
+
+跨 Electron 主/渲染进程用 `@dailyuse/ipc-client` 的 `IpcClientImpl`（自动解包 `IpcResult` 信封、抛结构化 `IpcClientError`、支持超时）；Web↔API 用 HTTP client。两者作为 client-side adapter 出现在 `packages/<feature>/src/infrastructure-client/adapters/{ipc,http}/`，实现同一个 client Port，保证 UI 层写法不变。
+
+### 明确弃用
+
+**不使用 mitt 版 `invoke`/`handle` 做同进程 RPC**。同进程需要请求-响应时一律走范式 B。理由见 Rationale。
+
+## Rationale
+
+**为什么进程内 RPC 不该用消息总线？** 消息式 RPC 相对 Port 有三个硬伤：
+
+1. **丢类型与堆栈** —— 通过字符串 channel 分发的调用编译期无法校验，出错时堆栈断裂。Port 是真函数调用，全部保留。
+2. **丢事务** —— 同一业务事务内需要多次同进程调用时（如 Setting 更新配置后立即写审计记录），消息式 RPC 无法共享同一个 DB 事务上下文；Port 直接透传。
+3. **丢可组合性** —— 消息式 RPC 隐藏了模块依赖（"我 invoke 一下就好"），而 Port 强制在组装根显式声明依赖，是宿主可插拔组装的前提。
+
+真跨进程时（范式 C），序列化不可避免，上述损失被物理边界"合法化"；同进程再引入消息层是主动制造损失。
+
+**为什么事件仍然要保留？** 事件的价值不在返回值，在**解耦发布方与订阅方**：发布方不需要知道谁在听，新增/移除订阅方不改动发布方。这是范式 B 无法替代的。判据是"我需不需要对方回答"—— 需要就用 B/C，不需要就用 A。
+
+## Consequences
+
+**正面：**
+
+- 判定明确，新联动场景不再需要临场讨论。
+- 三个范式各自的最佳实践已在仓库有代表实现，无学习成本。
+- 支持模块插件化：模块只暴露 contracts、inbound Port、module 工厂；实现完全隐藏。宿主是唯一组装点。
+- 允许删除 `CrossPlatformEventBus` 中未接线的 `invoke`/`handle`/`pendingRequests` 逻辑，收敛为纯事件总线。
+
+**负面 / 需承担的成本：**
+
+- Port 数量会随联动增多而增加。约定：每个跨模块协作**先建 Port**，即使当前只有一个实现；避免以后被迫大改。
+- 事件 payload 需要保持"自包含"，聚合根侧要为跨模块订阅者预留必要字段，可能略微增加 payload 体积。
+- 宿主组装代码会更长（每个 Port 一条注入），换来的是显式依赖与可测试性。
+
+## Migration & Enforcement
+
+- **删除 mitt-RPC**：见 `docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md` 阶段一 H1。
+- **Goal↔Task 联动重构**：见同计划 M6。反应逻辑搬入 Goal 包 `application-server/event-handlers`（替换现有空壳桩 `registerGoalEventListeners`），事件 payload 由 Task 侧填齐所需信息，`apps/api` 与 `apps/desktop` 两宿主分别挂载。
+- **未来所有 AI ↔ 其他模块、Setting ↔ 其他模块** 的联动一律遵循本 ADR。
+- **治理**：`raw-event-bus-audit.mjs` 已确保 `send`/`on` 走 typed seam；后续可增加 audit 检查"是否在业务代码中出现 `.invoke(` / `.handle(` 且不属于 IPC/HTTP adapter"。
+
+## References
+
+- ADR-002 采用 DDD 架构模式
+- ADR-003 事件驱动架构
+- ADR-023 Server-Side Layer Decoupling & Pure Dependency Injection
+- ADR-025 Module Composition Pattern
+- ADR-030 Standard Result Pattern
+- ADR-031 Server Feature Standard Shape
+- `docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md`

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -47,6 +47,7 @@ updated: 2026-04-26T00:00:00
 | [ADR-030](./ADR-030-standard-result-pattern.md) | Unifying API Responses with Result Pattern | 已采纳 | 2026-01-16 |
 | [ADR-031](./ADR-031-server-feature-standard-shape.md) | Server Feature Standard Shape | 已采纳 | 2026-05-25 |
 | [ADR-032](./ADR-032-support-package-import-conventions.md) | Support Package Import Conventions | 已采纳 | 2026-05-25 |
+| [ADR-033](./ADR-033-cross-module-communication-patterns.md) | Cross-Module Communication Patterns | 已采纳 | 2026-07-10 |
 
 ## 维护规则
 

--- a/docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md
+++ b/docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md
@@ -1,0 +1,126 @@
+---
+tags:
+  - plan
+  - active
+  - event-bus
+  - governance
+  - architecture
+description: 收敛事件总线死代码、修复 DomainEvent flush 一致性、加固治理自动化，来自 2026-07-10 架构审查
+created: 2026-07-10T00:00:00+08:00
+updated: 2026-07-10T18:00:00+08:00
+---
+
+# Event Bus & Governance Hardening
+
+## 背景
+
+2026-07-10 对仓库做了一次系统性架构审查，重点覆盖三块：跨平台事件总线与 RPC、文档与自动化治理体系、Monorepo 边界与依赖拓扑。
+
+总体结论：依赖拓扑（零循环、干净叶子层）与边界纪律（`IApiModule` facade、零 deep-import 违规）成熟度高；文档"真值顺序"设计优雅。当前最薄弱环节是**事件总线运行时机制**与**治理脚本的语义深度/自测**。
+
+本计划把审查诊断出的问题固化为可执行改动，按收益/风险排序。
+
+跨模块通信范式的判定规则单独固化为 [ADR-033: Cross-Module Communication Patterns](../../architecture/adr/ADR-033-cross-module-communication-patterns.md)。本计划为其配套的落地路线。
+
+## 结论前提
+
+- 项目处于活跃开发期，不要求向后兼容、不需要数据迁移。
+- 优先根因修复，不引入临时 shim 或双轨兼容。
+- 每项改动配套离改动最近的定向验证，并补跑 `daily-use:governance-check`。
+- 跨模块协作规则以 ADR-033 为准（三范式：事件 / Port / 跨进程 IPC-HTTP；同进程消息式 RPC 弃用）。
+
+## 问题清单（诊断结论）
+
+### High
+
+- **H1｜事件总线中未接线的 `invoke`/`handle` RPC 能力应删除。** 项目只有**一套**事件总线，`send`/`on`/`off` 是 DDD 跨模块解耦骨架，真实在用、保留并加固（见 H3/M1）。问题在同一个类 `CrossPlatformEventBus`（`packages/utils/src/domain/cross-platform-event-bus.ts:85-214`）里塞进的**同进程消息式 RPC**（`invoke`/`handle` + `requestId` + 动态监听 + `pendingRequests` + 超时）：全仓**零生产调用**，唯一引用是 `global-event-bus.ts:22` 的 docstring 示例。按 ADR-033 判定：同进程请求-响应走 Port（依赖倒置），跨进程走 `IpcClientImpl` / HTTP —— **mitt-RPC 无立足场景**。所谓"两套 RPC 并存"指的是这个被架空的 mitt-RPC vs 真在用的 `IpcClientImpl`，**不是两套事件总线**。
+- **H2｜`flushDomainEvents` 在持久化成功后同步触发，抛错会破坏一致性。** 仓储 `save()` 顺序执行多条 `db.execute` 后调用 `flushDomainEvents(publisher, aggregate)`（如 `packages/reminder/src/server/infrastructure/adapters/powersync/reminder-template-powersync.repository.ts:214-215`）。`flushDomainEvents` → `publisher.send` → `mitt.emit` 为**同步**且 `send` 无 try/catch（`cross-platform-event-bus.ts:58-61`）。后果：(a) 订阅者同步抛错会冒泡使 `save()` reject，但 DB 已落库；(b) `save()` 内多写**无事务包裹**，可能半持久化；(c) 无 outbox，"提交后、派发前"崩溃会丢事件。
+- **H3｜`send` 无 per-handler 错误隔离。** `mitt.emit` 顺序同步调用同一事件的多个 handler，唯一防护是各订阅方各自记得 try/catch（如 `register-account-event-listeners.ts:26-35`）。靠约定而非机制：一个 handler 抛错或阻塞会波及其余订阅者。
+
+### Medium
+
+- **M1｜每次 `send`/`on`/`off` 无条件 `logger.info` 并展开 payload**（`cross-platform-event-bus.ts:59/69/81`）。生产环境 logger 虽 `enabled=false`，但模板字符串与 payload 传参在进入 `log()` 前已求值，高频路径纯浪费 + 开发期噪音大。
+- **M2｜`layer:service`（ai-service）无 depConstraints。** `@nx/enforce-module-boundaries` 只约束 `layer:*`，`layer:service` 在 `eslint.config.ts` 无对应条目，Nx 对无约束 source tag 默认放行。`scope:*` / `type:*` 两套 tag 不参与任何约束。
+- **M3｜跨 feature 包隔离靠硬编码个案。** 所有 feature 同为 `layer:domain`，矩阵允许任意 feature 互相依赖，唯一防火墙是硬编码的 `goal ✗↔ task`。`public-surface-audit.mjs` 只拦"导入别包内部层子路径"，不拦"导入别包公开 API"。
+- **M4｜无"未 flush 的 DomainEvent"治理检查。** `tools/` 下零 `pullDomainEvents`/`domainEvents` 匹配。聚合根 `addDomainEvent` 后仓储漏 `flush` 会静默丢事件，无自动化拦截。
+- **M5｜13 个治理脚本零单元测试，且多为脆弱窗口式正则。** `find tools -name "*.spec.*"` 零结果；`governance-module-docs-audit.mjs:152-192`、`desktop-runtime-locator-audit.mjs:155` 属高脆弱启发式。`tools/` 因归类 `tooling-lib`（仅要求 `build`）逃过 `vitest-no-tests-audit`。
+- **M6｜Goal↔Task 联动已实现但只在 desktop，且为 bespoke，需按 ADR-033 重构为可复用包内实现。** 事实核校：`apps/desktop/src/main/events/initialize-event-listeners.ts` 已订阅 `task:instance-completed` 并调用 `CreateGoalRecordUseCase`（经 `@dailyuse/goal/events` 公开面）更新 KR 进度；desktop 主进程启动时 `main.ts:274` 挂载。真实缺口有三：
+  1. **API 后端未挂载同款监听器** —— web 端任务完成不会自动更新 KR（grep `apps/api/src` 里 `task:instance-completed` / `CreateGoalRecordUseCase` 均为空）。
+  2. **反应逻辑是 bespoke 副本，未成包** —— 应搬进 Goal 包 `application-server/event-handlers`，替换掉现有空壳桩 `registerGoalEventListeners`（`packages/goal/src/application-server/event-handlers/index.ts` 只打日志、参数 `_goalRepository` 未使用、无人调用）。
+  3. **Handler 回头查 Task 的 repository**（读 `taskInstance` / `template`）—— 这是隐性耦合。按 ADR-033 范式 A，事件 payload 应**自包含**：Task 侧发布 `task:instance-completed` 时把 `goalBinding`、`allInstancesCompleted` 等判定必要字段填齐，Goal 侧不再回查 Task。
+
+### Low
+
+- **L1**｜`generateUUID`（`cross-platform-event-bus.ts:10-27`）`globalThis.crypto` 与 `crypto` 两分支重复，可收敛为 `globalThis.crypto?.randomUUID()`。
+- **L2**｜`pendingRequests` 用 `any`（`:43`），可精确为 `ReturnType<typeof setTimeout>`（若 H1 移除 RPC 则一并消失）。
+- **L3**｜矛盾的 Accepted ADR：ADR-009 描述旧 `domain-server`/`application-server` 布局，ADR-031 定义现行 `src/server/{...}`。应把 ADR-009 标注 superseded-by ADR-031。
+- **L4**｜`adr/README.md` 32 行索引手工双写；`plan/archive/` ~90 文件多个 100KB+ 无子索引。
+
+## 实施步骤
+
+按收益/风险排序，前三项改动小、收益最高、互不冲突。
+
+### 阶段一：事件总线收敛与一致性（H1 → H2 → H3 / M1）
+
+1. **H1** 删除 `CrossPlatformEventBus` 中未接线的 mitt RPC：`invoke`/`handle`/`removeHandler`/`clearPendingRequests` 及 `rpcListeners`/`pendingRequests`/`handlers`/`defaultTimeout` 字段与 `TRpc` 泛型；把类收敛为单向事件总线。同步清理 `global-event-bus.ts` 的 `AppRpcRegistry` 注入与 docstring 示例。跨进程 RPC 唯一真相保留在 `IpcClientImpl`。
+2. **H3 + M1** 重写 `send`：debug 门控日志（不展开 payload），改为遍历 handler 并 per-handler try/catch，实现错误隔离。顺带处理 **L1**（`generateUUID` 若 RPC 移除后仍被 send/on 路径使用则保留精简版，否则删除）、**L2**。
+3. **H2(a)** 仓储 `save()` 用 `db.transaction` 包裹多条 `execute`，先 `pullDomainEvents()` 取出事件再进事务。逐个改造使用 `flushDomainEvents` 的仓储（reminder / ai / schedule / notification 等，见 `flushDomainEvents` 调用点）。
+4. **H2(b)** 事件派发挪到事务提交之后，用 `publishSafely` 吞派发侧异常（与 H3 隔离双保险）。中期是否引入 transactional outbox 另立 ADR，不在本计划范围。
+5. 定向验证：`utils`、各被改仓储所属 feature 的 `lint` / `typecheck` / `test`。
+6. **M6（Goal↔Task 联动重构，作为 ADR-033 范式 A 的标杆用例）**
+   - Task 侧：`task:instance-completed` 事件 payload 补齐 `goalBinding` 与"是否全部实例完成"标志（判定逻辑本属 Task，从 desktop handler 迁到 Task 应用层，事件发布前算好）。
+   - Goal 侧：把 `packages/goal/src/application-server/event-handlers/index.ts` 从桩改为真实实现 —— 订阅 `task:instance-completed`，直接消费 payload 调 `CreateGoalRecordUseCase`，**不再回查 Task 的 repository**。
+   - 宿主：`apps/api` 与 `apps/desktop` 分别在启动时调用同一份 `registerGoalEventListeners`（消除 desktop bespoke 副本，desktop 那份 `initialize-event-listeners.ts` 里的 task-goal 段删除）。
+   - Web 端（走 API）由此获得同款自动更新能力。
+
+### 阶段二：治理脚本自测与语义加固（M5 → M4 → M2）
+
+7. **M5** 将 `tools/governance/*.mjs` 核心逻辑抽为可导出纯函数 + fixture，补 `__tests__`；把 `tools/governance` 提为带 `test` target 的 Nx 项目并纳入 `governance-check` 前置。
+8. **M4** 用 `ts-morph` 新增 `unflushed-events-audit`：扫描继承 `AggregateRoot` 的类，命令方法体内有状态赋值但整类无 `addDomainEvent`、或仓储 `save` 无 `flushDomainEvents` 的疑似漏发点。同时新增 `mitt-rpc-forbidden-audit`：拦截业务代码中的 `.invoke(` / `.handle(`（放行 `packages/ipc-client` 及 `infrastructure-*` 目录），落实 ADR-033 弃用条款。
+9. **M2** 在 `eslint.config.ts` 的 `depConstraints` 追加 `layer:service` 条目，闭合无约束漏洞。
+10. **M3** 评估将跨 feature 边界从硬编码个案改为系统化规则（scope 级约束或 audit 扩展），本步先出结论，改动可另立计划。
+
+### 阶段三：文档剪枝（L3 / L4）
+
+11. **L3** ADR-009 标注 superseded-by ADR-031，更新 ADR 索引状态。
+12. **L4** `plan/archive/` 建按季度子索引；评估超大历史计划压缩归档。
+
+## 完成标准
+
+- `CrossPlatformEventBus` 收敛为纯发布订阅总线（保留 `send`/`on`/`off`），不再包含 `invoke`/`handle`/`pendingRequests`/超时逻辑；`grep` 确认 `eventBus.invoke`/`eventBus.handle` 零引用。
+- 仓储 `save()` 多写在单事务内；事件派发在提交后进行，派发失败不回滚业务；`send` 具备 per-handler 错误隔离。
+- Goal↔Task 联动按 ADR-033 范式 A 重构完成：反应逻辑收敛到 Goal 包内、事件 payload 自包含、`apps/api` 与 `apps/desktop` 两宿主挂载同一实现、desktop bespoke 副本删除、web 端亦获得自动更新能力（M6）。
+- `mitt-rpc-forbidden-audit` 接入 `governance-check`，全仓无业务代码调用 `eventBus.invoke` / `eventBus.handle`。
+- `send`/`on`/`off` 日志受 debug 门控，不在生产热路径求值 payload。
+- `tools/governance` 具备 `test` target 且核心脚本有单元测试；`unflushed-events-audit` 接入 `governance-check`。
+- `eslint.config.ts` 覆盖 `layer:service`。
+- ADR-009/031 冲突消解；`plan/archive` 具备子索引。
+- `daily-use:governance-check` 通过。
+
+## 备注
+
+- 阶段一与阶段二互不依赖，可并行成独立 PR。
+- 阶段一前三步（H1/H3/H2）是最小高收益集合，建议优先合入。
+- 后续 AI ↔ 各模块、Setting ↔ 各模块的联动一律遵循 ADR-033：查询/命令回执类用 Port（依赖倒置 + 宿主注入，参考 `createAIApiModule` 的 `IAnalyticsReadPort` / `IKnowledgeSourcePort` / `IKnowledgeNotePersistencePort`），通知反应类用事件。跨越 web↔api 或主↔渲染进程时才走 HTTP / Electron IPC。不新增 mitt-RPC 用法。
+
+## 实施进度
+
+### PR-1 · 阶段一 · 事件总线收敛与 flush 一致性（2026-07-10）
+
+分支：`refactor/event-bus-hardening-pr1`
+
+- [x] **H1** 删除 `CrossPlatformEventBus` 的 mitt-RPC（`invoke`/`handle`/`removeHandler`/`clearPendingRequests` 及 `rpcListeners`/`pendingRequests`/`handlers`/`defaultTimeout` 字段与 `TRpc` 泛型），收敛为单向事件总线。`GlobalEventBus` 去掉 `AppRpcRegistry` 泛型，`global-event-bus.ts` docstring 的 invoke 示例改为指向 Port / IPC。`AppRpcRegistry` 类型本身保留（仍聚合各模块 `RpcMap`，供 IPC channel 使用），仅解除与事件总线的耦合。
+- [x] **H3 + M1** 重写 `send`：debug 门控日志（生产不求值 payload），遍历 handler 快照逐个 try/catch，实现 per-handler 错误隔离。
+- [x] **L1/L2** 随 mitt-RPC 一并移除 `generateUUID`、`pendingRequests`（`any`）等仅服务 RPC 的死代码。
+- [x] **H2** 仓储事务与提交后派发：
+  - AI（Prisma）`save()` 三条写入包进 `$transaction`，事件在提交后 flush。
+  - Reminder（PowerSync）模板 + 历史多写包进 `writeTransaction`（`db` 类型收敛为 `IElectronDatabase`），事件提交后 flush。
+  - Schedule（PowerSync）任务 + 执行记录同上。
+  - AI（PowerSync）、Notification（Prisma/PowerSync）原本已是「事务内多写 + 提交后 flush」或单条写入，无需改动。
+  - 派发失败不回滚业务，与 H3 的 per-handler 隔离形成双保险。
+
+验证：
+- `pnpm nx run-many -t typecheck lint test -p utils reminder schedule ai notification` 全绿。
+- `pnpm nx run daily-use:governance-check --skip-nx-cache` 通过（`raw-event-bus-audit` 通过）。
+- 全仓 `grep eventBus.invoke|eventBus.handle` 零命中；无下游以第二个泛型实例化事件总线。
+- `desktop:typecheck` / `api:typecheck` 全图受**既有** `dashboard:build` / `app-vue:typecheck` 失败阻塞（`contracts` DTS `TS2209` 与 governance `RuleId` 品牌类型，均在干净 `main` 上复现，与本 PR 无关）；两宿主仅消费 `send`/`on`/`off`，签名未变，不受本次泛型收敛影响。

--- a/docs/plan/active/2026-07-10-event-bus-and-governance-hardening.prompt.md
+++ b/docs/plan/active/2026-07-10-event-bus-and-governance-hardening.prompt.md
@@ -1,0 +1,100 @@
+---
+tags:
+  - plan
+  - active
+  - prompt
+  - event-bus
+  - governance
+description: 交给 AI 执行 2026-07-10 事件总线与治理加固计划的自包含提示词
+created: 2026-07-10T18:30:00+08:00
+updated: 2026-07-10T18:30:00+08:00
+---
+
+# Implementation Prompt
+
+配套 `2026-07-10-event-bus-and-governance-hardening.md` 与 `ADR-033`。整份文件从下面分隔线开始即为提示词正文，粘贴到全新 AI 会话即可开始工作。
+
+---
+
+任务：按现有方案实施 Event Bus & Governance Hardening（含 ADR-033）
+
+你是资深软件架构工程师。在 /opt/dailyuse（pnpm + Nx monorepo）里，按已有方案与决策文档，完整、优雅地实施跨模块通信范式重构。代码是唯一真值，方案与决策文档只是路线图。
+
+## 强制第一步：读完这些再开始动手（不要跳过）
+
+1. AGENT.md — 协作规范、真值顺序、变更策略、最小验证要求。每条都要遵守。
+2. docs/architecture/adr/ADR-033-cross-module-communication-patterns.md — 跨模块通信三范式（事件 / Port / 跨进程 IPC-HTTP）与 mitt-RPC 弃用决策。所有实施必须与此 ADR 一致。
+3. docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md — 完整方案，含 H1/H2/H3/M1–M6/L1–L4 的诊断、步骤、完成标准。
+4. docs/standards/README.md、docs/governance/README.md — 规则与治理约定。
+5. packages/utils/src/domain/cross-platform-event-bus.ts、packages/utils/src/domain/typed-event-port.ts、packages/utils/src/domain/flush-domain-events.ts、packages/utils/src/domain/aggregate-root.ts — 事件总线现状。
+6. apps/desktop/src/main/events/initialize-event-listeners.ts、packages/goal/src/application-server/event-handlers/index.ts、packages/goal/src/events/index.ts — M6 涉及的 Goal↔Task 现状。
+7. packages/ai/src/api/module.ts、apps/api/src/main.ts 中 createAIApiModule(...) 部分 — Port + 宿主注入的现有范本（ADR-033 范式 B）。
+
+## 执行顺序（严格按此，一 PR 一阶段，互不掺杂）
+
+### PR-1｜阶段一 · 事件总线收敛与 flush 一致性（对应 plan 步骤 1–5）
+
+- **H1** 删除 CrossPlatformEventBus 中 invoke/handle/removeHandler/clearPendingRequests 以及 rpcListeners/pendingRequests/handlers/defaultTimeout 字段与 TRpc 泛型；GlobalEventBus 移除 AppRpcRegistry 泛型；清理 docstring 里的 invoke 示例。跨进程请求-响应真相唯一保留在 packages/ipc-client。
+- **H3 + M1** 重写 send：debug 门控日志（生产不求值 payload）；遍历 handler 时 per-handler try/catch，实现错误隔离，一个订阅者抛错不影响其余。
+- **H2** 在使用 flushDomainEvents 的仓储（reminder / ai / schedule / notification 等，详见 plan H2 列出的调用点）里：save() 用事务包裹多条 execute；pullDomainEvents() 在事务前后位置需要设计准确；事件派发放到事务成功提交之后，派发失败不回滚业务（用一个 publishSafely 或直接依赖 H3 的隔离即可）。
+- **L1/L2** 顺手：generateUUID 收敛为 globalThis.crypto?.randomUUID()；pendingRequests 若因 H1 被移除，则一并消失。
+
+**验收：** pnpm nx affected -t lint test typecheck 全绿；pnpm nx run daily-use:governance-check 通过；全仓 grep -r "eventBus.invoke\|eventBus.handle" 零命中。
+
+### PR-2｜阶段一 · Goal↔Task 联动重构（M6，作为 ADR-033 范式 A 标杆）
+
+三段：
+- **Task 侧**：task:instance-completed 事件 payload 扩展 goalBinding 与"是否全部实例完成"标志。判定逻辑（shouldTriggerOnAllInstancesCompleted）从 desktop handler 迁到 Task 应用层，在事件发布前算好。同步更新 @dailyuse/contracts/task 事件形状。
+- **Goal 侧**：把 packages/goal/src/application-server/event-handlers/index.ts 从空壳桩改为真实现——订阅 task:instance-completed，直接消费 payload，调 CreateGoalRecordUseCase，不得回查 Task 的 repository。返回可停止函数（幂等 start()/stop()，仿 register-account-event-listeners.ts）。
+- **宿主**：apps/api 与 apps/desktop 分别在启动时调用同一份 registerGoalEventListeners。desktop 的 initialize-event-listeners.ts 中 task-goal 那段删除（不是注释掉）；web 端由此自动获得同款能力。
+
+**验收：** 补 Goal handler 的单测（消费 fixture payload，断言调用了 CreateGoalRecordUseCase.execute）；补一条 desktop 或 api 的集成测试真跑事件；lint / typecheck / affected test 全绿。
+
+### PR-3｜阶段二 · 治理脚本自测与语义加固（M5 → M4 → M2）
+
+- **M5** 把 tools/governance/*.mjs 的核心逻辑抽为可导出纯函数 + fixtures，在同目录补 __tests__；把 tools/governance 提为带 test target 的 Nx 项目并纳入 governance-check 前置。
+- **M4** 新增两个 audit：
+  - unflushed-events-audit.mjs：用 ts-morph 扫描继承 AggregateRoot 的类，命令方法有状态改动但整类无 addDomainEvent、或仓储 save 无 flushDomainEvents 的疑似漏发点。
+  - mitt-rpc-forbidden-audit.mjs：拦截业务代码中的 .invoke( / .handle(（放行 packages/ipc-client 与 infrastructure-* 目录），落实 ADR-033 弃用条款。
+- **M2** eslint.config.ts 的 depConstraints 追加 layer:service 条目，闭合无约束漏洞。
+
+**验收：** 新增 audit 有正反 fixture 单测；governance-check 全绿；有意注入一处 mitt-RPC 反例本地跑一遍确认能被拦到，然后回退。
+
+### PR-4｜阶段三 · 文档剪枝（L3 / L4）
+
+- **L3** ADR-009 标注 superseded-by ADR-031，更新 ADR 索引状态列。
+- **L4** docs/plan/archive/ 建按季度子索引；不删历史文件，只加导航。
+
+## 全过程非协商规则
+
+- 不要引入向后兼容 shim、feature flag、双轨兼容。项目在活跃开发期。
+- 不要在事件总线里再加"同进程 RPC"变体。ADR-033 已明确弃用。
+- 不要跨模块 import 别包内部实现绕过 Port（若发现现有违规，先用 Port 修）。
+- 不要在集成测试里 mock 数据库；单元测试可以。
+- 不要用 --no-verify / --amend 跳 pre-commit 钩子或改已发布 commit。
+- 不要跑 git reset --hard / git clean -f / git checkout . 等破坏性命令，除非已 stash 全部改动并向用户确认。
+- 每 PR 一个分支，命名 refactor/event-bus-hardening-pr<N> 或 refactor/goal-task-linkage-pr<N>。基于 main 起分支。
+- 不要主动 git push 或建 PR，除非用户明说。写完代码、跑完验证、给我一句"PR-N 完成，等你确认推送"即可。
+- 每个 PR 完成后在 plan 文件对应步骤打勾（在 plan 里 append 一个短小 "## 实施进度" 段落，别改历史步骤文本）。plan 全部完成后把它挪到 docs/plan/archive/。
+
+## 遇到冲突或分歧时
+
+- 若 plan 或 ADR 与当前代码冲突 → 以代码为准（AGENT.md 真值顺序），修正 plan/ADR。
+- 若发现方案里没覆盖的必要改动 → 先在当前 PR 描述里列出、暂不做；除非它阻塞本 PR，才在本 PR 处理并明确标注"临时纳入"。
+- 若某个 use-case 的重构会牵扯 3+ 个包 → 停下来在 plan 里补一个短说明，问用户是否拆到独立 PR。
+- 环境或依赖有问题跑不了验证 → 明说"哪一步跑不动、为什么"，不要伪造通过。
+
+## 交付格式（每个 PR 完成时）
+
+给我一段简短汇报：
+1. 本 PR 分支名
+2. 改动概要（2-4 行，重点讲"为什么这么改"，不是"改了什么文件"）
+3. 验证命令与结果（命令 + 通过/失败）
+4. 有无偏离 plan/ADR 的地方（有的话解释）
+5. 下一步（下个 PR 或阻塞项）
+
+不需要贴 diff，我会自己看代码。
+
+---
+
+现在，从读文档开始。读完后给我一句"文档已读完，从 PR-1 阶段一开始，估计触及以下文件…（列 5-8 个关键路径）"，然后开工。

--- a/packages/ai/src/server/infrastructure/adapters/__tests__/ai-conversation-domain-events.spec.ts
+++ b/packages/ai/src/server/infrastructure/adapters/__tests__/ai-conversation-domain-events.spec.ts
@@ -61,7 +61,7 @@ function captureConversationEventTypes(): {
 }
 
 function createPrismaClientMock(): PrismaClient {
-  return {
+  const client = {
     aiConversation: {
       upsert: vi.fn(async () => undefined),
     },
@@ -69,7 +69,9 @@ function createPrismaClientMock(): PrismaClient {
       deleteMany: vi.fn(async () => undefined),
       createMany: vi.fn(async () => ({ count: 1 })),
     },
-  } as unknown as PrismaClient;
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(client)),
+  };
+  return client as unknown as PrismaClient;
 }
 
 function createElectronDatabaseMock(): IElectronDatabase {

--- a/packages/ai/src/server/infrastructure/adapters/prisma/ai-conversation-prisma.repository.ts
+++ b/packages/ai/src/server/infrastructure/adapters/prisma/ai-conversation-prisma.repository.ts
@@ -7,6 +7,7 @@
 
 import type {
   PrismaClient,
+  Prisma,
   AiConversation as PrismaAiConversation,
   AiMessage as PrismaAiMessage,
 } from '@dailyuse/database';
@@ -37,55 +38,59 @@ export class AIConversationPrismaRepository implements IAIConversationRepository
   async save(conversation: AIConversation): Promise<void> {
     const dto = conversation.toServerDTO(true);
 
-    await this.prisma.aiConversation.upsert({
-      where: { id: String(dto.id) },
-      create: {
-        id: String(dto.id),
-        identityId: String(dto.identityId),
-        name: dto.name,
-        status: dto.status,
-        messageCount: dto.messageCount,
-        lastMessageAt: dto.lastMessageAt != null ? new Date(dto.lastMessageAt) : null,
-        version: dto.version,
-        createdAt: new Date(dto.createdAt),
-        updatedAt: new Date(dto.updatedAt),
-        deletedAt: dto.deletedAt != null ? new Date(dto.deletedAt) : null,
-      },
-      update: {
-        name: dto.name,
-        status: dto.status,
-        messageCount: dto.messageCount,
-        lastMessageAt: dto.lastMessageAt != null ? new Date(dto.lastMessageAt) : null,
-        version: dto.version,
-        updatedAt: new Date(dto.updatedAt),
-        deletedAt: dto.deletedAt != null ? new Date(dto.deletedAt) : null,
-      },
-    });
-
-    if (dto.messages) {
-      await this.prisma.aiMessage.deleteMany({
-        where: { conversationId: String(dto.id) },
+    // 多条写入放进单事务，避免 upsert 成功而 message 同步失败导致的半持久化。
+    await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      await tx.aiConversation.upsert({
+        where: { id: String(dto.id) },
+        create: {
+          id: String(dto.id),
+          identityId: String(dto.identityId),
+          name: dto.name,
+          status: dto.status,
+          messageCount: dto.messageCount,
+          lastMessageAt: dto.lastMessageAt != null ? new Date(dto.lastMessageAt) : null,
+          version: dto.version,
+          createdAt: new Date(dto.createdAt),
+          updatedAt: new Date(dto.updatedAt),
+          deletedAt: dto.deletedAt != null ? new Date(dto.deletedAt) : null,
+        },
+        update: {
+          name: dto.name,
+          status: dto.status,
+          messageCount: dto.messageCount,
+          lastMessageAt: dto.lastMessageAt != null ? new Date(dto.lastMessageAt) : null,
+          version: dto.version,
+          updatedAt: new Date(dto.updatedAt),
+          deletedAt: dto.deletedAt != null ? new Date(dto.deletedAt) : null,
+        },
       });
 
-      if (dto.messages.length > 0) {
-        await this.prisma.aiMessage.createMany({
-          data: dto.messages.map((message) => ({
-            id: String(message.id),
-            conversationId: String(message.conversationId),
-            identityId: String(dto.identityId),
-            role: message.role,
-            content: message.content,
-            tokenUsage:
-              message.tokenCount != null
-                ? JSON.stringify({ totalTokens: message.tokenCount })
-                : null,
-            createdAt: new Date(message.createdAt),
-          })),
-          skipDuplicates: true,
+      if (dto.messages) {
+        await tx.aiMessage.deleteMany({
+          where: { conversationId: String(dto.id) },
         });
-      }
-    }
 
+        if (dto.messages.length > 0) {
+          await tx.aiMessage.createMany({
+            data: dto.messages.map((message) => ({
+              id: String(message.id),
+              conversationId: String(message.conversationId),
+              identityId: String(dto.identityId),
+              role: message.role,
+              content: message.content,
+              tokenUsage:
+                message.tokenCount != null
+                  ? JSON.stringify({ totalTokens: message.tokenCount })
+                  : null,
+              createdAt: new Date(message.createdAt),
+            })),
+            skipDuplicates: true,
+          });
+        }
+      }
+    });
+
+    // 事件在事务成功提交后派发；send 已具备 per-handler 错误隔离，派发失败不回滚业务。
     flushDomainEvents(aiEventPublisher, conversation);
   }
 

--- a/packages/reminder/src/server/infrastructure/adapters/powersync/reminder-template-powersync.repository.ts
+++ b/packages/reminder/src/server/infrastructure/adapters/powersync/reminder-template-powersync.repository.ts
@@ -1,5 +1,6 @@
 import type { IReminderTemplateRepository } from '../../../domain/repositories/i-reminder-template-repository';
 import type { ReminderStatus, ReminderEventMap } from '@dailyuse/contracts/reminder';
+import type { IElectronDatabase, IElectronDatabaseTransaction } from '@dailyuse/contracts/electron';
 import { ReminderTemplate } from '../../../domain/aggregates/reminder-template';
 import { createTypedEventPublisher, eventBus, flushDomainEvents } from '@dailyuse/utils/domain';
 import { createLogger } from '@dailyuse/utils/logger';
@@ -9,18 +10,11 @@ import {
   type PowerSyncReminderHistoryRow,
 } from './mappers/powersync-reminder-template.mapper';
 
-type Queryable = {
-  getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
-  getOptional<T>(sql: string, parameters?: unknown[]): Promise<T | null>;
-  get<T>(sql: string, parameters?: unknown[]): Promise<T>;
-  execute(sql: string, parameters?: unknown[]): Promise<unknown>;
-};
-
 const logger = createLogger('ReminderTemplatePowerSyncRepo');
 const reminderEventPublisher = createTypedEventPublisher<ReminderEventMap>(eventBus);
 
 export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRepository {
-  constructor(private readonly db: Queryable) {}
+  constructor(private readonly db: IElectronDatabase) {}
 
   async save(template: ReminderTemplate): Promise<void> {
     const data = PowerSyncReminderTemplateMapper.toPersistence(template);
@@ -38,13 +32,37 @@ export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRep
       pendingDomainEvents,
     });
 
-    const existingTemplate = await this.db.getOptional<{ id: string }>(
+    // 模板与其历史记录多条写入放进单事务，避免半持久化。
+    await this.db.writeTransaction(async (tx: IElectronDatabaseTransaction) => {
+      await this.saveWithin(tx, template, data);
+    });
+
+    if (pendingDomainEvents.length > 0) {
+      // 事件在事务成功提交后派发；send 已具备 per-handler 错误隔离，派发失败不回滚业务。
+      flushDomainEvents(reminderEventPublisher, template);
+      logger.info('[Reminder][Repo] Published domain events after PowerSync save', {
+        templateId: String(template.id),
+        publishedDomainEvents: pendingDomainEvents,
+      });
+    } else {
+      logger.warn('[Reminder][Repo] PowerSync save completed without domain events to publish', {
+        templateId: String(template.id),
+      });
+    }
+  }
+
+  private async saveWithin(
+    tx: IElectronDatabaseTransaction,
+    template: ReminderTemplate,
+    data: ReturnType<typeof PowerSyncReminderTemplateMapper.toPersistence>,
+  ): Promise<void> {
+    const existingTemplate = await tx.getOptional<{ id: string }>(
       'SELECT id FROM reminder_templates WHERE id = ? LIMIT 1',
       [data.id],
     );
 
     if (existingTemplate) {
-      await this.db.execute(
+      await tx.execute(
         `UPDATE reminder_templates
          SET name = ?,
              description = ?,
@@ -118,7 +136,7 @@ export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRep
         ],
       );
     } else {
-      await this.db.execute(
+      await tx.execute(
         `INSERT INTO reminder_templates (
           id, identity_id, name, description, type, self_enabled, status, reminder_group_id,
           importance_level, tags, color, icon, next_trigger_at, version, created_at, updated_at,
@@ -170,13 +188,13 @@ export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRep
 
     for (const history of template.getAllHistory()) {
       const dto = history.toServerDTO();
-      const existingHistory = await this.db.getOptional<{ id: string }>(
+      const existingHistory = await tx.getOptional<{ id: string }>(
         'SELECT id FROM reminder_history WHERE id = ? LIMIT 1',
         [dto.id],
       );
 
       if (existingHistory) {
-        await this.db.execute(
+        await tx.execute(
           `UPDATE reminder_history
            SET result = ?,
                error = ?,
@@ -192,7 +210,7 @@ export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRep
           ],
         );
       } else {
-        await this.db.execute(
+        await tx.execute(
           `INSERT INTO reminder_history (
             id, identity_id, template_id, triggered_at, result, error, notification_sent, notification_channel, created_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -209,21 +227,6 @@ export class ReminderTemplatePowerSyncRepository implements IReminderTemplateRep
           ],
         );
       }
-    }
-
-    if (pendingDomainEvents.length > 0) {
-      flushDomainEvents(reminderEventPublisher, template);
-      logger.info('[Reminder][Repo] Published domain events after PowerSync save', {
-        templateId: String(template.id),
-        publishedDomainEvents: pendingDomainEvents,
-      });
-    } else {
-      logger.warn(
-        '[Reminder][Repo] PowerSync save completed without domain events to publish',
-        {
-          templateId: String(template.id),
-        },
-      );
     }
   }
 

--- a/packages/reminder/src/server/infrastructure/powersync.ts
+++ b/packages/reminder/src/server/infrastructure/powersync.ts
@@ -23,13 +23,9 @@ import {
 } from './adapters/powersync';
 import type { ReminderScheduleExecutionSource } from '../../schedule-execution';
 import type { ReminderScheduleProjectionSource } from '../../schedule-projection';
+import type { IElectronDatabase } from '@dailyuse/contracts/electron';
 
-type Queryable = {
-  getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
-  getOptional<T>(sql: string, parameters?: unknown[]): Promise<T | null>;
-  get<T>(sql: string, parameters?: unknown[]): Promise<T>;
-  execute(sql: string, parameters?: unknown[]): Promise<unknown>;
-};
+type Queryable = IElectronDatabase;
 
 /**
  * Creates a ReminderModuleInstance backed by PowerSync repositories.

--- a/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-task-powersync.repository.ts
+++ b/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-task-powersync.repository.ts
@@ -11,19 +11,13 @@ import {
   type PowerSyncScheduleTaskRow,
 } from './mappers/powersync-schedule-task.mapper';
 import type { PowerSyncScheduleExecutionRow } from './mappers/powersync-schedule-execution.mapper';
-
-type Queryable = {
-  getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
-  getOptional<T>(sql: string, parameters?: unknown[]): Promise<T | null>;
-  get<T>(sql: string, parameters?: unknown[]): Promise<T>;
-  execute(sql: string, parameters?: unknown[]): Promise<unknown>;
-};
+import type { IElectronDatabase, IElectronDatabaseTransaction } from '@dailyuse/contracts/electron';
 
 const logger = createLogger('ScheduleTaskPowerSyncRepo');
 const scheduleEventPublisher = createTypedEventPublisher<ScheduleEventMap>(eventBus);
 
 export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository {
-  constructor(private readonly db: Queryable) {}
+  constructor(private readonly db: IElectronDatabase) {}
 
   async save(task: ScheduleTask): Promise<void> {
     const data = PowerSyncScheduleTaskMapper.toPersistence(task);
@@ -41,13 +35,37 @@ export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository 
       pendingDomainEvents,
     });
 
-    const existingTask = await this.db.getOptional<{ id: string }>(
+    // 任务与其执行记录多条写入放进单事务，避免半持久化。
+    await this.db.writeTransaction(async (tx: IElectronDatabaseTransaction) => {
+      await this.saveWithin(tx, task, data);
+    });
+
+    if (pendingDomainEvents.length > 0) {
+      // 事件在事务成功提交后派发；send 已具备 per-handler 错误隔离，派发失败不回滚业务。
+      flushDomainEvents(scheduleEventPublisher, task);
+      logger.info('[Schedule][Repo] Published domain events after PowerSync save', {
+        taskId: String(task.id),
+        publishedDomainEvents: pendingDomainEvents,
+      });
+    } else {
+      logger.warn('[Schedule][Repo] PowerSync save completed without domain events to publish', {
+        taskId: String(task.id),
+      });
+    }
+  }
+
+  private async saveWithin(
+    tx: IElectronDatabaseTransaction,
+    task: ScheduleTask,
+    data: ReturnType<typeof PowerSyncScheduleTaskMapper.toPersistence>,
+  ): Promise<void> {
+    const existingTask = await tx.getOptional<{ id: string }>(
       'SELECT id FROM schedule_tasks WHERE id = ? LIMIT 1',
       [data.id],
     );
 
     if (existingTask) {
-      await this.db.execute(
+      await tx.execute(
         `UPDATE schedule_tasks
          SET name = ?,
              description = ?,
@@ -113,7 +131,7 @@ export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository 
         ],
       );
     } else {
-      await this.db.execute(
+      await tx.execute(
         `INSERT INTO schedule_tasks (
           id, identity_id, name, description, source_module, source_entity_id, status, enabled,
           cron_expression, timezone, start_date, end_date, max_executions, next_run_at, last_run_at,
@@ -160,13 +178,13 @@ export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository 
 
     const executions = task.executions ?? [];
     for (const execution of executions) {
-      const existingExecution = await this.db.getOptional<{ id: string }>(
+      const existingExecution = await tx.getOptional<{ id: string }>(
         'SELECT id FROM schedule_executions WHERE id = ? LIMIT 1',
         [execution.id],
       );
 
       if (existingExecution) {
-        await this.db.execute(
+        await tx.execute(
           `UPDATE schedule_executions
            SET status = ?,
                duration = ?,
@@ -184,7 +202,7 @@ export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository 
           ],
         );
       } else {
-        await this.db.execute(
+        await tx.execute(
           `INSERT INTO schedule_executions (
             id, task_id, identity_id, execution_time, status, duration, result, error, retry_count, created_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -202,21 +220,6 @@ export class PowerSyncScheduleTaskRepository implements IScheduleTaskRepository 
           ],
         );
       }
-    }
-
-    if (pendingDomainEvents.length > 0) {
-      flushDomainEvents(scheduleEventPublisher, task);
-      logger.info('[Schedule][Repo] Published domain events after PowerSync save', {
-        taskId: String(task.id),
-        publishedDomainEvents: pendingDomainEvents,
-      });
-    } else {
-      logger.warn(
-        '[Schedule][Repo] PowerSync save completed without domain events to publish',
-        {
-          taskId: String(task.id),
-        },
-      );
     }
   }
 

--- a/packages/schedule/src/server/infrastructure/powersync.ts
+++ b/packages/schedule/src/server/infrastructure/powersync.ts
@@ -14,13 +14,9 @@ import {
 import { PowerSyncScheduleRepository } from './adapters/powersync/schedule-powersync.repository';
 import { PowerSyncScheduleExecutionRepository } from './adapters/powersync/schedule-execution-powersync.repository';
 import { PowerSyncScheduleTaskRepository } from './adapters/powersync/schedule-task-powersync.repository';
+import type { IElectronDatabase } from '@dailyuse/contracts/electron';
 
-type Queryable = {
-  getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
-  getOptional<T>(sql: string, parameters?: unknown[]): Promise<T | null>;
-  get<T>(sql: string, parameters?: unknown[]): Promise<T>;
-  execute(sql: string, parameters?: unknown[]): Promise<unknown>;
-};
+type Queryable = IElectronDatabase;
 
 export interface SchedulePowerSyncRepositories {
   readonly scheduleRepository: PowerSyncScheduleRepository;

--- a/packages/utils/src/domain/__tests__/cross-platform-event-bus.spec.ts
+++ b/packages/utils/src/domain/__tests__/cross-platform-event-bus.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CrossPlatformEventBus } from '../cross-platform-event-bus';
+
+type TestEvents = {
+  'test:event': { value: string };
+};
+
+describe('CrossPlatformEventBus', () => {
+  it('isolates synchronous subscriber failures', () => {
+    const eventBus = new CrossPlatformEventBus<TestEvents>();
+    const succeedingHandler = vi.fn();
+
+    eventBus.on('test:event', () => {
+      throw new Error('sync failure');
+    });
+    eventBus.on('test:event', succeedingHandler);
+
+    expect(() => eventBus.send('test:event', { value: 'payload' })).not.toThrow();
+    expect(succeedingHandler).toHaveBeenCalledWith({ value: 'payload' });
+  });
+
+  it('handles rejected subscriber promises without blocking later subscribers', async () => {
+    const eventBus = new CrossPlatformEventBus<TestEvents>();
+    const succeedingHandler = vi.fn();
+
+    eventBus.on('test:event', async () => {
+      throw new Error('async failure');
+    });
+    eventBus.on('test:event', succeedingHandler);
+
+    eventBus.send('test:event', { value: 'payload' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(succeedingHandler).toHaveBeenCalledWith({ value: 'payload' });
+  });
+});

--- a/packages/utils/src/domain/cross-platform-event-bus.ts
+++ b/packages/utils/src/domain/cross-platform-event-bus.ts
@@ -1,252 +1,92 @@
-import mitt, { type Emitter, type EventType, type Handler } from 'mitt';
+import mitt, { type Emitter, type Handler } from 'mitt';
 import { createLogger } from '../logger';
 
 // 基础类型约束
 type EventMap = Record<string, any>;
-type RpcMap = Record<string, [any, any]>;
 
 const logger = createLogger('CrossPlatformEventBus');
-// 生成 UUID 的跨平台实现
-function generateUUID(): string {
-  // 如果在 Node.js 环境中，使用 crypto
-  if (typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.randomUUID) {
-    return globalThis.crypto.randomUUID();
-  }
-
-  // 如果在现代浏览器环境中，使用 Web Crypto API
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-
-  // 降级方案：简单的 UUID v4 实现
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
 
 /**
- * 跨平台统一事件系统
- * 基于 mitt 实现，支持浏览器和 Node.js 环境
- * 提供单向通信（send/on）和双向通信（invoke/handle）
- * 类似 Electron IPC 的接口设计
+ * 跨平台单向事件总线
+ * 基于 mitt 实现，支持浏览器和 Node.js 环境。
+ *
+ * 只承载「通知式反应」（ADR-033 范式 A）：发布方 `send`，订阅方 `on`/`off`，
+ * 发布方不关心也不等待订阅方返回。同进程请求-响应走 Port（范式 B），
+ * 跨进程走 `@dailyuse/ipc-client` / HTTP（范式 C）。
+ *
+ * @see docs/architecture/adr/ADR-033-cross-module-communication-patterns.md
  */
-export class CrossPlatformEventBus<
-  TEvents extends EventMap = EventMap, 
-  TRpc extends RpcMap = RpcMap
-> {
+export class CrossPlatformEventBus<TEvents extends EventMap = EventMap> {
   private emitter: Emitter<any>;
-  private rpcListeners = new Map<string, Handler<any>>();
   private debugEnabled = false;
-  private defaultTimeout = 30000; // 30秒默认超时
-  private pendingRequests = new Map<string, any>(); // 使用 any 替代 NodeJS.Timeout
-  private handlers = new Map<string, (payload: any) => Promise<any> | any>();
 
   constructor() {
     this.emitter = mitt();
   }
 
-  // ===================== 单向通信 (send/on) =====================
-
   /**
-   * 发送单向事件（类似 Electron 的 ipcRenderer.send）
-   * 这里的 key 是 TEvents 的键，payload 是对应的值
+   * 发布单向事件。
+   *
+   * 遍历订阅者并逐个 try/catch：任一订阅者抛错只记录日志，不影响其余订阅者，
+   * 也不冒泡给发布方（H3 错误隔离）。日志受 debug 门控，热路径不展开 payload（M1）。
+   *
    * @param eventType 事件类型
    * @param payload 事件负载
    */
   send<K extends keyof TEvents>(eventType: K, payload: TEvents[K]): void {
-    logger.info(`📤 Send: ${String(eventType)}`, payload);
-    this.emitter.emit(eventType as string, payload);
+    const type = eventType as string;
+    if (this.debugEnabled) logger.debug(`📤 Send: ${type}`, payload);
+
+    // mitt 内部对同一 key 的 handler 是同步顺序调用；这里取出快照逐个隔离执行，
+    // 避免某个订阅者抛错中断后续订阅者（mitt.emit 本身无 per-handler 隔离）。
+    const handlers = this.emitter.all.get(type) as Array<Handler<any>> | undefined;
+    if (!handlers || handlers.length === 0) return;
+
+    for (const handler of [...handlers]) {
+      try {
+        handler(payload);
+      } catch (error) {
+        logger.error(`❌ Event handler failed: ${type}`, error);
+      }
+    }
   }
 
   /**
-   * 监听单向事件（类似 Electron 的 ipcRenderer.on）
+   * 订阅单向事件。
    * @param eventType 事件类型
-   * @param listener 监听器函数
+   * @param handler 监听器函数
    */
   on<K extends keyof TEvents>(eventType: K, handler: (event: TEvents[K]) => void): this {
-    logger.info(`👂 On: ${String(eventType)}`);
+    if (this.debugEnabled) logger.debug(`👂 On: ${String(eventType)}`);
     this.emitter.on(eventType as string, handler);
     return this;
   }
 
   /**
-   * 移除事件监听器
+   * 移除事件监听器。
    * @param eventType 事件类型
-   * @param listener 监听器函数
+   * @param handler 监听器函数
    */
   off<K extends keyof TEvents>(eventType: K, handler?: (event: TEvents[K]) => void): this {
-    logger.info(`🔇 Off: ${String(eventType)}`);
+    if (this.debugEnabled) logger.debug(`🔇 Off: ${String(eventType)}`);
     this.emitter.off(eventType as string, handler);
     return this;
   }
 
-  // ===================== 双向通信 (invoke/handle) =====================
-
   /**
-   * 注册请求处理器（类似 Electron 的 ipcMain.handle）
-   * @param requestType 请求类型
-   * @param handler 处理函数
-   */
-  handle<K extends keyof TRpc>(
-    requestType: K,
-    handler: (payload: TRpc[K][0]) => Promise<TRpc[K][1]> | TRpc[K][1],
-  ): void {
-    const typeStr = requestType as string;
-    const requestEventName = `${typeStr}:request`;
-
-    logger.info(`🔧 Register Handler: ${typeStr}`);
-
-    // 1. 防止重复注册：如果已存在，先卸载旧的
-    if (this.rpcListeners.has(typeStr)) {
-      logger.warn(`⚠️ Overwriting existing handler for: ${typeStr}`);
-      this.removeHandler(requestType);
-    }
-
-    // 2. 创建包装器：处理请求 -> 执行业务逻辑 -> 发回响应
-    const listener: Handler<any> = async (event: { requestId: string; payload: any }) => {
-      const { requestId, payload } = event;
-      const responseEvent = `${typeStr}:response:${requestId}`;
-
-      try {
-        if (this.debugEnabled) logger.info(`📥 Handle Request: ${typeStr} (${requestId})`);
-        
-        // 执行业务逻辑
-        const result = await handler(payload);
-
-        // 发送成功响应
-        this.emitter.emit(responseEvent, {
-          success: true,
-          data: result,
-          error: null,
-        });
-      } catch (error) {
-        // 发送错误响应
-        logger.error(`❌ Handle Error: ${typeStr} (${requestId})`, error);
-        this.emitter.emit(responseEvent, {
-          success: false,
-          data: null,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    };
-
-    // 3. 存储引用并注册
-    this.rpcListeners.set(typeStr, listener);
-    this.emitter.on(requestEventName, listener);
-  }
-
-  /**
-   * 移除 RPC 请求处理器
-   * @param requestType 请求类型
-   * * ⚠️ 优化点：使用存储的函数引用进行 off，确保真正移除
-   */
-  removeHandler<K extends keyof TRpc>(requestType: K): void {
-    const typeStr = requestType as string;
-    const requestEventName = `${typeStr}:request`;
-
-    const listener = this.rpcListeners.get(typeStr);
-    if (listener) {
-      logger.info(`🗑️ Remove Handler: ${typeStr}`);
-      this.emitter.off(requestEventName, listener);
-      this.rpcListeners.delete(typeStr);
-    }
-  }
-
-  /**
-   * 发送请求并等待响应（类似 Electron 的 ipcRenderer.invoke）
-   * @param requestType 请求类型
-   * @param payload 请求载荷
-   * @param options 选项
-   */
-  async invoke<K extends keyof TRpc>(
-    requestType: K,
-    payload: TRpc[K][0],
-    options?: { timeout?: number },
-  ): Promise<TRpc[K][1]> {
-    const typeStr = requestType as string;
-    const requestId = generateUUID();
-    const timeout = options?.timeout || this.defaultTimeout;
-    const responseEvent = `${typeStr}:response:${requestId}`;
-    const requestEvent = `${typeStr}:request`;
-
-    if (this.debugEnabled) logger.info(`📨 Invoke: ${typeStr} (${requestId})`);
-
-    return new Promise((resolve, reject) => {
-      // 清理函数：无论成功失败都要执行
-      const cleanup = () => {
-        clearTimeout(timer);
-        this.emitter.off(responseEvent, responseHandler);
-        this.pendingRequests.delete(requestId);
-      };
-
-      // 1. 设置超时
-      const timer = setTimeout(() => {
-        cleanup();
-        reject(new Error(`RPC Timeout: ${typeStr} (${timeout}ms)`));
-      }, timeout);
-
-      // 2. 存储 Pending 状态 (用于 destroy 时取消)
-      this.pendingRequests.set(requestId, { reject, timer });
-
-      // 3. 响应处理器
-      const responseHandler = (response: {
-        success: boolean;
-        data: any;
-        error: string | null;
-      }) => {
-        cleanup(); // 收到响应立即清理
-
-        if (response.success) {
-          if (this.debugEnabled) logger.info(`✅ Invoke Success: ${typeStr} (${requestId})`);
-          resolve(response.data);
-        } else {
-          logger.error(`❌ Invoke Failed: ${typeStr} (${requestId}) - ${response.error}`);
-          reject(new Error(response.error || 'Unknown RPC error'));
-        }
-      };
-
-      // 4. 监听响应并发送请求
-      this.emitter.on(responseEvent, responseHandler);
-      this.emitter.emit(requestEvent, { requestId, payload });
-    });
-  }
-
-  // ===================== 生命周期与维护 =====================
-
-  /**
-   * 清理所有等待中的请求
-   */
-  clearPendingRequests(): void {
-    logger.info(`🧹 Clearing ${this.pendingRequests.size} pending requests`);
-
-    for (const [requestId, { reject, timer }] of this.pendingRequests.entries()) {
-      clearTimeout(timer);
-      reject(new Error('EventBus destroyed: Request cancelled'));
-    }
-    this.pendingRequests.clear();
-  }
-
-  /**
-   * 销毁实例
+   * 销毁实例，清空所有监听器。
    */
   destroy(): void {
-    logger.info(`💥 Destroying EventBus`);
-    this.clearPendingRequests();
-    this.rpcListeners.clear();
+    if (this.debugEnabled) logger.debug('💥 Destroying EventBus');
     this.emitter.all.clear();
   }
 
   /**
-   * 获取诊断信息
+   * 获取诊断信息。
    */
   getStats() {
     return {
-      handlersCount: this.rpcListeners.size,
       listenersCount: this.emitter.all.size,
-      pendingRequestsCount: this.pendingRequests.size,
-      registeredHandlers: Array.from(this.rpcListeners.keys()),
     };
   }
 

--- a/packages/utils/src/domain/cross-platform-event-bus.ts
+++ b/packages/utils/src/domain/cross-platform-event-bus.ts
@@ -43,11 +43,20 @@ export class CrossPlatformEventBus<TEvents extends EventMap = EventMap> {
     if (!handlers || handlers.length === 0) return;
 
     for (const handler of [...handlers]) {
-      try {
-        handler(payload);
-      } catch (error) {
-        logger.error(`❌ Event handler failed: ${type}`, error);
+      this.invokeHandler(type, handler, payload);
+    }
+  }
+
+  private invokeHandler(type: string, handler: Handler<any>, payload: unknown): void {
+    try {
+      const result = (handler as (event: unknown) => unknown)(payload);
+      if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+        void Promise.resolve(result).catch((error) => {
+          logger.error(`❌ Async event handler failed: ${type}`, error);
+        });
       }
+    } catch (error) {
+      logger.error(`❌ Event handler failed: ${type}`, error);
     }
   }
 

--- a/packages/utils/src/domain/global-event-bus.ts
+++ b/packages/utils/src/domain/global-event-bus.ts
@@ -1,13 +1,13 @@
 import { CrossPlatformEventBus } from './cross-platform-event-bus';
-import type { AppEventRegistry, AppRpcRegistry } from '@dailyuse/contracts/shared';
+import type { AppEventRegistry } from '@dailyuse/contracts/shared';
 
-// ===================== 2. 全局事件总线类 =====================
+// ===================== 全局事件总线 =====================
 
 /**
- * 全局事件总线 (具体业务实现)
- * 继承自 CrossPlatformEventBus 并注入具体的 AppEvents 和 AppRpc 泛型
+ * 全局事件总线（具体业务实现）
+ * 继承自 CrossPlatformEventBus 并注入具体的 AppEventRegistry 泛型。
  */
-export class GlobalEventBus extends CrossPlatformEventBus<AppEventRegistry, AppRpcRegistry> {
+export class GlobalEventBus extends CrossPlatformEventBus<AppEventRegistry> {
   constructor() {
     super();
     this.setDebugMode(process.env.NODE_ENV === 'development');
@@ -15,10 +15,13 @@ export class GlobalEventBus extends CrossPlatformEventBus<AppEventRegistry, AppR
 }
 
 /**
- * 全局唯一的事件总线实例
- * * 使用示例:
- * 1. 发送事件: eventBus.send('user:login', { userId: '1', timestamp: Date.now() })
- * 2. 监听事件: eventBus.on('user:login', (e) => console.log(e.userId))
- * 3. 发起请求: const result = await eventBus.invoke('account:check-email', { email: 'a@b.com' })
+ * 全局唯一的事件总线实例。
+ *
+ * 使用示例（ADR-033 范式 A · 通知式反应）:
+ * 1. 发布事件: eventBus.send('user:login', { userId: '1', timestamp: Date.now() })
+ * 2. 订阅事件: eventBus.on('user:login', (e) => console.log(e.userId))
+ *
+ * 需要请求-响应（拿返回值）请走 Port（同进程）或 @dailyuse/ipc-client / HTTP（跨进程），
+ * 不要在事件总线上做 RPC。
  */
 export const eventBus = new GlobalEventBus();


### PR DESCRIPTION
配套 ADR-033 与 `docs/plan/active/2026-07-10-event-bus-and-governance-hardening.md` 阶段一（H1/H3/M1/H2/L1/L2）。

## 为什么这么改

- **H1 收敛为单向 pub/sub**：`CrossPlatformEventBus` 里的 mitt-RPC（`invoke`/`handle`/`pendingRequests`/超时）全仓零生产调用。按 ADR-033，同进程请求-响应走 Port、跨进程走 `@dailyuse/ipc-client` / HTTP，mitt-RPC 无立足场景。整块删除 + `TRpc` 泛型，`GlobalEventBus` 去掉 `AppRpcRegistry` 泛型。`AppRpcRegistry` 类型保留（仍供 IPC channel 聚合）。
- **H3 + M1 错误隔离 + 日志门控**：`send` 改为取 handler 快照逐个 try/catch，一个订阅者抛错不再波及其余、也不冒泡给发布方——把错误隔离从约定变为机制。日志改 debug 门控，生产热路径不再求值 payload。
- **H2 事务 + 提交后派发**：AI(Prisma) 三写包进 `$transaction`；Reminder/Schedule(PowerSync) 多写包进 `writeTransaction`（`db` 收敛为 `IElectronDatabase`）；事件统一在事务提交后 flush，派发失败不回滚业务，与 H3 隔离形成双保险。

## 验证

- `utils` / `reminder` / `schedule` / `ai` / `notification` 的 typecheck / lint / test 全绿。
- `daily-use:governance-check` 通过（`raw-event-bus-audit` 通过）。
- 全仓 `eventBus.invoke|eventBus.handle` 零命中；无下游以第二个泛型实例化事件总线。

> 注：全图 typecheck 需先合入 #164（修 PR #161 遗留破损）。本 PR 仅消费 `send`/`on`/`off`，签名未变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)