### PR TITLE
feat(governance): 治理脚本自测 + mitt-rpc/unflushed-events audit + layer:service 约束 (PR-3)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -48,6 +48,14 @@ const moduleBoundaryDepConstraints = [
     sourceTag: 'layer:testing',
     onlyDependOnLibsWithTags: ['layer:shared', 'layer:testing'],
   },
+  {
+    // service: standalone deployable services (e.g. ai-service Python backend).
+    // Isolated leaves in the TS graph — may only consume shared contracts, never
+    // reach into infra/domain/ui/app. Without this entry @nx/enforce-module-boundaries
+    // leaves layer:service source tags unconstrained (default allow-all).
+    sourceTag: 'layer:service',
+    onlyDependOnLibsWithTags: ['layer:shared'],
+  },
 ] as const;
 
 const moduleBoundaryOptions = {

--- a/project.json
+++ b/project.json
@@ -43,6 +43,7 @@
     "governance-check": {
       "executor": "nx:run-commands",
       "cache": true,
+      "dependsOn": ["governance-tools:test"],
       "inputs": [
         "{workspaceRoot}/AGENT.md",
         "{workspaceRoot}/AGENTS.md",
@@ -73,10 +74,14 @@
         "{workspaceRoot}/tools/governance/package-internal-boundary-audit.mjs",
         "{workspaceRoot}/tools/governance/package-export-audit.mjs",
         "{workspaceRoot}/tools/governance/public-surface-audit.mjs",
-        "{workspaceRoot}/tools/governance/raw-event-bus-audit.mjs"
+        "{workspaceRoot}/tools/governance/raw-event-bus-audit.mjs",
+        "{workspaceRoot}/tools/governance/mitt-rpc-forbidden-audit.mjs",
+        "{workspaceRoot}/tools/governance/unflushed-events-audit.mjs",
+        "{workspaceRoot}/tools/governance/lib/**/*.mjs",
+        "{workspaceRoot}/packages/**/src/**/*.ts"
       ],
       "options": {
-        "command": "node ./tools/docs/check-docs-config.mjs && node ./tools/governance/target-baseline-audit.mjs && node ./tools/governance/file-naming-audit.mjs && node ./tools/governance/governance-module-docs-audit.mjs && node ./tools/governance/platform-leakage-audit.mjs && node ./tools/governance/singleton-audit.mjs && node ./tools/governance/desktop-runtime-locator-audit.mjs && node ./tools/governance/vitest-no-tests-audit.mjs && node ./tools/governance/server-feature-shape-audit.mjs && node ./tools/governance/package-internal-boundary-audit.mjs && node ./tools/governance/package-export-audit.mjs && node ./tools/governance/public-surface-audit.mjs && node ./tools/governance/raw-event-bus-audit.mjs"
+        "command": "node ./tools/docs/check-docs-config.mjs && node ./tools/governance/target-baseline-audit.mjs && node ./tools/governance/file-naming-audit.mjs && node ./tools/governance/governance-module-docs-audit.mjs && node ./tools/governance/platform-leakage-audit.mjs && node ./tools/governance/singleton-audit.mjs && node ./tools/governance/desktop-runtime-locator-audit.mjs && node ./tools/governance/vitest-no-tests-audit.mjs && node ./tools/governance/server-feature-shape-audit.mjs && node ./tools/governance/package-internal-boundary-audit.mjs && node ./tools/governance/package-export-audit.mjs && node ./tools/governance/public-surface-audit.mjs && node ./tools/governance/raw-event-bus-audit.mjs && node ./tools/governance/mitt-rpc-forbidden-audit.mjs && node ./tools/governance/unflushed-events-audit.mjs"
       }
     },
 

--- a/tools/governance/__tests__/mitt-rpc-forbidden.test.mjs
+++ b/tools/governance/__tests__/mitt-rpc-forbidden.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findMittRpcViolations,
+  isExemptPath,
+  MITT_RPC_PATTERN,
+} from '../lib/mitt-rpc-forbidden.mjs';
+
+describe('MITT_RPC_PATTERN', () => {
+  it('matches eventBus.invoke( and eventBus.handle(', () => {
+    expect('await eventBus.invoke("x")').toMatch(MITT_RPC_PATTERN);
+    expect('eventBus.handle("x", fn)').toMatch(MITT_RPC_PATTERN);
+  });
+
+  it('does not match legitimate Electron IPC', () => {
+    expect('ipcMain.handle(CH, fn)').not.toMatch(MITT_RPC_PATTERN);
+    expect('await ipcRenderer.invoke(CH)').not.toMatch(MITT_RPC_PATTERN);
+    expect('bridge.invoke("auth:logout")').not.toMatch(MITT_RPC_PATTERN);
+  });
+
+  it('does not match send/on/off', () => {
+    expect('eventBus.send("x", p)').not.toMatch(MITT_RPC_PATTERN);
+    expect('eventBus.on("x", fn)').not.toMatch(MITT_RPC_PATTERN);
+  });
+});
+
+describe('isExemptPath', () => {
+  it('exempts ipc-client and infrastructure directories', () => {
+    expect(isExemptPath('packages/ipc-client/src/client.ts')).toBe(true);
+    expect(isExemptPath('packages/ai/src/infrastructure-server/adapters/x.ts')).toBe(true);
+    expect(isExemptPath('packages/ai/src/infrastructure-client/adapters/x.ts')).toBe(true);
+  });
+
+  it('does not exempt ordinary business code', () => {
+    expect(isExemptPath('packages/goal/src/application-server/x.ts')).toBe(false);
+  });
+});
+
+describe('findMittRpcViolations', () => {
+  it('flags eventBus.invoke/handle in business code (positive fixture)', () => {
+    const files = [
+      {
+        relPath: 'packages/goal/src/application-server/bad.ts',
+        content: `export async function f(eventBus) {\n  return eventBus.invoke('goal:get', { id });\n}`,
+      },
+    ];
+    const { violations } = findMittRpcViolations(files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      file: 'packages/goal/src/application-server/bad.ts',
+      method: 'invoke',
+      line: 2,
+    });
+  });
+
+  it('passes clean code and exempt directories (negative fixture)', () => {
+    const files = [
+      {
+        relPath: 'packages/goal/src/application-server/good.ts',
+        content: `eventBus.send('goal:created', p);\neventBus.on('task:done', fn);`,
+      },
+      {
+        relPath: 'packages/ipc-client/src/impl.ts',
+        content: `export class IpcClientImpl { invokeChannel() { return bus.invoke('x'); } }`,
+      },
+      {
+        relPath: 'packages/ai/src/infrastructure-server/adapters/ipc.ts',
+        content: `eventBus.handle('ai:x', fn);`,
+      },
+    ];
+    const { violations, exemptHits } = findMittRpcViolations(files);
+    expect(violations).toHaveLength(0);
+    expect(exemptHits).toBe(1); // only the infrastructure file actually contained a hit
+  });
+
+  it('ignores matches inside comments', () => {
+    const files = [
+      {
+        relPath: 'packages/goal/src/x.ts',
+        content: `// legacy: eventBus.invoke('x')\n/* eventBus.handle('y', fn) */\nconst ok = true;`,
+      },
+    ];
+    const { violations } = findMittRpcViolations(files);
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/tools/governance/__tests__/source-scan.test.mjs
+++ b/tools/governance/__tests__/source-scan.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { findPatternMatches, stripCommentsStateful } from '../lib/source-scan.mjs';
+
+describe('stripCommentsStateful', () => {
+  it('strips line comments', () => {
+    expect(stripCommentsStateful('const a = 1; // trailing', false).code).toBe('const a = 1; ');
+  });
+
+  it('threads block-comment state across lines', () => {
+    const first = stripCommentsStateful('code /* start', false);
+    expect(first.inBlockComment).toBe(true);
+    expect(first.code).toBe('code ');
+    const second = stripCommentsStateful('still comment', true);
+    expect(second.inBlockComment).toBe(true);
+    expect(second.code).toBe('');
+    const third = stripCommentsStateful('end */ tail', true);
+    expect(third.inBlockComment).toBe(false);
+    expect(third.code).toBe(' tail');
+  });
+});
+
+describe('findPatternMatches', () => {
+  const pattern = /\bfoo\.(bar|baz)\s*\(/;
+
+  it('reports line and captured method for real code', () => {
+    const content = 'line one\nfoo.bar(1)\nfoo.baz(2)';
+    const matches = findPatternMatches(content, pattern);
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toMatchObject({ line: 2, method: 'bar' });
+    expect(matches[1]).toMatchObject({ line: 3, method: 'baz' });
+  });
+
+  it('skips matches inside comments', () => {
+    const content = '// foo.bar(1)\n/* foo.baz(2) */\nconst ok = 1;';
+    expect(findPatternMatches(content, pattern)).toHaveLength(0);
+  });
+});

--- a/tools/governance/__tests__/unflushed-events.test.mjs
+++ b/tools/governance/__tests__/unflushed-events.test.mjs
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { Project } from 'ts-morph';
+import {
+  auditUnflushedEvents,
+  findEventEmittingAggregates,
+} from '../lib/unflushed-events.mjs';
+
+function projectWith(files) {
+  const project = new Project({ useInMemoryFileSystem: true });
+  for (const [filePath, content] of Object.entries(files)) {
+    project.createSourceFile(filePath, content);
+  }
+  return project;
+}
+
+const EMITTING_AGGREGATE = `
+  import { AggregateRoot } from '@dailyuse/utils/domain';
+  export class Goal extends AggregateRoot {
+    complete() { this.addDomainEvent('goal:completed', {}); }
+  }
+`;
+
+const SILENT_AGGREGATE = `
+  import { AggregateRoot } from '@dailyuse/utils/domain';
+  export class UserSetting extends AggregateRoot {
+    rename(name) { this._name = name; }
+  }
+`;
+
+describe('findEventEmittingAggregates', () => {
+  it('collects only AggregateRoot subclasses that call addDomainEvent', () => {
+    const project = projectWith({
+      '/agg/goal.ts': EMITTING_AGGREGATE,
+      '/agg/setting.ts': SILENT_AGGREGATE,
+    });
+    const emitting = findEventEmittingAggregates(project);
+    expect(emitting.has('Goal')).toBe(true);
+    expect(emitting.has('UserSetting')).toBe(false);
+  });
+});
+
+describe('auditUnflushedEvents', () => {
+  it('flags a repository saving an event-emitting aggregate without flush (positive)', () => {
+    const project = projectWith({
+      '/agg/goal.ts': EMITTING_AGGREGATE,
+      '/repo/goal-repo.ts': `
+        import { Goal } from '../agg/goal';
+        export class GoalRepository {
+          async save(goal: Goal): Promise<void> { await this.db.write(goal); }
+        }
+      `,
+    });
+    const { violations } = auditUnflushedEvents(project);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      className: 'GoalRepository',
+      method: 'save',
+      aggregate: 'Goal',
+    });
+  });
+
+  it('passes when the repository flushes (negative: flushDomainEvents)', () => {
+    const project = projectWith({
+      '/agg/goal.ts': EMITTING_AGGREGATE,
+      '/repo/goal-repo.ts': `
+        import { Goal } from '../agg/goal';
+        import { flushDomainEvents } from '@dailyuse/utils/domain';
+        export class GoalRepository {
+          async save(goal: Goal): Promise<void> {
+            await this.db.write(goal);
+            flushDomainEvents(pub, goal);
+          }
+        }
+      `,
+    });
+    const { violations } = auditUnflushedEvents(project);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('passes when the repository extends AggregateRepositoryBase (negative: base flushes)', () => {
+    const project = projectWith({
+      '/agg/goal.ts': EMITTING_AGGREGATE,
+      '/repo/goal-repo.ts': `
+        import { Goal } from '../agg/goal';
+        import { AggregateRepositoryBase } from '@dailyuse/patterns';
+        export class GoalRepository extends AggregateRepositoryBase<Goal> {
+          protected async persist(goal: Goal): Promise<void> { await this.db.write(goal); }
+        }
+      `,
+    });
+    const { violations } = auditUnflushedEvents(project);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('does not flag repositories saving silent (non-emitting) aggregates', () => {
+    const project = projectWith({
+      '/agg/setting.ts': SILENT_AGGREGATE,
+      '/repo/setting-repo.ts': `
+        import { UserSetting } from '../agg/setting';
+        export class UserSettingRepository {
+          async save(s: UserSetting): Promise<void> { await this.db.write(s); }
+        }
+      `,
+    });
+    const { violations } = auditUnflushedEvents(project);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('honours the allowlist (baseline exemption)', () => {
+    const project = projectWith({
+      '/agg/goal.ts': EMITTING_AGGREGATE,
+      '/repo/goal-repo.ts': `
+        import { Goal } from '../agg/goal';
+        export class GoalRepository {
+          async save(goal: Goal): Promise<void> { await this.db.write(goal); }
+        }
+      `,
+    });
+    const { violations, allowlistedHits } = auditUnflushedEvents(project, {
+      isAllowlisted: (filePath) => filePath.endsWith('/repo/goal-repo.ts'),
+    });
+    expect(violations).toHaveLength(0);
+    expect(allowlistedHits).toBe(1);
+  });
+});

--- a/tools/governance/lib/mitt-rpc-forbidden.mjs
+++ b/tools/governance/lib/mitt-rpc-forbidden.mjs
@@ -1,0 +1,66 @@
+/**
+ * mitt-RPC forbidden audit (pure logic).
+ *
+ * Enforces ADR-033: the same-process message-style RPC (`eventBus.invoke` /
+ * `eventBus.handle`) is deprecated. Same-process request/response goes through a
+ * Port; cross-process goes through @dailyuse/ipc-client / HTTP. This audit fails
+ * if business code reintroduces `eventBus.invoke(` / `eventBus.handle(`.
+ *
+ * Scoped to the `eventBus.` receiver on purpose: bare `.invoke(` / `.handle(`
+ * match legitimate Electron IPC (`ipcMain.handle`, `ipcRenderer.invoke`) which
+ * are the sanctioned cross-process mechanism, not mitt-RPC.
+ */
+
+import { findPatternMatches } from './source-scan.mjs';
+
+export const MITT_RPC_PATTERN = /\beventBus\.(invoke|handle)\s*\(/;
+
+/**
+ * Directory segments whose files are exempt (they legitimately own cross-process
+ * request/response adapters). Matched against forward-slash relative paths.
+ */
+export const EXEMPT_PATH_SEGMENTS = [
+  'packages/ipc-client/',
+  '/infrastructure-server/',
+  '/infrastructure-client/',
+  '/infrastructure/',
+];
+
+export function isExemptPath(relPath, exemptSegments = EXEMPT_PATH_SEGMENTS) {
+  return exemptSegments.some((segment) => relPath.includes(segment));
+}
+
+/**
+ * Find mitt-RPC violations across the given files.
+ * @param {Array<{ relPath: string, content: string }>} files
+ * @param {{ exemptSegments?: string[], allowlist?: Set<string> }} [options]
+ * @returns {{ violations: Array<{file:string,line:number,method:string}>, auditedFiles:number, exemptHits:number }}
+ */
+export function findMittRpcViolations(files, options = {}) {
+  const exemptSegments = options.exemptSegments ?? EXEMPT_PATH_SEGMENTS;
+  const allowlist = options.allowlist ?? new Set();
+  const violations = [];
+  let auditedFiles = 0;
+  let exemptHits = 0;
+
+  for (const { relPath, content } of files) {
+    auditedFiles += 1;
+    const matches = findPatternMatches(content, MITT_RPC_PATTERN);
+    if (matches.length === 0) continue;
+
+    if (isExemptPath(relPath, exemptSegments) || allowlist.has(relPath)) {
+      exemptHits += matches.length;
+      continue;
+    }
+
+    for (const match of matches) {
+      violations.push({ file: relPath, line: match.line, method: match.method });
+    }
+  }
+
+  return { violations, auditedFiles, exemptHits };
+}
+
+export function formatMittRpcViolation({ file, line, method }) {
+  return `${file}:${line}: eventBus.${method}() is deprecated (ADR-033) — use a Port (same-process) or @dailyuse/ipc-client / HTTP (cross-process)`;
+}

--- a/tools/governance/lib/source-scan.mjs
+++ b/tools/governance/lib/source-scan.mjs
@@ -1,0 +1,128 @@
+/**
+ * Shared source-tree scanning helpers for governance audits.
+ *
+ * Pure, dependency-free utilities extracted so audit logic can be unit-tested
+ * without touching the filesystem or process.exit. CLI wrappers pass real
+ * directories; tests pass fixtures.
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export const DEFAULT_SKIP_DIRS = new Set([
+  '.git',
+  '.nx',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  'generated',
+  'locales',
+  '__tests__',
+  '__mocks__',
+  'test',
+  'tests',
+  'e2e',
+]);
+
+export const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+/**
+ * Recursively collect source files under `rootDir`.
+ * Returns `{ absPath, relPath }` where relPath is forward-slash relative to `repoRoot`.
+ */
+export function collectSourceFiles(rootDir, repoRoot, options = {}) {
+  const skipDirs = options.skipDirs ?? DEFAULT_SKIP_DIRS;
+  const extensions = options.extensions ?? SOURCE_EXTENSIONS;
+  const results = [];
+
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (skipDirs.has(entry)) continue;
+      const abs = path.join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(abs);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(abs);
+      } else if (stat.isFile() && extensions.has(path.extname(entry))) {
+        results.push({
+          absPath: abs,
+          relPath: path.relative(repoRoot, abs).split(path.sep).join('/'),
+        });
+      }
+    }
+  };
+
+  walk(rootDir);
+  return results;
+}
+
+/**
+ * Strip `//` line comments and `/* *\/` block comments from a single line,
+ * threading block-comment state across lines via the returned `inBlockComment`.
+ * Used so audits match real code, not commented-out examples.
+ */
+export function stripCommentsStateful(line, inBlockComment) {
+  let result = '';
+  let cursor = 0;
+  let block = inBlockComment;
+
+  while (cursor < line.length) {
+    if (block) {
+      const end = line.indexOf('*/', cursor);
+      if (end === -1) return { code: result, inBlockComment: true };
+      cursor = end + 2;
+      block = false;
+      continue;
+    }
+    if (line.startsWith('/*', cursor)) {
+      block = true;
+      cursor += 2;
+      continue;
+    }
+    if (line.startsWith('//', cursor)) {
+      return { code: result, inBlockComment: false };
+    }
+    result += line[cursor];
+    cursor += 1;
+  }
+
+  return { code: result, inBlockComment: block };
+}
+
+/**
+ * Scan file content line-by-line for `pattern`, skipping comments.
+ * Returns matches as `{ line, column, method, text }`.
+ * `pattern` must expose a capturing group #1 for the matched method when relevant.
+ */
+export function findPatternMatches(content, pattern) {
+  const lines = content.split(/\r?\n/);
+  const matches = [];
+  let inBlockComment = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const { code, inBlockComment: next } = stripCommentsStateful(lines[index], inBlockComment);
+    inBlockComment = next;
+    const match = code.match(pattern);
+    if (match) {
+      matches.push({
+        line: index + 1,
+        column: (match.index ?? 0) + 1,
+        method: match[1],
+        text: match[0],
+      });
+    }
+  }
+
+  return matches;
+}

--- a/tools/governance/lib/unflushed-events.mjs
+++ b/tools/governance/lib/unflushed-events.mjs
@@ -1,0 +1,128 @@
+/**
+ * Unflushed domain-events audit (pure logic, ts-morph).
+ *
+ * Guards the failure mode fixed in the event-bus hardening plan (H2): an
+ * aggregate accumulates domain events via `addDomainEvent`, but the repository
+ * that persists it forgets to `flushDomainEvents` — so events are silently lost.
+ *
+ * Heuristic (tuned for zero false positives on the current tree):
+ *   1. Collect domain-server AggregateRoot subclasses that actually emit events
+ *      (their class body calls `addDomainEvent`). These are "event-emitting".
+ *   2. For every repository class with a `save`/`persist` method whose parameter
+ *      type is an event-emitting aggregate, require the repository's source file
+ *      to reference `flushDomainEvents` or `publishDomainEvents`. Otherwise flag.
+ *
+ * Operates on a ts-morph Project so CLI (real tsconfig) and tests (in-memory
+ * fixtures) share the exact same logic.
+ */
+
+const SAVE_METHOD_NAMES = new Set(['save', 'persist', 'saveMany', 'saveBatch']);
+
+/**
+ * Identifiers that prove a file participates in a domain-event flush pathway.
+ * Two sanctioned patterns exist in the tree:
+ *  - the `flushDomainEvents`/`publishDomainEvents` helper (repo owns its save()); and
+ *  - `AggregateRepositoryBase` whose base save() calls `publishAggregateEvents`
+ *    (subclasses only implement persist(); the base flushes).
+ */
+const FLUSH_IDENTIFIERS = [
+  'flushDomainEvents',
+  'publishDomainEvents',
+  'publishAggregateEvents',
+  'AggregateRepositoryBase',
+];
+
+/** True if the class extends the flush-owning base (its save() auto-publishes). */
+function extendsAggregateRepositoryBase(cls) {
+  const extendsExpr = cls.getExtends();
+  return Boolean(extendsExpr) && /\bAggregateRepositoryBase\b/.test(extendsExpr.getText());
+}
+
+/** Returns the set of class names that extend AggregateRoot and call addDomainEvent. */
+export function findEventEmittingAggregates(project) {
+  const emitting = new Set();
+
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const cls of sourceFile.getClasses()) {
+      const extendsExpr = cls.getExtends();
+      if (!extendsExpr) continue;
+      if (!/\bAggregateRoot\b/.test(extendsExpr.getText())) continue;
+      if (cls.getText().includes('addDomainEvent')) {
+        const name = cls.getName();
+        if (name) emitting.add(name);
+      }
+    }
+  }
+
+  return emitting;
+}
+
+/** Extract the simple type name(s) referenced by a parameter's type node. */
+function parameterTypeNames(param) {
+  const typeNode = param.getTypeNode();
+  if (!typeNode) return [];
+  // Match identifiers in the type text; covers `X`, `X | null`, `X[]`, `readonly X[]`.
+  return typeNode.getText().match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? [];
+}
+
+/**
+ * Find repositories that save an event-emitting aggregate but never flush.
+ * @returns {Array<{ file: string, className: string, method: string, aggregate: string }>}
+ */
+export function findUnflushedRepositories(project, emittingAggregates, options = {}) {
+  const isAllowlisted = options.isAllowlisted ?? (() => false);
+  const violations = [];
+  let allowlistedHits = 0;
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const fileText = sourceFile.getFullText();
+    const flushesSomewhere = FLUSH_IDENTIFIERS.some((id) => fileText.includes(id));
+
+    for (const cls of sourceFile.getClasses()) {
+      const className = cls.getName();
+      if (!className || !/Repository$/.test(className)) continue;
+
+      // Repos extending the flush-owning base delegate publishing to base.save();
+      // their persist() override is not a miss.
+      if (extendsAggregateRepositoryBase(cls)) continue;
+
+      for (const method of cls.getMethods()) {
+        if (!SAVE_METHOD_NAMES.has(method.getName())) continue;
+
+        const savedAggregate = method
+          .getParameters()
+          .flatMap((param) => parameterTypeNames(param))
+          .find((typeName) => emittingAggregates.has(typeName));
+
+        if (!savedAggregate || flushesSomewhere) continue;
+
+        const filePath = sourceFile.getFilePath();
+        if (isAllowlisted(filePath)) {
+          allowlistedHits += 1;
+          continue;
+        }
+
+        violations.push({
+          file: filePath,
+          className,
+          method: method.getName(),
+          aggregate: savedAggregate,
+        });
+      }
+    }
+  }
+
+  return { violations, allowlistedHits };
+}
+
+/** Full audit over a ts-morph Project. */
+export function auditUnflushedEvents(project, options = {}) {
+  const emitting = findEventEmittingAggregates(project);
+  const { violations, allowlistedHits } = findUnflushedRepositories(project, emitting, options);
+  return { emitting, violations, allowlistedHits };
+}
+
+export function formatUnflushedViolation({ file, className, method, aggregate }, repoRoot = '') {
+  const rel = repoRoot && file.startsWith(repoRoot) ? file.slice(repoRoot.length + 1) : file;
+  return `${rel}: ${className}.${method}() persists event-emitting aggregate ${aggregate} but the file never calls flushDomainEvents/publishDomainEvents`;
+}

--- a/tools/governance/mitt-rpc-forbidden-audit.mjs
+++ b/tools/governance/mitt-rpc-forbidden-audit.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * mitt-RPC Forbidden Audit (CLI)
+ *
+ * Fails if business code calls `eventBus.invoke(` / `eventBus.handle(`.
+ * See ADR-033 and tools/governance/lib/mitt-rpc-forbidden.mjs for rationale.
+ *
+ * Exit codes:
+ *   0 - no mitt-RPC usage in audited scope
+ *   1 - mitt-RPC usage detected
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { collectSourceFiles } from './lib/source-scan.mjs';
+import { findMittRpcViolations, formatMittRpcViolation } from './lib/mitt-rpc-forbidden.mjs';
+
+const ROOT = path.join(import.meta.dirname, '..', '..');
+const SCAN_ROOTS = [path.join(ROOT, 'apps'), path.join(ROOT, 'packages')];
+
+const files = SCAN_ROOTS.flatMap((scanRoot) => collectSourceFiles(scanRoot, ROOT)).map(
+  ({ relPath, absPath }) => ({ relPath, content: readFileSync(absPath, 'utf-8') }),
+);
+
+const { violations, auditedFiles, exemptHits } = findMittRpcViolations(files);
+
+if (violations.length > 0) {
+  console.error(`[mitt-rpc-forbidden-audit] failed with ${violations.length} issue(s):`);
+  for (const violation of violations) {
+    console.error(`  ${formatMittRpcViolation(violation)}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `[mitt-rpc-forbidden-audit] passed (${auditedFiles} files audited, ${exemptHits} exempt hit(s))`,
+);

--- a/tools/governance/project.json
+++ b/tools/governance/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "governance-tools",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "tools/governance",
+  "tags": ["scope:tools", "type:lib", "layer:testing"],
+  "targets": {
+    "build": {
+      "executor": "nx:noop",
+      "outputs": [],
+      "dependsOn": [],
+      "cache": false
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "options": {
+        "command": "node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts",
+        "cwd": "tools/governance"
+      }
+    },
+    "test:watch": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "node ../../node_modules/vitest/vitest.mjs --config vitest.config.ts",
+        "cwd": "tools/governance"
+      }
+    }
+  }
+}

--- a/tools/governance/target-baseline-manifest.json
+++ b/tools/governance/target-baseline-manifest.json
@@ -81,7 +81,8 @@
     "dashboard": "ui-lib",
     "assets": "ui-lib",
     "@dailyuse/test-utils": "tooling-lib",
-    "nx-test-system": "tooling-lib"
+    "nx-test-system": "tooling-lib",
+    "governance-tools": "tooling-lib"
   },
   "exemptions": [
     {

--- a/tools/governance/unflushed-events-audit.mjs
+++ b/tools/governance/unflushed-events-audit.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Unflushed Domain-Events Audit (CLI)
+ *
+ * Loads all domain-server aggregate + repository sources into a ts-morph Project
+ * and flags repositories that persist an event-emitting aggregate without ever
+ * calling flushDomainEvents/publishDomainEvents. See lib/unflushed-events.mjs.
+ *
+ * Exit codes:
+ *   0 - no suspected unflushed-event repositories
+ *   1 - suspected miss detected
+ */
+
+import path from 'node:path';
+import { Project } from 'ts-morph';
+import { collectSourceFiles } from './lib/source-scan.mjs';
+import { auditUnflushedEvents, formatUnflushedViolation } from './lib/unflushed-events.mjs';
+
+const ROOT = path.join(import.meta.dirname, '..', '..');
+const PACKAGES = path.join(ROOT, 'packages');
+
+// Only aggregate + repository sources are needed to decide both halves of the rule.
+const files = collectSourceFiles(PACKAGES, ROOT).filter(({ relPath }) => {
+  if (/\.(spec|test)\.[tj]sx?$/.test(relPath)) return false;
+  // In-memory repositories are unit-test doubles; they intentionally do not
+  // publish domain events and are out of scope.
+  if (relPath.includes('/adapters/memory/')) return false;
+  const isServerAggregate = relPath.includes('/domain-server/') && relPath.includes('/aggregates/');
+  const isServerRepo =
+    relPath.includes('/infrastructure-server/') && /repository\.[tj]s$/i.test(relPath);
+  return isServerAggregate || isServerRepo;
+});
+
+const project = new Project({ useInMemoryFileSystem: false, skipAddingFilesFromTsConfig: true });
+for (const { absPath } of files) {
+  project.addSourceFileAtPath(absPath);
+}
+
+/**
+ * Baseline of pre-existing suspected misses (repo-root-relative).
+ *
+ * These production repositories persist an event-emitting aggregate without a
+ * flush in-file. They are SURFACED, not blessed: this audit is introduced with
+ * the current tree frozen as a baseline so it fails on any NEW miss. Triaging
+ * whether each of these is a genuine event-loss bug or an intentionally
+ * unpublished aggregate is tracked as follow-up, out of this PR's scope.
+ */
+const BASELINE_ALLOWLIST = new Set([
+  'packages/account/src/infrastructure-server/adapters/powersync/account-powersync.repository.ts',
+  'packages/authentication/src/infrastructure-server/adapters/powersync/auth-session-powersync.repository.ts',
+  'packages/notification/src/infrastructure-server/adapters/powersync/notification-template-powersync.repository.ts',
+  'packages/notification/src/infrastructure-server/adapters/prisma/notification-template-prisma.repository.ts',
+  'packages/reminder/src/infrastructure-server/adapters/powersync/reminder-group-powersync.repository.ts',
+  'packages/repository/src/infrastructure-server/adapters/powersync/repository-powersync.repository.ts',
+  'packages/repository/src/infrastructure-server/adapters/prisma/repository-prisma.repository.ts',
+]);
+
+const toRel = (absPath) => path.relative(ROOT, absPath).split(path.sep).join('/');
+
+const { emitting, violations, allowlistedHits } = auditUnflushedEvents(project, {
+  isAllowlisted: (absPath) => BASELINE_ALLOWLIST.has(toRel(absPath)),
+});
+
+if (violations.length > 0) {
+  console.error(`[unflushed-events-audit] failed with ${violations.length} issue(s):`);
+  for (const violation of violations) {
+    console.error(`  ${formatUnflushedViolation(violation, ROOT)}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `[unflushed-events-audit] passed (${files.length} files audited, ${emitting.size} event-emitting aggregate(s), ${allowlistedHits} baseline exemption(s))`,
+);

--- a/tools/governance/vitest.config.ts
+++ b/tools/governance/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'governance-tools',
+    root: __dirname,
+    environment: 'node',
+    globals: true,
+    include: ['__tests__/**/*.test.mjs'],
+  },
+});


### PR DESCRIPTION
配套 ADR-033 与计划阶段二（M5 → M4 → M2）。

## 为什么这么改

- **M5 · tools/governance 提为 Nx 项目 + 逻辑抽为可测纯函数**：核心逻辑搬到 `tools/governance/lib/`（`source-scan` 文件遍历+注释剥离、`mitt-rpc-forbidden`、`unflushed-events`），CLI 只做 IO + `process.exit`。新增 `governance-tools` 项目（`build`+`test`），补 `__tests__` 正反 fixture 单测（18 例）。`governance-check` 增加 `dependsOn: governance-tools:test` 作前置——治理脚本本身从此有测试护栏。
- **M4 · 两个新 audit**：
  - `mitt-rpc-forbidden-audit`：拦截业务代码 `eventBus.invoke(` / `eventBus.handle(`，放行 `ipc-client` 与 `infrastructure-*`，落实 ADR-033 弃用条款。**收窄到 `eventBus.` 前缀**——bare `.invoke(`/`.handle(` 会误伤合法的 Electron `ipcMain.handle`/`ipcRenderer.invoke`（全仓 328 处）。
  - `unflushed-events-audit`（ts-morph）：扫描「会发事件」的 `AggregateRoot` 子类（类体含 `addDomainEvent`），若其仓储 `save`/`persist` 持久化该聚合却全文件无 `flushDomainEvents`/`publishDomainEvents` 且不继承 `AggregateRepositoryBase`，判为疑似漏发。内存仓储（测试替身）不扫。7 处**既有**生产疑似漏发以 documented baseline allowlist 冻结（surfaced 非 blessed，另行 triage），审计对**新增**漏发失败。
- **M2 · eslint depConstraints 补 layer:service**：`ai-service`（独立 Python 服务）此前无约束（`@nx/enforce-module-boundaries` 默认放行）。追加 `layer:service → onlyDependOnLibsWithTags: ['layer:shared']`，闭合无约束漏洞。

## 验证

- `governance-tools:test` 18 例全绿（source-scan / mitt-rpc / unflushed-events 正反 fixture）。
- 两个新 audit 对 `main` 全绿：mitt-rpc 0 命中；unflushed 21 个发事件聚合、7 baseline 豁免。
- **注入演练**：临时在业务代码写入 `eventBus.invoke(...)`，audit 精确报错（`file:line`）并 exit 1，随后回退确认恢复 0。
- `daily-use:governance-check` 全绿（含新 audit 与 governance-tools:test 前置）。
- `goal:lint` 0 error（确认 `eslint.config.ts` 带 layer:service 条目正常解析）。

> 注：`governance-check` 全绿需先合入 #164（修 PR #161 遗留的 mobile eslint 等）。本 PR 新增的两个 audit 与 governance-tools:test 自身在 main 上即通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)