### PR TITLE
docs(plan): archive completed event flush plans

### DIFF
--- a/docs/plan/archive/2026-07-11-unflushed-events-triage.md
+++ b/docs/plan/archive/2026-07-11-unflushed-events-triage.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - plan
-  - active
+  - archive
   - governance
   - event-bus
 description: server-first 目录下 unflushed-events 扫描盲区与统一 flush seam 收敛记录
@@ -10,6 +10,9 @@ updated: 2026-07-11T15:40:00+08:00
 ---
 
 # Unflushed Domain Events Triage
+
+> 已完成：PR #170 落地扫描修正和 9 个 seam 候选收敛；PR #165、#166 随后完成
+> 事件总线加固与 Goal↔Task 标杆联动。
 
 ## 背景
 
@@ -67,4 +70,4 @@ PR #167 引入 `unflushed-events-audit` 时，仓库仍使用 `domain-server` / 
 - 相关包 lint、typecheck、test、build 全绿。
 - `daily-use:governance-check` 全绿。
 
-以上标准已在 PR #170 分支本地验证，待 PR 合并后归档本计划。
+以上标准已在 PR #170 分支及合并后的 `main` 验证通过。

--- a/docs/plan/archive/2026-07-11-unified-event-flush-seam-v2.md
+++ b/docs/plan/archive/2026-07-11-unified-event-flush-seam-v2.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - plan
-  - active
+  - archive
   - event-bus
   - governance
 description: 工程 C 在 server-first 目录重构后的重放、扩展与治理收尾计划
@@ -10,6 +10,9 @@ updated: 2026-07-11T00:00:00+00:00
 ---
 
 # Unified Event Flush Seam V2
+
+> 已完成：PR #170 合并到 `main`，9 个仓储收敛到统一发布 seam，baseline 清零，
+> 完整 governance-check 恢复通过。
 
 ## 背景
 

--- a/docs/plan/archive/2026-Q3.md
+++ b/docs/plan/archive/2026-Q3.md
@@ -29,3 +29,5 @@ description: 2026 Q3 (7–9 月) 归档计划季度子索引
 | 2026-07-04 | [2026-07-04 Audit Follow-up Elegant Refactor Blueprint](./2026-07-04-audit-follow-up-elegant-refactor-blueprint.md) |
 | 2026-07-04 | [2026-07-04 Core Seam Reconvergence Multi-Round Executable Plan](./2026-07-04-core-seam-reconvergence-multi-round-executable-plan.md) |
 | 2026-07-04 | [2026-07-04 Post Core-Seam Elegant Refactor Plan](./2026-07-04-post-core-seam-elegant-refactor-plan.md) |
+| 2026-07-11 | [Unflushed Domain Events Triage](./2026-07-11-unflushed-events-triage.md) |
+| 2026-07-11 | [Unified Event Flush Seam V2](./2026-07-11-unified-event-flush-seam-v2.md) |


### PR DESCRIPTION
## Summary
- move the completed unified flush seam plan to the archive
- move the completed unflushed-events triage to the archive
- add both plans to the 2026 Q3 archive index

## Validation
- `pnpm nx run daily-use:governance-check --outputStyle=static`
- `git diff --check`