### PR TITLE
docs(plan): M3 跨 feature 边界加固计划 + unflushed-events triage

### DIFF
--- a/docs/plan/active/2026-07-11-cross-feature-boundary-hardening.md
+++ b/docs/plan/active/2026-07-11-cross-feature-boundary-hardening.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - plan
+  - active
+  - architecture
+  - module-boundaries
+  - governance
+description: 把跨 feature 包隔离从硬编码个案改为系统化 scope 级约束（ADR-033 M3 落地）
+created: 2026-07-11T00:00:00+08:00
+updated: 2026-07-11T00:00:00+08:00
+---
+
+# Cross-Feature Boundary Hardening
+
+## 背景
+
+来自 2026-07-10 架构审查的 **M3**（见 [`2026-07-10-event-bus-and-governance-hardening.md`](./2026-07-10-event-bus-and-governance-hardening.md) 步骤 10）。原计划对 M3 只要求「出结论、改动另立计划」，本文件即那份被拆出的计划。
+
+跨模块通信范式以 [ADR-033](../../architecture/adr/ADR-033-cross-module-communication-patterns.md) 为准：feature 之间默认**只能依赖 `contracts` / `utils`**，联动走**事件**（范式 A）或**宿主注入的 Port**（范式 B），而不是直接包依赖。本计划把这条原则从「个案硬编码」升级为「系统化默认拒绝」。
+
+## 问题（诊断结论，已核对代码）
+
+1. **layer 矩阵不区分 feature。** 所有 feature 包同为 `layer:domain`，`@nx/enforce-module-boundaries` 的 `depConstraints` 只按 `layer:*` 约束（`eslint.config.ts` 的 `moduleBoundaryDepConstraints`）。`layer:domain → layer:domain` 被允许，于是**任意 feature 可以 import 任意 feature**，矩阵层面零隔离。
+2. **唯一防火墙是硬编码个案。** `eslint.config.ts` 里两条 `no-restricted-imports` 手写死了 `goal ✗↔ task`（`packages/goal/**` 禁 import `@dailyuse/task`，反之亦然）。这是唯一的跨 feature 拦截，且只覆盖这一对。
+3. **audit 有盲区。** `public-surface-audit.mjs` 只拦「import 别包**内部层子路径**」（deep import），**不拦「import 别包公开 API」**。所以 `reminder` 直接 `import ... from '@dailyuse/goal'`（走公开面）不会被任何检查拦下。
+4. **`scope:*` tag 已存在但未参与任何约束。** 每个 feature 已有唯一 scope tag（核实：20 个 feature 各一个 `scope:<feature>`），但 `depConstraints` 里没有任何 `scope:*` 条目，tag 处于「声明了但没用」状态。
+
+## 现存跨 feature 依赖快照（2026-07-11，生产 src，排除 contracts/utils）
+
+系统化约束前必须先摸清现状，否则会大面积误伤。当前真实的跨 feature 边只有以下几类：
+
+| 源 | 目标 | 导入内容 | 判定 |
+| --- | --- | --- | --- |
+| goal / task / reminder | `@dailyuse/schedule`、`@dailyuse/schedule/domain-shared` | `ScheduleTask`、`ScheduleConfig`、`ScheduleTaskMetadata` | schedule 调度 shared-kernel，需决策：提为 contracts/shared 还是显式白名单 |
+| editor | `@dailyuse/repository/api` | `createRepositoryPrismaModule`（Port 组装） | 合法：走 `/api` 公开面，ADR-033 范式 B |
+| data-portability | `@dailyuse/{goal,task,reminder,notification,setting}/api` | `create*PrismaRepositories`（导入/导出聚合壳） | 合法：data-portability 本就是跨模块聚合宿主，走 `/api` |
+
+> 注：`ai → governance` 只是 `ai.module.ts` 的一条 `@see` docstring 引用，不是真实 import，不计入。
+
+关键观察：**没有任何 feature 走 deep-import 违规跨界**；现存跨界要么是 schedule shared-kernel，要么是走 `/api` 公开面的合法 Port/聚合。这说明系统化约束的迁移成本可控。
+
+## 决策：走路径 A（scope 级 depConstraint，默认拒绝）
+
+评估过两条路径：
+
+- **路径 A — Nx `scope:*` depConstraint**：在 `moduleBoundaryDepConstraints` 为每个 `scope:<feature>` 加一条 `onlyDependOnLibsWithTags`，把「默认允许」翻转为「默认拒绝，跨界必须显式声明」。
+- **路径 B — 扩 `public-surface-audit`**：给 audit 加一档拦「feature 间任何 import，除非 allowlist」。
+
+**选路径 A**，理由：
+1. 复用 Nx graph 的**精确**依赖分析，优于 audit 的正则/AST 近似。
+2. 与现有 `layer:*` 约束同机制、同配置块，不引入第二套边界规则（避免路径 B 的「两套规则漂移」）。
+3. 「默认拒绝 + 显式白名单」正是 ADR-033 依赖显式化的精神，硬编码的 goal↔task 个案随之自然消失。
+
+路径 B 仅作为补充选项保留（若将来要拦「公开 API 之外的深层符号」可再评估），本计划不采用。
+
+## 实施步骤
+
+### 阶段一：现状固化与 shared-kernel 决策
+
+1. 用 `pnpm nx graph --file=graph.json` 导出完整依赖图，脚本提取所有 `scope:A → scope:B (A≠B)` 边，作为**权威现状清单**（不靠 grep 拍脑袋）。
+2. 对 `goal/task/reminder → schedule` 这条 shared-kernel 边做决策（三选一，另开小讨论）：
+   - (a) 把 `ScheduleTask` / `ScheduleConfig` / `ScheduleTaskMetadata` 的**契约形态**下沉到 `@dailyuse/contracts/schedule`，feature 只依赖 contracts；或
+   - (b) 承认 schedule 是被共享的调度内核，给它单独的 `scope:schedule-kernel` 语义并进白名单；或
+   - (c) 经 `schedule-orchestration`（已是 `scope:shared`）中转，feature 不直连 schedule。
+   - 倾向 (a)：最符合「feature 间只依赖 contracts」，但工作量取决于 `ScheduleTask` 是否为纯数据。
+
+### 阶段二：scope 约束落地
+
+3. 在 `eslint.config.ts` 的 `moduleBoundaryDepConstraints` 为每个 `scope:<feature>` 追加条目，白名单只含：`scope:shared`（contracts/utils/patterns 等基础层）+ 阶段一确认的合法跨界目标。模板：
+   ```ts
+   { sourceTag: 'scope:goal', onlyDependOnLibsWithTags: ['scope:shared', 'scope:goal'] }
+   ```
+   （`data-portability` 的白名单显式列出它聚合的 5 个 feature；`editor` 列出 `scope:repository`。）
+4. 删除 `eslint.config.ts:170-190` 硬编码的 goal↔task `no-restricted-imports`——scope 约束已覆盖（goal 白名单不含 `scope:task`）。
+5. 跑 `pnpm nx run-many -t lint` 全绿；任何新暴露的违规按 ADR-033 用 Port / 事件 / contracts 下沉修掉，不加白名单豁免。
+
+### 阶段三：治理接入（防回归）
+
+6. 评估把 scope 约束的存在性纳入 `governance-check`：新增 feature 包若没有对应 `scope:*` depConstraint 条目则 fail（防止「加了新 feature 但忘了给它上约束」的漏网）。可复用 PR-3 建立的 `governance-tools` 测试骨架。
+
+## 完成标准
+
+- `moduleBoundaryDepConstraints` 覆盖全部 `scope:<feature>`，默认拒绝跨 feature 依赖。
+- 硬编码 goal↔task `no-restricted-imports` 删除，由 scope 约束等价覆盖。
+- `goal/task/reminder → schedule` 的 shared-kernel 边按阶段一决策收敛（下沉 contracts / 显式白名单 / 中转其一）。
+- `pnpm nx run-many -t lint typecheck` 全绿；`daily-use:governance-check` 通过。
+- 新增 feature 缺失 scope 约束能被治理拦截（阶段三，可选）。
+
+## 非目标 / 后续
+
+- 不改 `layer:*` 现有语义，只叠加 `scope:*` 维度。
+- 阶段一的 schedule shared-kernel 决策若牵扯 `ScheduleTask` 大幅重构（3+ 包），停下来单独立计划，不在本计划内硬做。
+- 路径 B（audit 拦公开 API 外的深层符号）暂不做，留作将来需要更细粒度时的选项。
+
+## 关联
+
+- [ADR-033: Cross-Module Communication Patterns](../../architecture/adr/ADR-033-cross-module-communication-patterns.md)
+- [2026-07-10 Event Bus & Governance Hardening](./2026-07-10-event-bus-and-governance-hardening.md)（M3 来源）

--- a/docs/plan/active/2026-07-11-unflushed-events-triage.md
+++ b/docs/plan/active/2026-07-11-unflushed-events-triage.md
@@ -1,0 +1,129 @@
+---
+tags:
+  - plan
+  - active
+  - governance
+  - event-bus
+description: PR-3 unflushed-events-audit 冻结的 baseline 逐条 triage + 审计自身盲区修复，来自 2026-07-10 事件总线加固后续
+created: 2026-07-11T00:00:00+08:00
+updated: 2026-07-11T00:00:00+08:00
+---
+
+# Unflushed Domain Events — Baseline Triage
+
+## 背景
+
+PR-3（`docs/plan/archive/2026-07-10-event-bus-and-governance-hardening.md` 阶段二 M4）新增了
+`tools/governance/unflushed-events-audit.mjs`，用 ts-morph 扫描"聚合会
+`addDomainEvent`、但持久化它的仓储从不冲刷事件到总线"的疑似漏发点。
+
+首次运行 surfaced 出 7 处既有条目，当时以 **documented baseline allowlist** 冻结（不阻塞
+PR-3，标注 SURFACED-not-blessed，待独立 triage）。本文件是对这 7 条的逐一核查结论，以及
+审计自身一个盲区的修复计划。
+
+## 先厘清一个概念疑问："领域事件不是应该自动发送吗？"
+
+是的，**这正是设计意图**——但"自动"依赖仓储接对发布 seam。当前仓库的机制链是：
+
+1. **领域方法里 `addDomainEvent`**：聚合根（`AggregateRoot`，
+   `packages/utils/src/domain/aggregate-root.ts`）在业务方法内把事件推进内部
+   `_domainEvents` 数组。这一步各聚合做得很到位。
+2. **仓储 `save` 后冲刷**：事件**不会**自己发出去。必须由持久化该聚合的仓储，在写库成功后
+   调用某个"取出并发布"的动作，把 `_domainEvents` 冲刷到 `eventBus`。
+3. **总线派发给订阅者**：`eventBus.send` → mitt → 各 `on` 订阅者。
+
+**为什么会出现"没发送"**：第 2 步不是语言层面强制的。仓库里存在**两套并行的发布 seam**，
+外加一种手写变体，任何一个 adapter 只要哪套都没接，事件就在 `save` 结束后随聚合一起被丢弃
+（下次 `pullDomainEvents` 或 GC 时清空），且**没有任何编译错误或运行时报错**——这正是
+静默丢事件的根因，也是 H2/H3/M4 要根治的对象。
+
+### 两套发布 seam（都合法，是历史演进产物）
+
+| Seam | 机制 | 代表 | 数量 |
+| --- | --- | --- | --- |
+| **A. AggregateRepositoryBase**（自动） | 仓储 `extends AggregateRepositoryBase`，只实现 `persist()`；基类 `save()` 在 `persist()` 成功后自动 `publishAggregateEvents()` 冲刷（`packages/patterns/src/repository/aggregate-repository.base.ts:86-89`） | goal / task / authentication 的多数 prisma+powersync 仓储（18 个） | 多数 |
+| **B. flushDomainEvents 帮助函数**（手动） | 仓储直接 `implements I*Repository`，在 `save()` 末尾手动 `flushDomainEvents(publisher, aggregate)`（`packages/utils/src/domain/flush-domain-events.ts`） | reminder-template / schedule-task / ai-conversation / notification（PR-1 加固过的那批） | 若干 |
+| **C. 手写 pull+send 循环**（手动变体） | 仓储手动 `const events = agg.pullDomainEvents(); for (…) eventBus.send(…)`，不走 A 也不走 B | account-powersync | 1（已知） |
+
+**根因**：seam 有 A/B/C 三种写法、且 A 是"继承即自动"而 B/C 是"记得手写才有"。新加的 adapter
+（尤其是 powersync 侧后补的）很容易忘记接任何一套。**这就是"应该自动却没发"的确切答案**：
+自动只对接了 seam A 的仓储成立；接 B/C 的靠人记得，漏接的就静默丢。
+
+## 逐条 triage（7 条 → 实为 1 误报 + 6 真空档，其中 5 潜伏 + 1 待定）
+
+核查维度：聚合是否真的 emit 事件、仓储是否以**任何** seam（A/B/C）发布、该事件全仓有无 `.on` 订阅者。
+
+| # | 仓储 | 聚合 emit? | 发布 seam? | 订阅者 | 结论 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | account-powersync | ✅ | **C（手写 pull+send，第 114-117 行）** | 0 | **审计误报**——实际有发，只是审计不认 seam C |
+| 2 | auth-session-powersync | ✅ | ❌ 无（未 import eventBus） | 0 | 真空档 · 潜伏 |
+| 3 | notification-template-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+| 4 | notification-template-prisma | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+| 5 | reminder-group-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+| 6 | repository-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+| 7 | repository-prisma | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+
+### 关键结论
+
+- **没有一条是"正在造成可观察 bug"**：这 7 类事件（`account:*`/`auth:session-*`/
+  `notification:template-*`/`reminder:group-*`/`repository:*`）在全仓 **0 订阅者**。今天不发
+  也没有功能失效。它们是**潜伏雷**：将来任何人写 `eventBus.on('repository:created', …)`
+  会发现事件根本不来，且无报错。
+- **#1 account-powersync 是审计自身的盲区**：它用 seam C 发了事件，审计只认 seam A（继承）
+  和 seam B（`flushDomainEvents`/`publishDomainEvents`/`publishAggregateEvents`），漏认了
+  "手写 `pullDomainEvents()` + `eventBus.send()`"。这是 **audit 的假阳性，不是代码 bug**。
+- **account 后端不一致的原有判断需要更正**：先前以为 "prisma 发、powersync 不发"。实际是
+  **两个后端都发**，只是走了不同 seam（prisma 走 A 的 `publishAggregateEvents`，powersync 走 C
+  的手写循环）。行为一致，只是写法分裂。
+
+## 实施步骤
+
+### 阶段一：修审计盲区（先做，因为它改变 baseline 内容）
+
+1. **让 `unflushed-events-audit` 识别 seam C**：在 `tools/governance/lib/unflushed-events.mjs`
+   的"仓储是否发布事件"判定里，除现有的 `flushDomainEvents`/`publishDomainEvents`/
+   `publishAggregateEvents`/继承 `AggregateRepositoryBase` 之外，追加识别
+   **`pullDomainEvents(` 与 `eventBus.send(`/`.send(` 在同一文件同时出现** 的手写冲刷模式。
+   补正反 fixture 单测。
+2. 重新运行审计：#1 account-powersync 应自动移出（不再需要 allowlist 条目）。把
+   `BASELINE_ALLOWLIST` 从 7 条缩到 6 条。
+3. `governance-tools:test` + `daily-use:governance-check` 全绿。
+
+### 阶段二：消化 6 条真空档（每条二选一，可独立小 PR）
+
+对 #2–#7 六个仓储，逐个决策——**不要无脑加 flush**，先判断"这些事件到底要不要对外发"：
+
+- **若事件有未来消费者**（如 `repository:created` 将来要触发索引/通知）：给该 adapter 接一套
+  seam。**推荐统一接 seam A**（改为 `extends AggregateRepositoryBase`，与同包 prisma 侧对齐），
+  消除 B/C 手写变体的分裂。接完从 allowlist 移除该条。
+- **若聚合本就不该对外发事件**（这些 `addDomainEvent` 是早期占位、无人会消费）：更干净的做法是
+  **把 `addDomainEvent` 从聚合领域方法里删掉**——别攒不发的事件。审计随之自然放行，allowlist
+  再缩一格。
+
+  > 判据：搜 `contracts/<module>/protocol/*-event-map.ts` 看该事件是否在 EventMap 里被"郑重
+  > 声明为跨模块契约"。是 → 倾向接线（阶段二选项一）；只是聚合内部 `addDomainEvent` 而 EventMap
+  > 无对应键、也无任何 `.on` → 倾向删事件（选项二）。
+
+3. 每处理一个，`BASELINE_ALLOWLIST` 缩一条。**目标：allowlist 归零**，届时审计从"现状封顶"
+   升级为"全仓强不变式：会发事件的聚合，其所有仓储必接发布 seam"。
+
+### 阶段三：统一 seam（可选，收敛技术债）
+
+- 评估把 seam B/C 的手写仓储逐步迁到 seam A（`AggregateRepositoryBase`），让"发布"从"记得手写"
+  变成"继承即有"。这是消除本类问题**根因**的终极手段，但涉及面广（B/C 仓储数十个，powersync 侧
+  还牵涉 PR-1 引入的 `writeTransaction` 事务边界），务必独立成计划、分包推进，不与阶段一/二混。
+- 是否引入 transactional outbox（"提交后、派发前崩溃丢事件"的彻底解法）另立 ADR，超出本计划。
+
+## 完成标准
+
+- 审计识别 seam C；account-powersync 移出 baseline；`governance-tools:test` 覆盖 seam C 的正反
+  fixture。
+- 6 条真空档各有明确 verdict（接线 / 删事件），逐条落地后 `BASELINE_ALLOWLIST` 归零。
+- `daily-use:governance-check` 全程保持绿。
+
+## 备注
+
+- 阶段一是纯工具修复、零业务风险，建议优先。
+- 阶段二每条改动小但需要业务判断（事件要不要留），适合逐包独立 PR，配 adapter 层单测断言
+  "save 后事件确实进了总线"。
+- 本计划与 `2026-07-11-cross-feature-boundary-hardening.md`（M3 落地）互不依赖，可并行。

--- a/docs/plan/active/2026-07-11-unflushed-events-triage.md
+++ b/docs/plan/active/2026-07-11-unflushed-events-triage.md
@@ -4,126 +4,67 @@ tags:
   - active
   - governance
   - event-bus
-description: PR-3 unflushed-events-audit 冻结的 baseline 逐条 triage + 审计自身盲区修复，来自 2026-07-10 事件总线加固后续
+description: server-first 目录下 unflushed-events 扫描盲区与统一 flush seam 收敛记录
 created: 2026-07-11T00:00:00+08:00
-updated: 2026-07-11T00:00:00+08:00
+updated: 2026-07-11T15:40:00+08:00
 ---
 
-# Unflushed Domain Events — Baseline Triage
+# Unflushed Domain Events Triage
 
 ## 背景
 
-PR-3（`docs/plan/archive/2026-07-10-event-bus-and-governance-hardening.md` 阶段二 M4）新增了
-`tools/governance/unflushed-events-audit.mjs`，用 ts-morph 扫描"聚合会
-`addDomainEvent`、但持久化它的仓储从不冲刷事件到总线"的疑似漏发点。
+PR #167 引入 `unflushed-events-audit` 时，仓库仍使用 `domain-server` / `infrastructure-server`
+目录。审计冻结了 7 个旧路径 baseline。随后 PR #162 把业务包迁移到 `src/server/*`，但
+审计的路径匹配和 baseline 没有同步迁移，导致审计在新目录下扫描 0 个目标文件并错误通过。
 
-首次运行 surfaced 出 7 处既有条目，当时以 **documented baseline allowlist** 冻结（不阻塞
-PR-3，标注 SURFACED-not-blessed，待独立 triage）。本文件是对这 7 条的逐一核查结论，以及
-审计自身一个盲区的修复计划。
+## 新目录复核结果
 
-## 先厘清一个概念疑问："领域事件不是应该自动发送吗？"
+让扫描器同时识别旧目录和 `server/domain` / `server/infrastructure` 后，共得到 9 个迁移候选：
 
-是的，**这正是设计意图**——但"自动"依赖仓储接对发布 seam。当前仓库的机制链是：
+| 模块 | 仓储 | 迁移前状态 |
+| --- | --- | --- |
+| account | PowerSyncAccountRepository | 已手写 `pullDomainEvents + eventBus.send`，不是漏发，但属于分裂 seam |
+| authentication | PowerSyncAuthSessionRepository | 漏发 |
+| governance | PowerSyncRuleRepository | 漏发 |
+| governance | RulePrismaRepository | 漏发 |
+| notification | PowerSyncNotificationTemplateRepository | 漏发 |
+| notification | NotificationTemplatePrismaRepository | 漏发 |
+| reminder | ReminderGroupPowerSyncRepository | 漏发 |
+| repository | PowerSyncRepositoryRepository | 漏发 |
+| repository | RepositoryPrismaRepository | 漏发 |
 
-1. **领域方法里 `addDomainEvent`**：聚合根（`AggregateRoot`，
-   `packages/utils/src/domain/aggregate-root.ts`）在业务方法内把事件推进内部
-   `_domainEvents` 数组。这一步各聚合做得很到位。
-2. **仓储 `save` 后冲刷**：事件**不会**自己发出去。必须由持久化该聚合的仓储，在写库成功后
-   调用某个"取出并发布"的动作，把 `_domainEvents` 冲刷到 `eventBus`。
-3. **总线派发给订阅者**：`eventBus.send` → mitt → 各 `on` 订阅者。
+因此准确口径是：**9 个 seam 收敛候选，其中 8 个真实漏发，1 个手写发布变体**。
 
-**为什么会出现"没发送"**：第 2 步不是语言层面强制的。仓库里存在**两套并行的发布 seam**，
-外加一种手写变体，任何一个 adapter 只要哪套都没接，事件就在 `save` 结束后随聚合一起被丢弃
-（下次 `pullDomainEvents` 或 GC 时清空），且**没有任何编译错误或运行时报错**——这正是
-静默丢事件的根因，也是 H2/H3/M4 要根治的对象。
+旧工程 C 还迁移了 editor、schedule、setting 的相关仓储。PR #162 已在新目录实现中吸收这些
+改动，所以 server-first 版本不再重复修改它们。
 
-### 两套发布 seam（都合法，是历史演进产物）
+## 实施决策
 
-| Seam | 机制 | 代表 | 数量 |
-| --- | --- | --- | --- |
-| **A. AggregateRepositoryBase**（自动） | 仓储 `extends AggregateRepositoryBase`，只实现 `persist()`；基类 `save()` 在 `persist()` 成功后自动 `publishAggregateEvents()` 冲刷（`packages/patterns/src/repository/aggregate-repository.base.ts:86-89`） | goal / task / authentication 的多数 prisma+powersync 仓储（18 个） | 多数 |
-| **B. flushDomainEvents 帮助函数**（手动） | 仓储直接 `implements I*Repository`，在 `save()` 末尾手动 `flushDomainEvents(publisher, aggregate)`（`packages/utils/src/domain/flush-domain-events.ts`） | reminder-template / schedule-task / ai-conversation / notification（PR-1 加固过的那批） | 若干 |
-| **C. 手写 pull+send 循环**（手动变体） | 仓储手动 `const events = agg.pullDomainEvents(); for (…) eventBus.send(…)`，不走 A 也不走 B | account-powersync | 1（已知） |
+工程 C v2 统一处理全部 9 个候选：
 
-**根因**：seam 有 A/B/C 三种写法、且 A 是"继承即自动"而 B/C 是"记得手写才有"。新加的 adapter
-（尤其是 powersync 侧后补的）很容易忘记接任何一套。**这就是"应该自动却没发"的确切答案**：
-自动只对接了 seam A 的仓储成立；接 B/C 的靠人记得，漏接的就静默丢。
+1. 普通仓储继承 `AggregateRepositoryBase`，只实现 `persist()`。
+2. 有复合事务或自定义错误映射的 Rule 仓储在事务成功后调用 `publishAggregateEvents()`。
+3. account PowerSync 保留 `save(account, tx?)` 的事务执行器语义，再统一发布事件。
+4. audit 同时扫描旧目录与 server-first 目录，并将 baseline 清零。
+5. 增加 account PowerSync adapter 回归测试，覆盖事务内持久化、事件发送和事件缓冲清空。
 
-## 逐条 triage（7 条 → 实为 1 误报 + 6 真空档，其中 5 潜伏 + 1 待定）
+实现由 PR #170（`refactor/unified-flush-seam-v2`）承载。
 
-核查维度：聚合是否真的 emit 事件、仓储是否以**任何** seam（A/B/C）发布、该事件全仓有无 `.on` 订阅者。
+## 治理联动
 
-| # | 仓储 | 聚合 emit? | 发布 seam? | 订阅者 | 结论 |
-| --- | --- | --- | --- | --- | --- |
-| 1 | account-powersync | ✅ | **C（手写 pull+send，第 114-117 行）** | 0 | **审计误报**——实际有发，只是审计不认 seam C |
-| 2 | auth-session-powersync | ✅ | ❌ 无（未 import eventBus） | 0 | 真空档 · 潜伏 |
-| 3 | notification-template-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
-| 4 | notification-template-prisma | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
-| 5 | reminder-group-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
-| 6 | repository-powersync | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
-| 7 | repository-prisma | ✅ | ❌ 无 | 0 | 真空档 · 潜伏 |
+目录扫描修正后，`unflushed-events-audit` 应扫描非零文件，并报告 0 baseline exemption。
 
-### 关键结论
-
-- **没有一条是"正在造成可观察 bug"**：这 7 类事件（`account:*`/`auth:session-*`/
-  `notification:template-*`/`reminder:group-*`/`repository:*`）在全仓 **0 订阅者**。今天不发
-  也没有功能失效。它们是**潜伏雷**：将来任何人写 `eventBus.on('repository:created', …)`
-  会发现事件根本不来，且无报错。
-- **#1 account-powersync 是审计自身的盲区**：它用 seam C 发了事件，审计只认 seam A（继承）
-  和 seam B（`flushDomainEvents`/`publishDomainEvents`/`publishAggregateEvents`），漏认了
-  "手写 `pullDomainEvents()` + `eventBus.send()`"。这是 **audit 的假阳性，不是代码 bug**。
-- **account 后端不一致的原有判断需要更正**：先前以为 "prisma 发、powersync 不发"。实际是
-  **两个后端都发**，只是走了不同 seam（prisma 走 A 的 `publishAggregateEvents`，powersync 走 C
-  的手写循环）。行为一致，只是写法分裂。
-
-## 实施步骤
-
-### 阶段一：修审计盲区（先做，因为它改变 baseline 内容）
-
-1. **让 `unflushed-events-audit` 识别 seam C**：在 `tools/governance/lib/unflushed-events.mjs`
-   的"仓储是否发布事件"判定里，除现有的 `flushDomainEvents`/`publishDomainEvents`/
-   `publishAggregateEvents`/继承 `AggregateRepositoryBase` 之外，追加识别
-   **`pullDomainEvents(` 与 `eventBus.send(`/`.send(` 在同一文件同时出现** 的手写冲刷模式。
-   补正反 fixture 单测。
-2. 重新运行审计：#1 account-powersync 应自动移出（不再需要 allowlist 条目）。把
-   `BASELINE_ALLOWLIST` 从 7 条缩到 6 条。
-3. `governance-tools:test` + `daily-use:governance-check` 全绿。
-
-### 阶段二：消化 6 条真空档（每条二选一，可独立小 PR）
-
-对 #2–#7 六个仓储，逐个决策——**不要无脑加 flush**，先判断"这些事件到底要不要对外发"：
-
-- **若事件有未来消费者**（如 `repository:created` 将来要触发索引/通知）：给该 adapter 接一套
-  seam。**推荐统一接 seam A**（改为 `extends AggregateRepositoryBase`，与同包 prisma 侧对齐），
-  消除 B/C 手写变体的分裂。接完从 allowlist 移除该条。
-- **若聚合本就不该对外发事件**（这些 `addDomainEvent` 是早期占位、无人会消费）：更干净的做法是
-  **把 `addDomainEvent` 从聚合领域方法里删掉**——别攒不发的事件。审计随之自然放行，allowlist
-  再缩一格。
-
-  > 判据：搜 `contracts/<module>/protocol/*-event-map.ts` 看该事件是否在 EventMap 里被"郑重
-  > 声明为跨模块契约"。是 → 倾向接线（阶段二选项一）；只是聚合内部 `addDomainEvent` 而 EventMap
-  > 无对应键、也无任何 `.on` → 倾向删事件（选项二）。
-
-3. 每处理一个，`BASELINE_ALLOWLIST` 缩一条。**目标：allowlist 归零**，届时审计从"现状封顶"
-   升级为"全仓强不变式：会发事件的聚合，其所有仓储必接发布 seam"。
-
-### 阶段三：统一 seam（可选，收敛技术债）
-
-- 评估把 seam B/C 的手写仓储逐步迁到 seam A（`AggregateRepositoryBase`），让"发布"从"记得手写"
-  变成"继承即有"。这是消除本类问题**根因**的终极手段，但涉及面广（B/C 仓储数十个，powersync 侧
-  还牵涉 PR-1 引入的 `writeTransaction` 事务边界），务必独立成计划、分包推进，不与阶段一/二混。
-- 是否引入 transactional outbox（"提交后、派发前崩溃丢事件"的彻底解法）另立 ADR，超出本计划。
+完整 `daily-use:governance-check` 还暴露了 PR #162 留下的独立 shape 问题：
+`data-portability` 缺少 ADR-031 要求的 `server/domain`。PR #170 同时补齐最小 domain 入口，
+使完整治理检查恢复通过。
 
 ## 完成标准
 
-- 审计识别 seam C；account-powersync 移出 baseline；`governance-tools:test` 覆盖 seam C 的正反
-  fixture。
-- 6 条真空档各有明确 verdict（接线 / 删事件），逐条落地后 `BASELINE_ALLOWLIST` 归零。
-- `daily-use:governance-check` 全程保持绿。
+- unflushed audit 扫描 server-first 目录，不再出现“0 文件通过”。
+- 9 个候选全部接入统一发布 seam，8 个真实漏发归零。
+- baseline allowlist 为空。
+- account PowerSync 事务参数行为有回归测试。
+- 相关包 lint、typecheck、test、build 全绿。
+- `daily-use:governance-check` 全绿。
 
-## 备注
-
-- 阶段一是纯工具修复、零业务风险，建议优先。
-- 阶段二每条改动小但需要业务判断（事件要不要留），适合逐包独立 PR，配 adapter 层单测断言
-  "save 后事件确实进了总线"。
-- 本计划与 `2026-07-11-cross-feature-boundary-hardening.md`（M3 落地）互不依赖，可并行。
+以上标准已在 PR #170 分支本地验证，待 PR 合并后归档本计划。


### PR DESCRIPTION
## 背景

对 2026-07-10 事件总线与治理加固计划的两个收尾产物：M3 的落地路线，以及 PR-3 (#167) 冻结的 unflushed-events baseline 的逐条 triage。

## 内容

### 1. `2026-07-11-cross-feature-boundary-hardening.md`（M3 落地）
走**路径 A**：scope 级 `depConstraint`，把跨 feature 从"默认允许 + 硬编码 goal↔task 个案"翻转为"默认拒绝 + 显式白名单"。计划基于**实测的现存跨 feature 边**（非猜测）：
- `goal/task/reminder → schedule`（+ `schedule/domain-shared`）：共享内核式引用
- `editor → repository/api`：Port 组合
- `data-portability → goal/task/reminder/notification/setting 的 /api`：聚合壳，合法
含逐步执行方案与"每 feature 只默认依赖 contracts/utils、联动走事件"的白名单设计原则。

### 2. `2026-07-11-unflushed-events-triage.md`（7 处 baseline 核实）
逐条核实后修正了 PR-3 的判断：
- **account-powersync 是审计假阳性** —— 它用 raw `pullDomainEvents()` + `eventBus.send()` 循环发布（不是 `flushDomainEvents` 助手），审计只认助手名字所以误报。
- **其余 6 处是真漏发** —— 完全不 import eventBus，聚合 emit 的事件被静默丢弃；但当前**全部 0 订阅者**，属潜伏雷而非在坏功能。
- 记录了 audit 需补的能力：识别 raw `pullDomainEvents()+eventBus.send()` 发布 seam，消除这类假阳性。

## 说明

纯文档，无代码改动。两份计划落在 `docs/plan/active/`，待各自实施后再归档。M3 计划本身对应原 plan 步骤 10「先出结论、改动另立计划」的要求。

🤖 Generated with [Claude Code](https://claude.com/claude-code)