### PR TITLE
docs: ADR-009↔031 互补交叉引用 + plan/archive 季度子索引 (PR-4)

### DIFF
--- a/docs/architecture/adr/ADR-009-standard-clean-architecture-layers.md
+++ b/docs/architecture/adr/ADR-009-standard-clean-architecture-layers.md
@@ -3,6 +3,11 @@
 ## Status
 Accepted
 
+> **关联 ADR-031（互补，非取代）**：本 ADR 定义分层原则与依赖方向（domain ← application ← infrastructure ← ui）。
+> 服务端 feature 包这些层的**具体目录形态**（`domain-server/` `application-server/` `infrastructure-server/` …）
+> 由 [ADR-031: Server Feature Standard Shape](./ADR-031-server-feature-standard-shape.md) 定义。
+> 组合根允许 `domain`→`infra` 的例外见 [ADR-023](./ADR-023-server-side-clean-architecture-refactor.md) 与 `eslint.config.ts` 的 `layer:domain` 约束。
+
 ## Date
 2026-01-15
 
@@ -32,12 +37,16 @@ We enforce a strict **Clean Architecture** with a unidirectional dependency flow
 *   **Contains:** Vue/React Components, Controllers, IPC Handlers.
 *   **Dependencies:** Application, Domain.
 
-### 2. Package Responsibilities
-*   `contracts`: Shared types (No deps).
+### 2. Layer Responsibilities
+
+这些是**分层职责**，在每个 feature 包内以同名目录承载（`packages/<feature>/src/<layer>/`，
+目录形态见 ADR-031），不是独立的顶层包：
+
+*   `contracts`: Shared types (No deps) —— 这是独立包。
 *   `domain-server`/`domain-client`: Pure business logic.
 *   `application-server`/`application-client`: Use cases.
-*   `infrastructure-*`: Technical implementations.
-*   `ui-*`: Visuals.
+*   `infrastructure-server`/`infrastructure-client`: Technical implementations.
+*   `ui-*`: Visuals —— 独立包。
 
 ### 3. Code Example
 ```typescript

--- a/docs/plan/archive/2026-Q2.md
+++ b/docs/plan/archive/2026-Q2.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - plan
+  - archive
+  - index
+description: 2026 Q2 (4–6 月) 归档计划季度子索引
+---
+
+# 归档计划 · 2026 Q2 (4–6 月)
+
+> 本文件仅为导航索引；计划正文仍在 `docs/plan/archive/` 原文件。返回 [归档总览](./README.md)。
+
+| 日期 | 计划 |
+| --- | --- |
+| 2026-04-26 | [配置与领域测试治理收敛方案](./2026-04-26-configuration-and-domain-test-governance.md) |
+| 2026-04-26 | [领域层测试执行快速参考卡](./2026-04-26-domain-test-quick-reference.md) |
+| 2026-04-26 | [领域层测试系统完整实现报告](./2026-04-26-domain-test-system-implementation-report.md) |
+| 2026-04-26 | [Frontend Context Menu Infrastructure + Form-DTO Alignment](./2026-04-26-frontend-context-menu-and-form-alignment.md) |
+| 2026-04-26 | [仓库一致性治理收敛方案](./2026-04-26-repository-governance-unification.md) |
+| 2026-04-26 | [TDD Test System Rollout](./2026-04-26-tdd-test-system-rollout.md) |
+| 2026-04-27 | [完整测试体系第三阶段优化方案](./2026-04-27-full-test-system-rollout.md) |
+| 2026-04-27 | [测试系统推断器化方案](./2026-04-27-test-system-oracle-hardening.md) |
+| 2026-04-29 | [AI Goal / Agent Workflow Unification](./2026-04-29-ai-goal-agent-workflow-unification.md) |
+| 2026-04-30 | [AI Goal Workflow Test System](./2026-04-30-ai-goal-workflow-test-system.md) |
+| 2026-04-30 | [AI Service 文件日志与 Goal Workflow 调试增强](./2026-04-30-ai-service-file-logging-and-goal-debugging.md) |
+| 2026-04-30 | [API Goal Flow 调试日志增强](./2026-04-30-api-goal-flow-debug-logging.md) |
+| 2026-04-30 | [全量检测报告（2026-05-01，重检版 v3）](./2026-04-30-全量检测报告.md) |
+| 2026-05-01 | [CI pnpm Bootstrap Hotfix](./2026-05-01-ci-pnpm-bootstrap-hotfix.md) |
+| 2026-05-01 | [CI Workflow Consolidation](./2026-05-01-ci-workflow-consolidation.md) |
+| 2026-05-01 | [Mobile Lint Flat Config Hotfix](./2026-05-01-mobile-lint-flat-config-hotfix.md) |
+| 2026-05-02 | [Application-Server 层标准化计划](./2026-05-02-application-server-layer-standardization.md) |
+| 2026-05-02 | [Contracts 包治理与业务模块标准化优化](./2026-05-02-contracts-governance-optimization.md) |
+| 2026-05-02 | [Domain 层标准化收尾计划](./2026-05-02-domain-layer-standardization.md) |
+| 2026-05-02 | [日程冲突检测实现计划](./2026-05-02-schedule-conflict-detection-implementation.md) |
+| 2026-05-03 | [Application-Client 层标准化计划](./2026-05-03-application-client-layer-standardization.md) |
+| 2026-05-03 | [Contracts 层优化：移除 PersistenceDTO、统一值对象、删除展示文本](./2026-05-03-contracts-persistence-dto-removal.md) |
+| 2026-05-03 | [Governance Infrastructure Layer — 注释标准化计划](./2026-05-03-governance-infrastructure-layer-standardization.md) |
+| 2026-05-03 | [仓储层不优雅问题分析与改造方案](./2026-05-03-repository-layer-inelegance-analysis.md) |
+| 2026-05-05 | [Contracts 跨模块一致性收敛实施计划](./2026-05-05-contracts-cross-module-consistency-sweep.md) |
+| 2026-05-06 | [AI Runtime Module Split 执行方案](./2026-05-06-ai-runtime-module-split.md) |
+| 2026-05-06 | [Codebase Architecture Deepening 审查与后续计划](./2026-05-06-codebase-architecture-deepening-audit.md) |
+| 2026-05-06 | [Goal Read-Model Workflow Deepening 执行方案](./2026-05-06-goal-read-model-workflow-deepening.md) |
+| 2026-05-06 | [Repository Resource Mutation Deepening 执行方案](./2026-05-06-repository-resource-mutation-deepening.md) |
+| 2026-05-06 | [服务端 Deepening 执行总览](./2026-05-06-server-deepening-execution-overview.md) |
+| 2026-05-07 | [服务端 Deepening 完整优化执行方案](./2026-05-07-server-deepening-completion-plan.md) |
+| 2026-05-07 | [服务端 Deepening 实现诊断](./2026-05-07-server-deepening-implementation-diagnosis.md) |
+| 2026-05-10 | [删除事件接入统一事件总线执行状态](./2026-05-10-delete-event-bus-delete-flow.md) |
+| 2026-05-10 | [Frontend Deepening 执行方案](./2026-05-10-frontend-deepening-execution-plan.md) |
+| 2026-05-12 | [Web Typecheck 失败链修复方案](./2026-05-12-web-typecheck-fix-plan.md) |
+| 2026-05-14 | [Web E2E 剩余失败用例分析与修复方案](./2026-05-14-web-e2e-failure-analysis.md) |
+| 2026-05-16 | [Monorepo 统一构建规范实施方案](./2026-05-16-monorepo-build-standardization.md) |
+| 2026-05-16 | [PowerSync Schema 拆包实施方案](./2026-05-16-powersync-schema-split.md) |
+| 2026-05-17 | [Desktop QQ 风格登录改造方案](./2026-05-17-desktop-auth-qq-login-redesign.md) |
+| 2026-05-17 | [Desktop 开发模式热更新修复方案](./2026-05-17-desktop-dev-hot-reload-fix.md) |
+| 2026-05-17 | [桌面端多账号本地存储架构实现状态](./2026-05-17-desktop-multi-account-local-storage-architecture.md) |
+| 2026-05-17 | [Web 与 Mobile 登录页 QQ 风格统一改造方案](./2026-05-17-web-mobile-auth-qq-redesign.md) |
+| 2026-05-22 | [Remaining Architecture Optimizations Workpacks](./2026-05-22-codebase-architecture-consistency-analysis.md) |
+| 2026-05-24 | [文件命名规范重设与首轮统一方案](./2026-05-24-file-naming-standardization.md) |
+| 2026-05-25 | [2026-05-25 Architecture Deepening Refactor Plan](./2026-05-25-architecture-deepening-refactor-plan.md) |
+| 2026-05-28 | [2026-05-28 Architecture And Governance Deepening Plan](./2026-05-28-architecture-governance-deepening.md) |
+| 2026-05-29 | [2026-05-29 Repository Paradigm Unification Plan](./2026-05-29-repository-paradigm-unification-plan.md) |
+| 2026-06-02 | [目标模块功能资产底图建设计划](./2026-06-02-goal-feature-asset-map.md) |
+| 2026-06-02 | [用户可见模块功能资产底图扩展方案](./2026-06-02-product-module-asset-map-rollout.md) |
+| 2026-06-03 | [Desktop 端用户数据导入导出详细实现方案](./2026-06-03-user-data-portability-desktop-plan.md) |
+| 2026-06-03 | [用户数据导入导出 V1 详细实现方案](./2026-06-03-user-data-portability-v1.md) |
+| 2026-06-04 | [AI Agent 框架选型方案](./2026-06-04-ai-agent-framework-options.md) |
+| 2026-06-04 | [AI Agent 实施路线图](./2026-06-04-ai-agent-implementation-roadmap.md) |
+| 2026-06-04 | [AI Agent 系统搭建方案](./2026-06-04-ai-agent-runtime-architecture-options.md) |
+| 2026-06-04 | [AI Agent 工作台产品体验重构计划](./2026-06-04-ai-agent-workspace-product-experience-plan.md) |
+| 2026-06-04 | [Desktop 端 Data Portability 合约测试与 IPC 集成测试方案](./2026-06-04-data-portability-desktop-test-plan.md) |
+| 2026-06-04 | [Goal Agent Workflow 方案](./2026-06-04-goal-agent-workflow-options.md) |
+| 2026-06-04 | [Knowledge Generation Workflow 方案](./2026-06-04-knowledge-generation-workflow-options.md) |
+| 2026-06-04 | [Knowledge Q&A Workflow 方案](./2026-06-04-knowledge-qa-rag-workflow-options.md) |
+| 2026-06-05 | [Data Portability Contracts 收口与模块化重构方案](./2026-06-05-data-portability-contracts-refactor-plan.md) |
+| 2026-06-08 | [AI Agent 总体实施方案](./2026-06-08-ai-agent-master-implementation-plan.md) |
+| 2026-06-12 | [AI Agent Master 实施最终总结](./2026-06-12-ai-agent-implementation-final-summary.md) |
+| 2026-06-12 | [AI Agent Master 实施状况审查](./2026-06-12-implementation-status-audit.md) |
+| 2026-06-13 | [AI Agent Master - 完整优雅实施 - 最终报告](./2026-06-13-ai-agent-complete-elegant-implementation-final.md) |
+| 2026-06-13 | [AI Agent 剩余错误收口计划](./2026-06-13-ai-agent-remaining-errors-remediation-plan.md) |
+| 2026-06-13 | [AI Agent 剩余错误收口 - 最终完成报告](./2026-06-13-checkpoint-final-remediation-completion.md) |
+| 2026-06-13 | [Checkpoint 持久化收口 - 完成报告](./2026-06-13-checkpoint-refinement-completion.md) |
+| 2026-06-13 | [Checkpoint 持久化收口方案](./2026-06-13-checkpoint-refinement-plan.md) |
+| 2026-06-13 | [Database LangGraph Checkpointer - 实施计划](./2026-06-13-database-langgraph-checkpointer-plan.md) |
+| 2026-06-13 | [AI Agent Master - 剩余问题分析与处理建议](./2026-06-13-remaining-issues-analysis.md) |
+| 2026-06-13 | [Local Deployment Validation Fixes](./2026-06-13-validation-fixes.md) |
+| 2026-06-14 | [PR Readiness Validation](./2026-06-14-pr-readiness-validation.md) |

--- a/docs/plan/archive/2026-Q3.md
+++ b/docs/plan/archive/2026-Q3.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - plan
+  - archive
+  - index
+description: 2026 Q3 (7–9 月) 归档计划季度子索引
+---
+
+# 归档计划 · 2026 Q3 (7–9 月)
+
+> 本文件仅为导航索引；计划正文仍在 `docs/plan/archive/` 原文件。返回 [归档总览](./README.md)。
+
+| 日期 | 计划 |
+| --- | --- |
+| 2026-07-01 | [2026-07-01 Code Quality Consistency Remediation Plan](./2026-07-01-code-quality-consistency-remediation-plan.md) |
+| 2026-07-02 | [2026-07-02 Core Seam Reconvergence Blueprint](./2026-07-02-core-seam-reconvergence-blueprint.md) |
+| 2026-07-02 | [2026-07-02 Core Seam Reconvergence Execution Plan](./2026-07-02-core-seam-reconvergence-execution-plan.md) |
+| 2026-07-02 | [R01 TaskTemplate Deep Aggregate](./2026-07-02-core-seam-reconvergence-r01-task-template-deep-aggregate.md) |
+| 2026-07-02 | [R02 Typed Event Seam Foundation](./2026-07-02-core-seam-reconvergence-r02-typed-event-seam-foundation.md) |
+| 2026-07-02 | [R03 Task Schedule Projection Source](./2026-07-02-core-seam-reconvergence-r03-task-schedule-projection-source.md) |
+| 2026-07-02 | [R04 Schedule Orchestration Task Owner](./2026-07-02-core-seam-reconvergence-r04-schedule-orchestration-task-owner.md) |
+| 2026-07-02 | [R05 Goal Reminder Projection Owner](./2026-07-02-core-seam-reconvergence-r05-goal-reminder-projection-owner.md) |
+| 2026-07-02 | [R06 Source Executor Host Thinning](./2026-07-02-core-seam-reconvergence-r06-source-executor-host-thinning.md) |
+| 2026-07-02 | [R07 Controller Route Seam Unification](./2026-07-02-core-seam-reconvergence-r07-controller-route-seam-unification.md) |
+| 2026-07-02 | [R08 Strict ID Contract Fixtures](./2026-07-02-core-seam-reconvergence-r08-strict-id-contract-fixtures.md) |
+| 2026-07-02 | [R09 Host Runtime Tests Doc Alignment](./2026-07-02-core-seam-reconvergence-r09-host-runtime-tests-doc-alignment.md) |
+| 2026-07-03 | [2026-07-03 Core Seam Reconvergence Direct Execution Runbook](./2026-07-03-core-seam-reconvergence-direct-execution-runbook.md) |
+| 2026-07-03 | [2026-07-03 Core Seam Reconvergence Round Playbook](./2026-07-03-core-seam-reconvergence-round-playbook.md) |
+| 2026-07-04 | [2026-07-04 Audit Follow-up Elegant Refactor Blueprint](./2026-07-04-audit-follow-up-elegant-refactor-blueprint.md) |
+| 2026-07-04 | [2026-07-04 Core Seam Reconvergence Multi-Round Executable Plan](./2026-07-04-core-seam-reconvergence-multi-round-executable-plan.md) |
+| 2026-07-04 | [2026-07-04 Post Core-Seam Elegant Refactor Plan](./2026-07-04-post-core-seam-elegant-refactor-plan.md) |

--- a/docs/plan/archive/README.md
+++ b/docs/plan/archive/README.md
@@ -15,3 +15,24 @@ updated: 2026-04-26T00:00:00
 
 - 不在这里维护活跃任务
 - 归档文件保留原始计划上下文，必要时在文首补充结果或停用原因
+
+## 季度子索引
+
+历史文件较多，按季度分组导航（子索引仅为导航，正文仍在本目录原文件）：
+
+- [2026 Q2（4–6 月）](./2026-Q2.md)
+- [2026 Q3（7–9 月）](./2026-Q3.md)
+
+### 未注日期（早期文件，无日期前缀）
+
+| 计划 |
+| --- |
+| [CHECKPOINT-domain-test-system](./CHECKPOINT-domain-test-system.md) |
+| [INDEX-domain-test-documentation](./INDEX-domain-test-documentation.md) |
+| [P0-1-clarification-complete-summary](./P0-1-clarification-complete-summary.md) |
+| [P0-1-文档导航](./P0-1-文档导航.md) |
+| [baseline-report](./baseline-report.md) |
+| [memoflow-ai-goal-feature-backlog](./memoflow-ai-goal-feature-backlog.md) |
+| [p0-1-clarification-implementation-plan](./p0-1-clarification-implementation-plan.md) |
+| [route-2-unified-ai-workflow-orchestrator-plan](./route-2-unified-ai-workflow-orchestrator-plan.md) |
+| [tdd-ai-whimsical-swan](./tdd-ai-whimsical-swan.md) |


### PR DESCRIPTION
配套计划阶段三 L3/L4。

## L3 — ADR-009（修正 plan 前提，不做 superseded）

plan 原设想「ADR-009 描述旧布局、被 ADR-031 取代 → 标 superseded-by」。**核对代码后该前提不成立**：

- ADR-009 是**分层原则**（domain ← application ← infra ← ui 的依赖方向），其 `domain-server` / `application-server` / `infrastructure-*` 层名在现行代码中仍成立（`packages/*/src/application-server` 等真实存在）。
- ADR-031 用**同名层**、只定义 feature 包内的**具体目录形态**，从未声明取代 009，也没有 plan 说的「`src/server/{...}` 布局」。
- 二者**互补**（009=原则，031=形态）。标 superseded 会让一个仍准确的基础 ADR 看起来退役，误导读者。

按 AGENT.md 真值顺序（代码为准，修正文档）处理：
- ADR-009 顶部加指向 ADR-031 / ADR-023 的**互补交叉引用**；
- §2 措辞从「独立包」更正为「feature 包内的同名目录」，消除唯一的陈述偏差；
- **索引状态不变**（仍「已采纳」）。

## L4 — plan/archive 季度子索引

- 新增 `2026-Q2.md`（72 条）/ `2026-Q3.md`（17 条）季度导航子索引，仅导航、不移动/删除任何历史正文。
- `archive/README.md` 链接两个季度子索引，并列出 9 个无日期前缀的早期文件。
- 所有链接目标经脚本校验存在（missing=0）。

## 验证

- `check-docs-config` 的 ADR 索引 + 文档链接校验通过。
- `file-naming-audit` 通过（Q2/Q3 文件名合规，audited 2801）。
- `daily-use:governance-check`（PR-4 + #164 合并态）全绿。

> 注：全绿需先合入 #164。另：活跃计划文件 `docs/plan/active/2026-07-10-...md`（在 #165）待四个 PR 全部合并后再挪入 archive——跨独立分支无法在本 PR 干净完成，作为合并后收尾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)