### PR TITLE
refactor(goal): UI redesign V2 S2 — Goal 面板两档适配（第二侧栏窄档收敛 + 容器查询网格）

### DIFF
--- a/packages/app-vue/src/layouts/shell/BusinessPanel.vue
+++ b/packages/app-vue/src/layouts/shell/BusinessPanel.vue
@@ -4,12 +4,14 @@
  *
  * 多 Tab 业务工作区（V2 §2.3，参照 Codex 桌面端右侧面板）。
  * Tab 条 [模块图标 + 标题] ×N + 右侧 Maximize/Minimize + ✕(关面板)；
- * 内容区 S0 为 <slot>，S1 放 <router-view> + <KeepAlive :include>。
+ * 内容区放 <router-view> + KeepAlive（由 AppShell 通过 slot 注入）。
  *
- * S0 骨架：Tab 增删/激活/关闭交互 emit + B⇄C 切换 + 拖宽把手；
- * 不含 router-view（接线在 S1）。Tab 数据由 AppShell 从 store 透传。
+ * 面板两档（V2 §7）：内容区用 ResizeObserver 实测宽度并 provide
+ * （usePanelWidth），同时挂 Tailwind 命名容器 `@container/panel`——
+ * 结构性切换（第二侧栏 ↔ 下拉）走 JS 档位，纯样式（网格列数）走
+ * CSS 容器查询（`@2xl/panel:` 等）。
  */
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   AlarmClock,
@@ -25,6 +27,7 @@ import {
 } from 'lucide-vue-next';
 import type { Component } from 'vue';
 import type { BusinessTab, ShellLayout, ShellModule } from './useAppShellStore';
+import { providePanelWidth } from './usePanelWidth';
 
 const props = defineProps<{
   tabs: BusinessTab[];
@@ -41,6 +44,26 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+
+// ── 面板宽度上下文（V2 §7 两档；面板内业务视图 usePanelWidth 消费） ──
+const { width: panelContentWidth } = providePanelWidth();
+const contentEl = ref<HTMLElement | null>(null);
+let resizeObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+  if (!contentEl.value || typeof ResizeObserver === 'undefined') return;
+  panelContentWidth.value = contentEl.value.clientWidth;
+  resizeObserver = new ResizeObserver((entries) => {
+    const entry = entries[0];
+    if (entry) panelContentWidth.value = entry.contentRect.width;
+  });
+  resizeObserver.observe(contentEl.value);
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+});
 
 const moduleIcons: Record<ShellModule, Component> = {
   goal: Target,
@@ -112,8 +135,8 @@ const isFocused = computed(() => props.layout === 'focus');
       </div>
     </div>
 
-    <!-- 内容区（S1 放 router-view + KeepAlive） -->
-    <div class="min-h-0 flex-1 overflow-auto">
+    <!-- 内容区（router-view 由 AppShell slot 注入；命名容器供 CSS 容器查询） -->
+    <div ref="contentEl" class="@container/panel min-h-0 flex-1 overflow-auto">
       <slot />
     </div>
 

--- a/packages/app-vue/src/layouts/shell/usePanelWidth.ts
+++ b/packages/app-vue/src/layouts/shell/usePanelWidth.ts
@@ -1,0 +1,69 @@
+/**
+ * Panel Width Context (UI 重构 V2 §7：从"视口四档"到"面板两档")
+ *
+ * V2 的宽度适配对象是**面板本身**，不是视口。BusinessPanel 用 ResizeObserver
+ * 测量自己的内容宽度，provide 给面板内的业务视图；视图据此在
+ *   - 窄档（narrow）：split 态、面板 320–750px → 第二侧栏收下拉、网格 1–2 列、
+ *     重交互（拖拽/图谱）禁用并提示"最大化后可用"
+ *   - 宽档（wide）：focus 态满屏 → 完整布局，等价该页桌面形态
+ * 之间切换。同一组件在 split 与 focus 下**自适应**，不再用 `md:`/`lg:`/`xl:`
+ * 视口断点。
+ *
+ * 阈值 900px：略高于 split 上限 750，确保分栏态永远判定为 narrow，
+ * 只有进入 focus（满屏）才升 wide。
+ */
+import { computed, inject, provide, readonly, ref, type ComputedRef, type InjectionKey, type Ref } from 'vue';
+
+export type PanelWidthTier = 'narrow' | 'wide';
+
+/** narrow ↔ wide 的临界像素宽度（面板内容宽度）。 */
+export const PANEL_WIDE_THRESHOLD = 900;
+
+interface PanelWidthContext {
+  /** 面板内容当前像素宽度（未挂载/未测量时为 null）。 */
+  width: Readonly<Ref<number | null>>;
+  /** 宽度档位（V2 §7 两档）。 */
+  tier: ComputedRef<PanelWidthTier>;
+  /** 便捷判定：是否窄档（split）。 */
+  isNarrow: ComputedRef<boolean>;
+  /** 便捷判定：是否宽档（focus）。 */
+  isWide: ComputedRef<boolean>;
+}
+
+const PANEL_WIDTH_KEY: InjectionKey<PanelWidthContext> = Symbol('PanelWidthContext');
+
+/**
+ * 面板容器侧调用：持有宽度 ref、派生档位并 provide。
+ * BusinessPanel 用 ResizeObserver 把测得的宽度写进返回的 `width`。
+ */
+export function providePanelWidth(): { width: Ref<number | null> } {
+  const width = ref<number | null>(null);
+  const tier = computed<PanelWidthTier>(() =>
+    width.value != null && width.value < PANEL_WIDE_THRESHOLD ? 'narrow' : 'wide',
+  );
+  provide(PANEL_WIDTH_KEY, {
+    width: readonly(width),
+    tier,
+    isNarrow: computed(() => tier.value === 'narrow'),
+    isWide: computed(() => tier.value === 'wide'),
+  });
+  return { width };
+}
+
+/**
+ * 业务视图侧调用：读取面板宽度档位。
+ * 面板外（不太可能，因为 router-view 只在 BusinessPanel 内）默认 wide，
+ * 保证独立渲染/单测时是完整布局。
+ */
+export function usePanelWidth(): PanelWidthContext {
+  const injected = inject(PANEL_WIDTH_KEY, null);
+  if (injected) return injected;
+  const width = ref<number | null>(null);
+  const tier = computed<PanelWidthTier>(() => 'wide');
+  return {
+    width: readonly(width),
+    tier,
+    isNarrow: computed(() => false),
+    isWide: computed(() => true),
+  };
+}

--- a/packages/app-vue/src/modules/goal/components/GoalViewSwitcherBar.vue
+++ b/packages/app-vue/src/modules/goal/components/GoalViewSwitcherBar.vue
@@ -1,0 +1,160 @@
+<template>
+  <div
+    class="flex h-12 shrink-0 items-center gap-1 border-b bg-sidebar/60 px-2"
+    data-testid="goal-view-switcher-bar"
+  >
+    <!-- 视图切换下拉：系统视图 + 文件夹（窄档形态的第二侧栏） -->
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-8 min-w-0 gap-1.5 px-2 font-medium"
+          data-testid="goal-view-switcher-trigger"
+        >
+          <LayoutGrid class="h-4 w-4 shrink-0 text-primary" />
+          <span class="truncate">{{ currentLabel }}</span>
+          <span v-if="currentCount !== null" class="text-xs text-muted-foreground">
+            {{ currentCount }}
+          </span>
+          <ChevronDown class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" class="w-56">
+        <DropdownMenuItem
+          v-for="view in systemViews"
+          :key="view.id"
+          :data-testid="`goal-system-view-${view.id}`"
+          :class="activeSystemView === view.id && !selectedFolderId ? 'bg-accent' : ''"
+          @click="$emit('select-system-view', view.id)"
+        >
+          <LayoutGrid class="mr-2 h-4 w-4" />
+          <span class="flex-1 truncate">{{ view.label }}</span>
+          <span class="text-xs text-muted-foreground">{{ view.count }}</span>
+        </DropdownMenuItem>
+
+        <template v-if="folders.length > 0">
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            v-for="folder in folders"
+            :key="folder.id"
+            :class="selectedFolderId === folder.id ? 'bg-accent' : ''"
+            @click="$emit('select-folder', folder.id)"
+          >
+            <span
+              class="mr-2 h-2.5 w-2.5 shrink-0 rounded-full border border-border/60"
+              :style="{ backgroundColor: folder.color || 'hsl(var(--muted-foreground))' }"
+            />
+            <span class="flex-1 truncate">{{ folder.name }}</span>
+          </DropdownMenuItem>
+        </template>
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem @click="$emit('create-folder')">
+          <FolderPlus class="mr-2 h-4 w-4" />
+          {{ t('goal.list.newFolder') }}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <div class="ml-auto flex items-center gap-1">
+      <!-- 专注模式：未激活 = 弱化图标；激活 = 主色点 + 剩余天数 -->
+      <Button
+        variant="ghost"
+        size="sm"
+        class="h-8 gap-1.5 px-2"
+        :class="focusMode ? 'text-primary' : 'text-muted-foreground'"
+        :title="t('goal.focusMode.sidebarTitle')"
+        data-testid="goal-focus-entry"
+        @click="focusMode ? $emit('go-focus') : $emit('open-focus')"
+      >
+        <Crosshair class="h-4 w-4" />
+        <span v-if="focusMode" class="text-xs font-medium">{{ remainingDays }}d</span>
+      </Button>
+
+      <!-- 主操作：新建目标（testid 契约随迁，e2e 快路径两档都可用） -->
+      <Button
+        size="sm"
+        class="h-8"
+        data-testid="create-goal-entry"
+        @click="$emit('create-goal')"
+      >
+        <Plus class="mr-1 h-4 w-4" />
+        {{ t('goal.list.newGoal') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * GoalViewSwitcherBar — 目标模块第二侧栏的窄档形态（UI 重构 V2 §6.1 / §7）
+ *
+ * split 窄档下 GoalSidebar（w-64）在 320–750px 面板里放不下，收敛为
+ * 一行顶栏：视图下拉（系统视图计数 + 文件夹色点）+ 专注入口 + 新建目标。
+ * 与 GoalSidebar 同一套 props/emits 子集，由 GoalModuleLayout 按面板档位
+ * 二选一渲染；`goal-system-view-*` / `goal-focus-entry` / `create-goal-entry`
+ * testid 契约随迁（V2 §8-1）。
+ */
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { ChevronDown, Crosshair, FolderPlus, LayoutGrid, Plus } from 'lucide-vue-next';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@dailyuse/ui-vue-shadcn';
+import type {
+  FocusModeDTO,
+  GoalFolderClientDTO,
+  GoalSystemView,
+} from '@dailyuse/contracts/goal';
+
+const props = defineProps<{
+  systemViews: Array<{ id: GoalSystemView; label: string; count: number }>;
+  activeSystemView: GoalSystemView;
+  folders: GoalFolderClientDTO[];
+  selectedFolderId: string | null;
+  focusMode: FocusModeDTO | null;
+}>();
+
+defineEmits<{
+  'create-goal': [];
+  'create-folder': [];
+  'select-system-view': [view: GoalSystemView];
+  'select-folder': [folderId: string];
+  'open-focus': [];
+  'go-focus': [];
+}>();
+
+const { t } = useI18n();
+
+const currentLabel = computed(() => {
+  if (props.selectedFolderId) {
+    return (
+      props.folders.find((folder) => folder.id === props.selectedFolderId)?.name ??
+      t('nav.goals')
+    );
+  }
+  return (
+    props.systemViews.find((view) => view.id === props.activeSystemView)?.label ??
+    t('nav.goals')
+  );
+});
+
+const currentCount = computed<number | null>(() => {
+  if (props.selectedFolderId) return null;
+  return (
+    props.systemViews.find((view) => view.id === props.activeSystemView)?.count ?? null
+  );
+});
+
+const remainingDays = computed(() => {
+  const mode = props.focusMode;
+  if (!mode) return 0;
+  return Math.max(0, Math.ceil((mode.endTime - Date.now()) / (1000 * 60 * 60 * 24)));
+});
+</script>

--- a/packages/app-vue/src/modules/goal/views/GoalListView.vue
+++ b/packages/app-vue/src/modules/goal/views/GoalListView.vue
@@ -9,8 +9,8 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <!-- 搜索：目标数为 0 时隐藏（§3-5 空集合搜索无意义） -->
-        <div v-if="goals.length > 0" class="relative mr-2 hidden w-64 lg:block">
+        <!-- 搜索：目标数为 0 时隐藏（§3-5 空集合搜索无意义）；宽档才显示（窄档收在下拉外，靠列表精简） -->
+        <div v-if="goals.length > 0" class="relative mr-2 hidden w-64 @3xl/panel:block">
           <Search class="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             v-model="searchQuery"
@@ -53,7 +53,7 @@
         <!-- 加载 = 卡片骨架 ×6（§0.3） -->
         <div
           v-if="isLoading"
-          class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+          class="grid grid-cols-1 gap-4 @2xl/panel:grid-cols-2 @5xl/panel:grid-cols-3"
           data-testid="goal-list-skeleton"
         >
           <div v-for="i in 6" :key="i" class="space-y-3 rounded-lg border border-border/50 p-4">
@@ -65,7 +65,7 @@
 
         <div
           v-else-if="filteredGoals.length > 0"
-          class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+          class="grid grid-cols-1 gap-4 @2xl/panel:grid-cols-2 @5xl/panel:grid-cols-3"
           data-testid="goal-list"
         >
           <GoalCard

--- a/packages/app-vue/src/modules/goal/views/GoalModuleLayout.vue
+++ b/packages/app-vue/src/modules/goal/views/GoalModuleLayout.vue
@@ -1,6 +1,25 @@
 <template>
-  <div class="flex h-full min-h-0 w-full overflow-hidden bg-background">
+  <div
+    class="flex h-full min-h-0 w-full overflow-hidden bg-background"
+    :class="isNarrow ? 'flex-col' : 'flex-row'"
+  >
+    <!-- 宽档（focus）：第二侧栏；窄档（split）：收敛为顶部下拉栏（V2 §6.1/§7） -->
+    <GoalViewSwitcherBar
+      v-if="isNarrow"
+      :system-views="visibleSystemViews"
+      :active-system-view="systemView"
+      :folders="goalFolders"
+      :selected-folder-id="selectedFolderId"
+      :focus-mode="currentFocusMode"
+      @create-goal="openGoalDialog"
+      @create-folder="openFolderDialog"
+      @select-system-view="selectSystemView"
+      @select-folder="selectFolder"
+      @open-focus="openFocusDialog"
+      @go-focus="goFocus"
+    />
     <GoalSidebar
+      v-else
       :system-views="visibleSystemViews"
       :active-system-view="systemView"
       :folders="goalFolders"
@@ -45,6 +64,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@dailyuse/utils/logger';
 import { useGoal } from '../composables/useGoal';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
 import type {
   GoalClientDTO,
   GoalSystemView,
@@ -52,11 +72,14 @@ import type {
 } from '@dailyuse/contracts/goal';
 import { GoalDialog, GoalFolderDialog, ActivateFocusModeDialog } from '../components';
 import GoalSidebar from '../components/GoalSidebar.vue';
+import GoalViewSwitcherBar from '../components/GoalViewSwitcherBar.vue';
 
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 const logger = createLogger('goal:layout');
+// 面板两档（V2 §7）：窄档收侧栏为顶部下拉，宽档恢复完整侧栏。
+const { isNarrow } = usePanelWidth();
 const stringify = (value: unknown): string => {
   try {
     return JSON.stringify(value);


### PR DESCRIPTION
## 概要

UI 重构 V2 **S2 面板内容改造首个切片：Goal**（`docs/UI_REDESIGN_V2_PLAN.md` §6.1 / §7）。

在 S1（#176）落成的三态壳之上，把"视口四档响应式"换成 V2 §7 的**面板两档宽度模型**——同一组件靠**面板宽度**（而非视口）在 split 窄档 / focus 宽档间自适应。这套两档基建（`usePanelWidth` + `@container/panel`）由后续每个 S2 模块 PR 复用。

## 变更

**壳基建（S2 通用，后续模块复用）**
- `usePanelWidth` / `providePanelWidth`（`layouts/shell`）：`BusinessPanel` 用 ResizeObserver 实测内容宽度并 provide `{ width, tier, isNarrow, isWide }`；`tier` = narrow（<900px，split）/ wide（focus 满屏）。面板外渲染（独立/单测）默认 wide
- `BusinessPanel` 内容区挂 Tailwind v4 命名容器 `@container/panel`：结构性切换（第二侧栏 ↔ 下拉）走 JS 档位，纯样式（网格列数）走 CSS 容器查询

**Goal 模块（§6.1）**
- 新增 `GoalViewSwitcherBar`：窄档下 `GoalSidebar`（w-64）在 320–750px 面板放不下，收敛为一行顶栏——视图下拉（系统视图计数 + 文件夹色点）+ 专注入口 + 新建目标
- `GoalModuleLayout`：按面板档位二选一渲染 `GoalViewSwitcherBar`（窄）/ `GoalSidebar`（宽）；`goal-system-view-*`、`goal-focus-entry`、`create-goal-entry` testid 契约随迁（V2 §8-1）
- `GoalListView`：卡片网格从视口断点（`md:`/`lg:`）改为容器查询（`@2xl/panel:` 2 列、`@5xl/panel:` 3 列）；头部搜索仅 `@3xl/panel` 起显示

## 验证

- ✅ app-vue lint / typecheck / test（189 通过）+ web vue-tsc（覆盖 SFC 类型）
- ✅ MSW mock 真浏览器冒烟 **10/10**：**同一 1280px 视口**下，split 面板渲染 1 列 + 顶部视图切换栏，focus 渲染 3 列 + 完整第二侧栏；窄档下拉切换系统视图正常；0 页面错误

## 说明

- 契约安全：`create-goal-entry` 在两档都在（e2e 快路径 + `?dialog=goal` URL 兜底不变）
- 不含 S1 遗留的 MSW/错误边界修复（按既定节奏留到重构收尾统一处理）
- 下一切片：S2-Task（§6.2，任务库更名、FilterBar、图谱视图、拖拽建依赖仅 focus 档启用）
