### PR TITLE
refactor(events): restore unified flush seam on server-first layout

### DIFF
--- a/docs/plan/active/2026-07-11-unified-event-flush-seam-v2.md
+++ b/docs/plan/active/2026-07-11-unified-event-flush-seam-v2.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - plan
+  - active
+  - event-bus
+  - governance
+description: 工程 C 在 server-first 目录重构后的重放、扩展与治理收尾计划
+created: 2026-07-11T00:00:00+00:00
+updated: 2026-07-11T00:00:00+00:00
+---
+
+# Unified Event Flush Seam V2
+
+## 背景
+
+原工程 C 基于旧的 `domain-server` / `infrastructure-server` 目录完成 13 个仓储的自动
+flush 收敛。PR #162 将业务包迁移到 `src/server/*` 后，旧提交无法直接合并，同时
+`unflushed-events-audit` 仍只扫描旧路径，导致在新目录下审计 0 个文件。
+
+## 范围
+
+1. 让 unflushed-events audit 同时识别旧目录和 `src/server/*` 标准目录。
+2. 将新目录扫描出的 9 个仓储接入统一事件发布 seam，并清空 baseline。
+3. 保留 account PowerSync 仓储已有的可选事务执行器语义。
+4. 补 adapter 回归测试，验证事务内持久化和持久化后事件发布。
+5. 补齐 data-portability 的最小 `server/domain` 入口，使 ADR-031 shape audit 恢复通过。
+6. 清理与本工程无关的 lockfile 版本漂移。
+
+## 验证
+
+- 相关业务包 typecheck、test、lint。
+- `governance-tools:test`。
+- `daily-use:governance-check`。
+- `git diff --check`。
+
+## 完成标准
+
+- 新目录下 unflushed audit 扫描非零文件且 baseline 为零。
+- 9 个仓储不再存在未发布事件路径。
+- account PowerSync 的 `save(account, tx)` 使用传入事务执行器。
+- 完整 governance-check 通过。

--- a/packages/account/src/server/infrastructure/adapters/powersync/account-powersync.repository.spec.ts
+++ b/packages/account/src/server/infrastructure/adapters/powersync/account-powersync.repository.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IdentityId } from '@dailyuse/domain-shared/shared';
+import { eventBus } from '@dailyuse/utils/domain';
+import { Account } from '../../../domain';
+import {
+  PowerSyncAccountRepository,
+  type Transactional,
+} from './account-powersync.repository';
+
+function createQueryable() {
+  return {
+    getAll: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue({ count: 0 }),
+    getOptional: vi.fn().mockResolvedValue(null),
+    execute: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('PowerSyncAccountRepository', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists with the provided transaction and flushes domain events', async () => {
+    const defaultDb = {
+      ...createQueryable(),
+      writeTransaction: vi.fn(),
+    } satisfies Transactional;
+    const tx = createQueryable();
+    const sendSpy = vi.spyOn(eventBus, 'send').mockImplementation(() => undefined);
+    const account = Account.create({
+      id: IdentityId.generate(),
+      email: 'transaction@example.com',
+    });
+    const repository = new PowerSyncAccountRepository(defaultDb);
+
+    await repository.save(account, tx);
+
+    expect(tx.getOptional).toHaveBeenCalledOnce();
+    expect(tx.execute).toHaveBeenCalledOnce();
+    expect(defaultDb.getOptional).not.toHaveBeenCalled();
+    expect(defaultDb.execute).not.toHaveBeenCalled();
+    expect(sendSpy).toHaveBeenCalledWith('account:created', expect.any(Object));
+    expect(account.domainEvents).toHaveLength(0);
+  });
+});

--- a/packages/account/src/server/infrastructure/adapters/powersync/account-powersync.repository.ts
+++ b/packages/account/src/server/infrastructure/adapters/powersync/account-powersync.repository.ts
@@ -1,11 +1,17 @@
 import type { IAccountRepository } from '../../../domain';
 import { Account } from '../../../domain';
-import type { AppEventRegistry } from '@dailyuse/contracts/shared';
+import {
+  AggregateRepositoryBase,
+  createEventBusAdapter,
+  publishAggregateEvents,
+} from '@dailyuse/patterns';
 import { eventBus } from '@dailyuse/utils/domain';
 import {
   AccountPowerSyncMapper,
   type PowerSyncAccountRow,
 } from './mappers/account-powersync.mapper';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 type Queryable = {
   getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
@@ -18,10 +24,15 @@ export type Transactional = Queryable & {
   writeTransaction<T>(callback: (tx: Queryable) => Promise<T>): Promise<T>;
 };
 
-export class PowerSyncAccountRepository implements IAccountRepository {
-  constructor(private readonly db: Transactional) {}
+export class PowerSyncAccountRepository
+  extends AggregateRepositoryBase<Account>
+  implements IAccountRepository
+{
+  constructor(private readonly db: Transactional) {
+    super(eventBusAdapter);
+  }
 
-  async save(account: Account, tx?: unknown): Promise<void> {
+  protected async persist(account: Account, tx?: unknown): Promise<void> {
     const executor = this.asQueryable(tx) ?? this.db;
     const row = AccountPowerSyncMapper.toRow(account);
 
@@ -110,12 +121,11 @@ export class PowerSyncAccountRepository implements IAccountRepository {
         ],
       );
     }
+  }
 
-    const domainEvents = account.pullDomainEvents();
-    for (const evt of domainEvents) {
-      const eventType = evt.eventType as keyof AppEventRegistry;
-      eventBus.send(eventType, evt.payload as AppEventRegistry[typeof eventType]);
-    }
+  override async save(account: Account, tx?: unknown): Promise<void> {
+    await this.persist(account, tx);
+    await publishAggregateEvents(account, this.eventBus);
   }
 
   async findById(id: string, tx?: unknown): Promise<Account | null> {

--- a/packages/authentication/src/server/infrastructure/adapters/powersync/auth-session-powersync.repository.ts
+++ b/packages/authentication/src/server/infrastructure/adapters/powersync/auth-session-powersync.repository.ts
@@ -1,16 +1,25 @@
 import type { IElectronDatabase, IElectronDatabaseTransaction } from '@dailyuse/contracts/electron';
 import type { IAuthSessionRepository } from '../../../domain';
 import { AuthSession } from '../../../domain';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
 import {
   PowerSyncAuthSessionMapper,
   type PowerSyncAuthSessionRow,
   type PowerSyncAuthSessionWriteData,
 } from './mappers/powersync-auth-session.mapper';
 
-export class PowerSyncAuthSessionRepository implements IAuthSessionRepository {
-  constructor(private readonly db: IElectronDatabase) {}
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
-  async save(session: AuthSession): Promise<void> {
+export class PowerSyncAuthSessionRepository
+  extends AggregateRepositoryBase<AuthSession>
+  implements IAuthSessionRepository
+{
+  constructor(private readonly db: IElectronDatabase) {
+    super(eventBusAdapter);
+  }
+
+  protected async persist(session: AuthSession): Promise<void> {
     const d = PowerSyncAuthSessionMapper.toPersistence(session);
 
     await this.db.writeTransaction(async (tx) => {

--- a/packages/authentication/tsconfig.json
+++ b/packages/authentication/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@dailyuse/patterns": ["../patterns/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/data-portability/src/server/domain/index.ts
+++ b/packages/data-portability/src/server/domain/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Data portability has no domain model of its own.
+ *
+ * It orchestrates import and export use cases over contracts and feature-owned
+ * domain models while retaining the canonical server feature shape.
+ */
+export {};

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -30,7 +30,8 @@
     "@dailyuse/http-client": "workspace:*",
     "@dailyuse/utils": "workspace:*",
     "express": "^4.21.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "@dailyuse/patterns": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"

--- a/packages/governance/src/server/infrastructure/adapters/powersync/rule-powersync.repository.ts
+++ b/packages/governance/src/server/infrastructure/adapters/powersync/rule-powersync.repository.ts
@@ -35,6 +35,10 @@ import {
 } from './mappers/powersync-rule.mapper';
 import { PowerSyncRuleRevisionMapper } from './mappers/powersync-rule-revision.mapper';
 import { escapeSqlLike } from '../mapper-helpers';
+import { createEventBusAdapter, publishAggregateEvents } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 /**
  * PowerSync-backed Rule repository for offline-capable desktop.
@@ -141,6 +145,7 @@ export class PowerSyncRuleRepository implements IRuleRepository {
     try {
       const row = PowerSyncRuleMapper.toPersistence(rule);
       await this._upsertRule(this.db, row);
+      await publishAggregateEvents(rule, eventBusAdapter);
     } catch (err) {
       throw toResultErrorException(mapInfraErrorToResultError(err, 'Failed to save rule'));
     }
@@ -186,6 +191,7 @@ export class PowerSyncRuleRepository implements IRuleRepository {
         );
       });
 
+      await publishAggregateEvents(rule, eventBusAdapter);
     } catch (err) {
       throw toResultErrorException(
         mapInfraErrorToResultError(err, 'Failed to save rule with revision'),

--- a/packages/governance/src/server/infrastructure/adapters/prisma/rule-prisma.repository.ts
+++ b/packages/governance/src/server/infrastructure/adapters/prisma/rule-prisma.repository.ts
@@ -32,6 +32,10 @@ import { toResultErrorException } from '@dailyuse/contracts/result';
 import { mapInfraErrorToResultError } from '@dailyuse/utils/errors';
 import { RulePrismaMapper } from './mappers/rule-prisma.mapper';
 import { RuleRevisionPrismaMapper } from './mappers/rule-revision-prisma.mapper';
+import { createEventBusAdapter, publishAggregateEvents } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 /**
  * Prisma Rule Repository
@@ -72,6 +76,8 @@ export class RulePrismaRepository implements IRuleRepository {
           updatedAt: rule.updatedAt,
         },
       });
+
+      await publishAggregateEvents(rule, eventBusAdapter);
     } catch (err) {
       throw toResultErrorException(mapInfraErrorToResultError(err, 'Failed to save rule'));
     }
@@ -110,6 +116,8 @@ export class RulePrismaRepository implements IRuleRepository {
 
         await tx.ruleRevision.create({ data: revisionData });
       });
+
+      await publishAggregateEvents(rule, eventBusAdapter);
     } catch (err) {
       throw toResultErrorException(
         mapInfraErrorToResultError(err, 'Failed to save rule with revision'),

--- a/packages/governance/tsconfig.json
+++ b/packages/governance/tsconfig.json
@@ -33,7 +33,8 @@
       ],
       "@dailyuse/http-client": ["../http-client/src/index.ts"],
       "@dailyuse/utils": ["../utils/src/index.ts"],
-      "@dailyuse/utils/*": ["../utils/src/*/index.ts"]
+      "@dailyuse/utils/*": ["../utils/src/*/index.ts"],
+      "@dailyuse/patterns": ["../patterns/src/index.ts"]
     }
   },
 

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -40,7 +40,8 @@
     "@dailyuse/http-client": "workspace:*",
     "@dailyuse/utils": "workspace:*",
     "express": "^5.1.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@dailyuse/patterns": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"

--- a/packages/notification/src/server/infrastructure/adapters/powersync/notification-template-powersync.repository.ts
+++ b/packages/notification/src/server/infrastructure/adapters/powersync/notification-template-powersync.repository.ts
@@ -3,6 +3,10 @@ import type { INotificationTemplateRepository } from '../../../domain/repositori
 import { NotificationTemplate } from '../../../domain/aggregates/notification-template';
 import { NotificationTemplateConfig } from '../../../domain/value-objects/notification-template-config';
 import type { NotificationCategory, NotificationType } from '@dailyuse/contracts/notification';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 interface NotificationTemplateRow {
   id: string;
@@ -50,10 +54,15 @@ function hydrateTemplate(row: NotificationTemplateRow): NotificationTemplate {
   });
 }
 
-export class PowerSyncNotificationTemplateRepository implements INotificationTemplateRepository {
-  constructor(private readonly db: IElectronDatabase) {}
+export class PowerSyncNotificationTemplateRepository
+  extends AggregateRepositoryBase<NotificationTemplate>
+  implements INotificationTemplateRepository
+{
+  constructor(private readonly db: IElectronDatabase) {
+    super(eventBusAdapter);
+  }
 
-  async save(template: NotificationTemplate): Promise<void> {
+  protected async persist(template: NotificationTemplate): Promise<void> {
     const dto = template.toServerDTO();
     await this.db.execute(
       `INSERT OR REPLACE INTO notification_templates (

--- a/packages/notification/src/server/infrastructure/adapters/prisma/notification-template-prisma.repository.ts
+++ b/packages/notification/src/server/infrastructure/adapters/prisma/notification-template-prisma.repository.ts
@@ -16,6 +16,10 @@ import type { INotificationTemplateRepository } from '../../../domain';
 import { NotificationTemplate } from '../../../domain/aggregates/notification-template';
 import { NotificationTemplateConfig } from '../../../domain/value-objects/notification-template-config';
 import type { NotificationCategory, NotificationType } from '@dailyuse/contracts/notification';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 // ============================================================
 // Type definitions for Prisma query results
@@ -83,10 +87,15 @@ function mapPrismaTemplateToDomain(row: PrismaNotificationTemplate): Notificatio
 /**
  * NotificationTemplate Prisma Repository
  */
-export class NotificationTemplatePrismaRepository implements INotificationTemplateRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+export class NotificationTemplatePrismaRepository
+  extends AggregateRepositoryBase<NotificationTemplate>
+  implements INotificationTemplateRepository
+{
+  constructor(private readonly prisma: PrismaClient) {
+    super(eventBusAdapter);
+  }
 
-  async save(template: NotificationTemplate): Promise<void> {
+  protected async persist(template: NotificationTemplate): Promise<void> {
     const dto = template.toServerDTO();
     const templateConfig = dto.template;
 

--- a/packages/notification/tsconfig.json
+++ b/packages/notification/tsconfig.json
@@ -18,7 +18,8 @@
       "@dailyuse/contracts/reminder": ["../contracts/src/modules/reminder/index.ts"],
       "@dailyuse/contracts/schedule": ["../contracts/src/modules/schedule/index.ts"],
       "@dailyuse/utils": ["../utils/src/index.ts"],
-      "@dailyuse/utils/result": ["../utils/src/result/index.ts"]
+      "@dailyuse/utils/result": ["../utils/src/result/index.ts"],
+      "@dailyuse/patterns": ["../patterns/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/reminder/src/server/infrastructure/adapters/powersync/reminder-group-powersync.repository.ts
+++ b/packages/reminder/src/server/infrastructure/adapters/powersync/reminder-group-powersync.repository.ts
@@ -5,6 +5,10 @@ import {
   PowerSyncReminderGroupMapper,
   type PowerSyncReminderGroupRow,
 } from './mappers/powersync-reminder-group.mapper';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 type Queryable = {
   getAll<T>(sql: string, parameters?: unknown[]): Promise<T[]>;
@@ -13,10 +17,15 @@ type Queryable = {
   execute(sql: string, parameters?: unknown[]): Promise<unknown>;
 };
 
-export class ReminderGroupPowerSyncRepository implements IReminderGroupRepository {
-  constructor(private readonly db: Queryable) {}
+export class ReminderGroupPowerSyncRepository
+  extends AggregateRepositoryBase<ReminderGroup>
+  implements IReminderGroupRepository
+{
+  constructor(private readonly db: Queryable) {
+    super(eventBusAdapter);
+  }
 
-  async save(group: ReminderGroup): Promise<void> {
+  protected async persist(group: ReminderGroup): Promise<void> {
     const data = PowerSyncReminderGroupMapper.toPersistence(group);
     const existing = await this.db.getOptional<{ id: string }>(
       'SELECT id FROM reminder_groups WHERE id = ? LIMIT 1',

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -34,7 +34,8 @@
     "express": "^5.1.0",
     "gray-matter": "4.0.3",
     "multer": "2.0.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@dailyuse/patterns": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"

--- a/packages/repository/src/server/infrastructure/adapters/powersync/repository-powersync.repository.ts
+++ b/packages/repository/src/server/infrastructure/adapters/powersync/repository-powersync.repository.ts
@@ -6,11 +6,20 @@ import {
   PowerSyncRepositoryMapper,
   type PowerSyncRepositoryRow,
 } from './mappers/powersync-repository.mapper';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
 
-export class PowerSyncRepositoryRepository implements IRepositoryRepository {
-  constructor(private readonly db: IElectronDatabase) {}
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
-  async save(repository: Repository): Promise<void> {
+export class PowerSyncRepositoryRepository
+  extends AggregateRepositoryBase<Repository>
+  implements IRepositoryRepository
+{
+  constructor(private readonly db: IElectronDatabase) {
+    super(eventBusAdapter);
+  }
+
+  protected async persist(repository: Repository): Promise<void> {
     const d = PowerSyncRepositoryMapper.toPersistence(repository);
     const existing = await this.db.getOptional<{ id: string }>(
       `SELECT id FROM repositories WHERE id = ? LIMIT 1`,

--- a/packages/repository/src/server/infrastructure/adapters/prisma/repository-prisma.repository.ts
+++ b/packages/repository/src/server/infrastructure/adapters/prisma/repository-prisma.repository.ts
@@ -10,16 +10,25 @@ import type { IRepositoryRepository } from '../../../domain/repositories/i-repos
 import { Repository } from '../../../domain/aggregates/repository';
 import type { RepositoryStatus } from '@dailyuse/contracts/repository';
 import { RepositoryPrismaMapper } from './mappers/repository-prisma.mapper';
+import { AggregateRepositoryBase, createEventBusAdapter } from '@dailyuse/patterns';
+import { eventBus } from '@dailyuse/utils/domain';
+
+const eventBusAdapter = createEventBusAdapter(eventBus);
 
 /**
  * Repository Prisma Repository
  *
  * Skeleton implementation - to be completed when extracting from apps/api.
  */
-export class RepositoryPrismaRepository implements IRepositoryRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+export class RepositoryPrismaRepository
+  extends AggregateRepositoryBase<Repository>
+  implements IRepositoryRepository
+{
+  constructor(private readonly prisma: PrismaClient) {
+    super(eventBusAdapter);
+  }
 
-  async save(repository: Repository): Promise<void> {
+  protected async persist(repository: Repository): Promise<void> {
     const dto = repository.toServerDTO();
     await this.prisma.repository.upsert({
       where: { id: dto.id },

--- a/packages/repository/tsconfig.json
+++ b/packages/repository/tsconfig.json
@@ -17,7 +17,8 @@
       "@dailyuse/contracts/primitives": ["../contracts/src/primitives/index.ts"],
       "@dailyuse/contracts/electron": ["../contracts/src/electron/index.ts"],
       "@dailyuse/utils": ["../utils/src/index.ts"],
-      "@dailyuse/utils/result": ["../utils/src/result/index.ts"]
+      "@dailyuse/utils/result": ["../utils/src/result/index.ts"],
+      "@dailyuse/patterns": ["../patterns/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1555,6 +1555,9 @@ importers:
       '@dailyuse/http-client':
         specifier: workspace:*
         version: link:../http-client
+      '@dailyuse/patterns':
+        specifier: workspace:*
+        version: link:../patterns
       '@dailyuse/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1612,6 +1615,9 @@ importers:
       '@dailyuse/http-client':
         specifier: workspace:*
         version: link:../http-client
+      '@dailyuse/patterns':
+        specifier: workspace:*
+        version: link:../patterns
       '@dailyuse/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1709,6 +1715,9 @@ importers:
       '@dailyuse/http-client':
         specifier: workspace:*
         version: link:../http-client
+      '@dailyuse/patterns':
+        specifier: workspace:*
+        version: link:../patterns
       '@dailyuse/utils':
         specifier: workspace:*
         version: link:../utils

--- a/tools/governance/unflushed-events-audit.mjs
+++ b/tools/governance/unflushed-events-audit.mjs
@@ -26,9 +26,15 @@ const files = collectSourceFiles(PACKAGES, ROOT).filter(({ relPath }) => {
   // In-memory repositories are unit-test doubles; they intentionally do not
   // publish domain events and are out of scope.
   if (relPath.includes('/adapters/memory/')) return false;
-  const isServerAggregate = relPath.includes('/domain-server/') && relPath.includes('/aggregates/');
+  // Match both the legacy layout (domain-server / infrastructure-server) and the
+  // server-feature-shape layout introduced by the client/electron/server refactor
+  // (server/domain / server/infrastructure).
+  const isServerAggregate =
+    (relPath.includes('/domain-server/') || relPath.includes('/server/domain/')) &&
+    relPath.includes('/aggregates/');
   const isServerRepo =
-    relPath.includes('/infrastructure-server/') && /repository\.[tj]s$/i.test(relPath);
+    (relPath.includes('/infrastructure-server/') || relPath.includes('/server/infrastructure/')) &&
+    /repository\.[tj]s$/i.test(relPath);
   return isServerAggregate || isServerRepo;
 });
 
@@ -40,21 +46,13 @@ for (const { absPath } of files) {
 /**
  * Baseline of pre-existing suspected misses (repo-root-relative).
  *
- * These production repositories persist an event-emitting aggregate without a
- * flush in-file. They are SURFACED, not blessed: this audit is introduced with
- * the current tree frozen as a baseline so it fails on any NEW miss. Triaging
- * whether each of these is a genuine event-loss bug or an intentionally
- * unpublished aggregate is tracked as follow-up, out of this PR's scope.
+ * Previously this froze 7 legacy-layout repositories. Scanning the server-first
+ * layout surfaced 2 additional Rule repositories, for 9 repositories in total.
+ * They now use the unified event publishing seam (工程 C), so the baseline is
+ * EMPTY: every event-emitting aggregate repository in the tree flushes its
+ * events on save. The audit fails on any new miss.
  */
-const BASELINE_ALLOWLIST = new Set([
-  'packages/account/src/infrastructure-server/adapters/powersync/account-powersync.repository.ts',
-  'packages/authentication/src/infrastructure-server/adapters/powersync/auth-session-powersync.repository.ts',
-  'packages/notification/src/infrastructure-server/adapters/powersync/notification-template-powersync.repository.ts',
-  'packages/notification/src/infrastructure-server/adapters/prisma/notification-template-prisma.repository.ts',
-  'packages/reminder/src/infrastructure-server/adapters/powersync/reminder-group-powersync.repository.ts',
-  'packages/repository/src/infrastructure-server/adapters/powersync/repository-powersync.repository.ts',
-  'packages/repository/src/infrastructure-server/adapters/prisma/repository-prisma.repository.ts',
-]);
+const BASELINE_ALLOWLIST = new Set([]);
 
 const toRel = (absPath) => path.relative(ROOT, absPath).split(path.sep).join('/');
 


### PR DESCRIPTION
## Summary
- update unflushed-events audit for the server-first package layout and clear the baseline
- route 9 aggregate repositories through the unified event publishing seam
- preserve PowerSync account transaction semantics and add an adapter regression test
- restore the canonical data-portability server shape

## Validation
- `pnpm nx run-many -t lint,typecheck,test --projects=account,authentication,data-portability,governance,notification,reminder,repository --parallel=3 --outputStyle=static`
- `pnpm nx run-many -t build --projects=account,authentication,data-portability,governance,notification,reminder,repository --parallel=3 --outputStyle=static`
- `pnpm nx run daily-use:governance-check --outputStyle=static`
- `git diff --check`