### PR TITLE
refactor(schedule): S2 panel adaptation — focus-on-enter + day-only narrow + capsule (V2 §6.3/§7)

### DIFF
--- a/packages/app-vue/src/layouts/shell/AppShell.vue
+++ b/packages/app-vue/src/layouts/shell/AppShell.vue
@@ -28,6 +28,7 @@ import { useAppShellStore, MAX_BUSINESS_TABS, type ShellModule } from './useAppS
 import { useShellRouterSync } from './useShellRouterSync';
 import { useDesktopWindowControls } from '../../shared/composables/useDesktopWindowControls';
 import { useNotification } from '../../modules/notification/composables/useNotification';
+import { formatScheduleCapsuleLabel, useCalendarView } from '../../modules/schedule/composables/useCalendarView';
 import { useAuthenticationStore } from '../../modules/authentication/stores/authentication-store';
 import AIChatView from '../../modules/ai/views/AIChatView.vue';
 import type { ConversationSummary } from '../../modules/ai/composables/types';
@@ -145,16 +146,34 @@ const userName = computed<string | undefined>(() => {
 // ── 通知未读角标（SSE 启动钩子推流，胶囊消费；V2 §8-7） ──
 const notification = useNotification();
 
+// 日程胶囊实时文案（V2 §2 / §6.3）：当前时段或下一事件，每分钟刷新。
+const calendarView = useCalendarView();
+const scheduleNowMs = ref(Date.now());
+let scheduleTickTimer: ReturnType<typeof setInterval> | null = null;
+const scheduleLabel = computed(() =>
+  formatScheduleCapsuleLabel(calendarView.getScheduleCapsuleSnapshot(scheduleNowMs.value), t),
+);
+
+
 // ── 桌面窗控（既有 IPC 通道，V2 §9；Web 分支不渲染按钮） ──
 const windowControls = useDesktopWindowControls();
 
 onMounted(() => {
   void notification.refreshStats();
   if (isDesktop) windowControls.startListening();
+  void calendarView.ensureTodayLoaded(scheduleNowMs.value);
+  scheduleTickTimer = setInterval(() => {
+    scheduleNowMs.value = Date.now();
+    void calendarView.ensureTodayLoaded(scheduleNowMs.value);
+  }, 60_000);
 });
 
 onBeforeUnmount(() => {
   if (isDesktop) windowControls.stopListening();
+  if (scheduleTickTimer) {
+    clearInterval(scheduleTickTimer);
+    scheduleTickTimer = null;
+  }
 });
 
 // ── 拖拽调宽（侧栏 / 面板），状态回写 store ──
@@ -188,8 +207,11 @@ function enterModule(id: string) {
 }
 
 function openSchedule() {
+  // 日程进入即建议 focus（V2 §6.3）；openModule 内 shouldOpenInFocus 也会兜底。
+  store.setLayout('focus');
   void sync.openModule('schedule', '/schedule/calendar');
 }
+
 
 function openSettings() {
   void sync.openModule('setting', '/settings');
@@ -220,7 +242,7 @@ function panelCacheKey(fullPath: string, routeName: unknown): string {
       :sidebar-collapsed="sidebarCollapsed"
       :active-module="activeModule"
       :unread-count="notification.unreadCount.value"
-      :schedule-label="null"
+      :schedule-label="scheduleLabel"
       :is-desktop="isDesktop"
       :is-mac="isMac"
       :window-controls="windowControls.windowControlsState"

--- a/packages/app-vue/src/layouts/shell/useShellRouterSync.spec.ts
+++ b/packages/app-vue/src/layouts/shell/useShellRouterSync.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { moduleForPath, MODULE_TITLE_KEYS } from './useShellRouterSync';
+import { moduleForPath, MODULE_TITLE_KEYS, shouldOpenInFocus } from './useShellRouterSync';
 
 describe('moduleForPath (V2 §3 module matrix)', () => {
   it('maps every business route family to its shell module', () => {
@@ -38,5 +38,14 @@ describe('moduleForPath (V2 §3 module matrix)', () => {
     for (const key of Object.values(MODULE_TITLE_KEYS)) {
       expect(key).toMatch(/^nav\./);
     }
+  });
+});
+
+describe('shouldOpenInFocus (V2 §3 / §6.3)', () => {
+  it('marks settings and schedule for default focus entry', () => {
+    expect(shouldOpenInFocus('setting')).toBe(true);
+    expect(shouldOpenInFocus('schedule')).toBe(true);
+    expect(shouldOpenInFocus('task')).toBe(false);
+    expect(shouldOpenInFocus('goal')).toBe(false);
   });
 });

--- a/packages/app-vue/src/layouts/shell/useShellRouterSync.ts
+++ b/packages/app-vue/src/layouts/shell/useShellRouterSync.ts
@@ -49,6 +49,11 @@ export const MODULE_TITLE_KEYS: Record<ShellModule, string> = {
   setting: 'nav.settings',
 };
 
+/** 进入即建议 focus 的模块（V2 §3 Settings / §6.3 Schedule）。 */
+export function shouldOpenInFocus(module: ShellModule): boolean {
+  return module === 'setting' || module === 'schedule';
+}
+
 /** 判定一条路由路径归属哪个业务模块；壳外/未知路径返回 null。 */
 export function moduleForPath(path: string): ShellModule | null {
   for (const [prefix, module] of MODULE_PREFIXES) {
@@ -68,8 +73,9 @@ export function useShellRouterSync() {
   }
 
   function maybeAutoFocus(module: ShellModule): void {
-    // Settings 默认专注态打开（V2 §3）；窄窗口分栏放不下时自动升专注态。
-    if (module === 'setting') {
+    // Settings 默认 focus（V2 §3）；Schedule 日历天然要宽度，进入即建议 focus（V2 §6.3）。
+    // 窄窗口分栏放不下时，其它模块也自动升专注态。
+    if (shouldOpenInFocus(module)) {
       store.setLayout('focus');
       return;
     }
@@ -171,7 +177,7 @@ export function useShellRouterSync() {
     const existing = store.tabs.find((tab) => tab.module === module);
     if (existing) {
       await activateTab(existing.id);
-      if (module === 'setting') store.setLayout('focus');
+      if (shouldOpenInFocus(module)) store.setLayout('focus');
       return;
     }
     await router.push(landingRoute).catch(() => {});

--- a/packages/app-vue/src/locales/en-US.ts
+++ b/packages/app-vue/src/locales/en-US.ts
@@ -155,6 +155,9 @@ export default {
     aiWorkspacePlaceholder: 'AI workspace (pending wiring)',
     schedule: {
       empty: 'Nothing scheduled today',
+      current: '{start}–{end} · {title}',
+      upcoming: '{start} · {title} (in {minutes} min)',
+      currentAllDay: 'Today · {title}',
     },
     conversation: {
       today: 'Today',
@@ -1967,6 +1970,7 @@ export default {
     },
 
     calendar: {
+      narrowDayOnly: 'Day view only in split — maximize for week/month',
       today: 'Today',
       createSchedule: 'New Schedule',
       weekRange: '{start} - {end}',

--- a/packages/app-vue/src/locales/zh-CN.ts
+++ b/packages/app-vue/src/locales/zh-CN.ts
@@ -155,6 +155,9 @@ export default {
     aiWorkspacePlaceholder: 'AI 工作区（待接线）',
     schedule: {
       empty: '今日无安排',
+      current: '{start}–{end} · {title}',
+      upcoming: '{start} · {title}（{minutes} 分钟后）',
+      currentAllDay: '今日 · {title}',
     },
     conversation: {
       today: '今天',
@@ -1919,6 +1922,7 @@ export default {
     },
 
     calendar: {
+      narrowDayOnly: '分栏态仅显示日视图，最大化后可切换周/月',
       today: '今天',
       createSchedule: '新建日程',
       weekRange: '{start} - {end}',

--- a/packages/app-vue/src/modules/schedule/components/ScheduleTaskDetailDialog.vue
+++ b/packages/app-vue/src/modules/schedule/components/ScheduleTaskDetailDialog.vue
@@ -131,7 +131,7 @@
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div class="grid grid-cols-2 @2xl/panel:grid-cols-4 gap-4">
               <div>
                 <p class="text-sm text-muted-foreground mb-1">
                   {{ t('schedule.detailDialog.cronExpression') }}

--- a/packages/app-vue/src/modules/schedule/components/StatisticsCard.vue
+++ b/packages/app-vue/src/modules/schedule/components/StatisticsCard.vue
@@ -44,7 +44,7 @@
         <!-- Overall Statistics -->
         <div>
           <h4 class="text-sm font-semibold mb-3">{{ t('schedule.statistics.overallOverview') }}</h4>
-          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div class="grid grid-cols-2 @2xl/panel:grid-cols-4 gap-3">
             <Card class="bg-primary/10 hover:-translate-y-0.5 transition-transform">
               <CardContent class="text-center p-4">
                 <div class="text-3xl font-bold text-primary">{{ statistics.totalTasks }}</div>
@@ -139,7 +139,7 @@
           <h4 class="text-sm font-semibold mb-3">
             {{ t('schedule.statistics.moduleDistribution') }}
           </h4>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div class="grid grid-cols-1 @2xl/panel:grid-cols-3 gap-3">
             <Card
               v-for="(stats, moduleName) in moduleStatistics"
               :key="moduleName"

--- a/packages/app-vue/src/modules/schedule/composables/useCalendarView.capsule.spec.ts
+++ b/packages/app-vue/src/modules/schedule/composables/useCalendarView.capsule.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatCapsuleTime,
+  formatScheduleCapsuleLabel,
+  resolveScheduleCapsule,
+  type CalendarEventItem,
+} from './useCalendarView';
+
+function event(partial: Partial<CalendarEventItem> & Pick<CalendarEventItem, 'id' | 'title' | 'startTime' | 'endTime'>): CalendarEventItem {
+  return {
+    displayMode: 'timed',
+    source: 'schedule',
+    originalId: partial.id,
+    ...partial,
+  };
+}
+
+describe('schedule capsule helpers (V2 §2 / §6.3)', () => {
+  const day = new Date(2026, 6, 13, 12, 0, 0, 0); // local noon
+  const now = day.getTime();
+
+  it('prefers an in-progress timed event as current', () => {
+    const current = event({
+      id: 'c1',
+      title: 'Deep Work',
+      startTime: now - 30 * 60_000,
+      endTime: now + 30 * 60_000,
+    });
+    const next = event({
+      id: 'n1',
+      title: 'Standup',
+      startTime: now + 60 * 60_000,
+      endTime: now + 90 * 60_000,
+    });
+    const snap = resolveScheduleCapsule([next, current], now);
+    expect(snap.kind).toBe('current');
+    expect(snap.event?.id).toBe('c1');
+  });
+
+  it('falls back to the next upcoming timed event', () => {
+    const next = event({
+      id: 'n1',
+      title: 'Standup',
+      startTime: now + 25 * 60_000,
+      endTime: now + 55 * 60_000,
+    });
+    const snap = resolveScheduleCapsule([next], now);
+    expect(snap.kind).toBe('upcoming');
+    expect(snap.minutesUntilStart).toBe(25);
+  });
+
+  it('formats capsule labels for current and upcoming', () => {
+    const t = (key: string, params?: Record<string, unknown>) =>
+      `${key}:${JSON.stringify(params ?? {})}`;
+
+    const currentSnap = resolveScheduleCapsule(
+      [
+        event({
+          id: 'c1',
+          title: 'Deep Work',
+          startTime: now - 10 * 60_000,
+          endTime: now + 50 * 60_000,
+        }),
+      ],
+      now,
+    );
+    const currentLabel = formatScheduleCapsuleLabel(currentSnap, t);
+    expect(currentLabel).toContain('shell.schedule.current');
+    expect(currentLabel).toContain('Deep Work');
+
+    const upcomingSnap = resolveScheduleCapsule(
+      [
+        event({
+          id: 'n1',
+          title: 'Standup',
+          startTime: now + 30 * 60_000,
+          endTime: now + 60 * 60_000,
+        }),
+      ],
+      now,
+    );
+    const upcomingLabel = formatScheduleCapsuleLabel(upcomingSnap, t);
+    expect(upcomingLabel).toContain('shell.schedule.upcoming');
+    expect(upcomingLabel).toContain('30');
+  });
+
+  it('formats local HH:mm without locale drift', () => {
+    const ms = new Date(2026, 6, 13, 9, 5, 0, 0).getTime();
+    expect(formatCapsuleTime(ms)).toBe('09:05');
+  });
+});

--- a/packages/app-vue/src/modules/schedule/composables/useCalendarView.ts
+++ b/packages/app-vue/src/modules/schedule/composables/useCalendarView.ts
@@ -34,6 +34,79 @@ export function toLocalDateKey(value: Date | number): string {
   return `${year}-${month}-${day}`;
 }
 
+/** HH:mm in local time for shell schedule capsule. */
+export function formatCapsuleTime(ms: number): string {
+  const date = new Date(ms);
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+export type ScheduleCapsuleSnapshot = {
+  kind: 'empty' | 'current' | 'upcoming';
+  event: CalendarEventItem | null;
+  /** Minutes until start (upcoming only). */
+  minutesUntilStart: number | null;
+};
+
+/**
+ * Pick the "current / next" event for the header schedule capsule (V2 §2).
+ * Prefers an in-progress timed event; otherwise the next upcoming event today.
+ */
+export function resolveScheduleCapsule(
+  events: CalendarEventItem[],
+  nowMs: number = Date.now(),
+): ScheduleCapsuleSnapshot {
+  const todayKey = toLocalDateKey(nowMs);
+  const todays = events
+    .filter((event) => toLocalDateKey(event.startTime) === todayKey || toLocalDateKey(event.endTime) === todayKey)
+    .sort((a, b) => a.startTime - b.startTime);
+
+  const current = todays.find(
+    (event) => event.displayMode === 'timed' && event.startTime <= nowMs && event.endTime > nowMs,
+  );
+  if (current) {
+    return { kind: 'current', event: current, minutesUntilStart: null };
+  }
+
+  const upcoming = todays.find((event) => event.startTime > nowMs);
+  if (upcoming) {
+    const minutesUntilStart = Math.max(0, Math.round((upcoming.startTime - nowMs) / 60000));
+    return { kind: 'upcoming', event: upcoming, minutesUntilStart };
+  }
+
+  // All-day only (or nothing timed left) still counts as "has schedule" when present.
+  const allDay = todays.find((event) => event.displayMode === 'all-day');
+  if (allDay) {
+    return { kind: 'current', event: allDay, minutesUntilStart: null };
+  }
+
+  return { kind: 'empty', event: null, minutesUntilStart: null };
+}
+
+export function formatScheduleCapsuleLabel(
+  snapshot: ScheduleCapsuleSnapshot,
+  t: (key: string, params?: Record<string, unknown>) => string,
+): string | null {
+  if (snapshot.kind === 'empty' || !snapshot.event) return null;
+  const event = snapshot.event;
+  if (snapshot.kind === 'current') {
+    if (event.displayMode === 'all-day') {
+      return t('shell.schedule.currentAllDay', { title: event.title });
+    }
+    return t('shell.schedule.current', {
+      start: formatCapsuleTime(event.startTime),
+      end: formatCapsuleTime(event.endTime),
+      title: event.title,
+    });
+  }
+  return t('shell.schedule.upcoming', {
+    start: formatCapsuleTime(event.startTime),
+    title: event.title,
+    minutes: snapshot.minutesUntilStart ?? 0,
+  });
+}
+
 // ============ 转换工具函数 ============
 
 /** TaskInstance → CalendarEventItem（用 instanceDate + timeRange 分钟偏移） */
@@ -137,12 +210,29 @@ export function useCalendarView() {
     ]);
   }
 
+  /** Ensure today's events are loaded (shell capsule). */
+  async function ensureTodayLoaded(nowMs: number = Date.now()) {
+    const start = startOfDay(new Date(nowMs)).getTime();
+    const end = endOfDay(new Date(nowMs)).getTime();
+    // Avoid refetch thrash if window already covers today.
+    if (windowStart.value <= start && windowEnd.value >= end && windowEnd.value > 0) {
+      return;
+    }
+    await fetchForRange(start, end);
+  }
+
+  function getScheduleCapsuleSnapshot(nowMs: number = Date.now()): ScheduleCapsuleSnapshot {
+    return resolveScheduleCapsule(events.value, nowMs);
+  }
+
   return {
     events,
     isLoading,
     windowStart,
     windowEnd,
     fetchForRange,
+    ensureTodayLoaded,
+    getScheduleCapsuleSnapshot,
     // expose sub-composables for DEV panel access
     scheduleTasks: schedule.tasks,
   };

--- a/packages/app-vue/src/modules/schedule/views/ScheduleCalendarView.vue
+++ b/packages/app-vue/src/modules/schedule/views/ScheduleCalendarView.vue
@@ -7,8 +7,8 @@
       <div class="flex items-center gap-4">
         <h1 class="text-lg font-medium text-foreground">{{ t('schedule.dashboard.title') }}</h1>
         <Separator orientation="vertical" class="h-4" />
-        <!-- View Mode Tabs: Day / Week / Month -->
-        <div class="flex items-center gap-1">
+        <!-- 宽档：日/周/月切换；窄档（split）只渲日视图（V2 §6.3 / §7） -->
+        <div v-if="!isNarrow" class="flex items-center gap-1" data-testid="schedule-view-tabs">
           <Button
             v-for="tab in viewTabs"
             :key="tab.value"
@@ -18,12 +18,20 @@
               'h-7 px-3 text-muted-foreground hover:text-foreground',
               activeView === tab.value ? 'bg-secondary font-medium text-foreground' : '',
             ]"
+            :data-testid="`schedule-view-tab-${tab.value}`"
             @click="activeView = tab.value"
           >
             <component :is="tab.icon" class="mr-1.5 h-3.5 w-3.5" />
             {{ tab.label }}
           </Button>
         </div>
+        <p
+          v-else
+          class="text-xs text-muted-foreground"
+          data-testid="schedule-narrow-day-hint"
+        >
+          {{ t('schedule.calendar.narrowDayOnly') }}
+        </p>
       </div>
 
       <div class="flex items-center gap-2">
@@ -36,9 +44,9 @@
 
     <!-- Calendar Content -->
     <div class="flex-1 overflow-hidden">
-      <!-- Day View -->
+      <!-- Day View（窄档强制日视图） -->
       <DayViewCalendar
-        v-if="activeView === 'day'"
+        v-if="effectiveView === 'day'"
         :schedules="events"
         :loading="isLoading"
         @event-click="handleEventClick"
@@ -47,7 +55,7 @@
 
       <!-- Week View -->
       <WeekViewCalendar
-        v-else-if="activeView === 'week'"
+        v-else-if="effectiveView === 'week'"
         :schedules="events"
         :loading="isLoading"
         @event-click="handleEventClick"
@@ -56,7 +64,7 @@
 
       <!-- Month View -->
       <MonthViewCalendar
-        v-else-if="activeView === 'month'"
+        v-else-if="effectiveView === 'month'"
         :schedules="events"
         :loading="isLoading"
         @event-click="handleEventClick"
@@ -93,7 +101,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { toast } from 'vue-sonner';
 import { CalendarDays, Calendar, CalendarRange, Plus } from 'lucide-vue-next';
@@ -109,6 +117,7 @@ import DevScheduleDebugPanel from '../components/DevScheduleDebugPanel.vue';
 import { toLocalDateKey, useCalendarView } from '../composables/useCalendarView';
 import { useSchedule } from '../composables/useSchedule';
 import { useTask } from '../../task/composables/useTask';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
 import type { CalendarEventItem } from '../composables/useCalendarView';
 import type { CreateScheduleRequest } from '@dailyuse/contracts/schedule';
 
@@ -116,9 +125,22 @@ const { t } = useI18n();
 const { events, isLoading, fetchForRange, windowStart, windowEnd } = useCalendarView();
 const { tasks: scheduleTasks, createCalendarEntry } = useSchedule();
 const task = useTask();
+// 面板两档（V2 §6.3/§7）：窄档只渲日视图；宽档允许日/周/月。
+const { isNarrow } = usePanelWidth();
 
 const showCreateDialog = ref(false);
 const activeView = ref<'day' | 'week' | 'month'>('week');
+const effectiveView = computed<'day' | 'week' | 'month'>(() =>
+  isNarrow.value ? 'day' : activeView.value,
+);
+
+watch(
+  isNarrow,
+  (narrow) => {
+    if (narrow) activeView.value = 'day';
+  },
+  { immediate: true },
+);
 
 // Day detail sheet state
 const dayDetailOpen = ref(false);
@@ -205,8 +227,13 @@ async function handleCreateSchedule(data: CreateScheduleRequest) {
 }
 
 onMounted(async () => {
-  // Load current week by default
   const now = new Date();
+  if (isNarrow.value) {
+    // split 窄档：只加载当日窗口
+    handleDayChange(now);
+    return;
+  }
+  // 宽档默认周视图窗口
   const weekStart = new Date(now);
   const day = weekStart.getDay();
   const diff = day === 0 ? -6 : 1 - day;


### PR DESCRIPTION
## 概要

UI 重构 V2 **S2 面板内容改造切片：Schedule**（`docs/UI_REDESIGN_V2_PLAN.md` §6.3 / §7）。

日历天然要宽度：进入日程即建议 focus；split 窄档只渲染日视图；头部「当前时段」胶囊接入 `useCalendarView` 实时文案。`ScheduleDashboardView` → `ScheduleCalendarView` 更名与 `EventDetailSheet` 已在 main，本切片只做面板化差异。

## 变更

**壳 / 导航**
- `shouldOpenInFocus(module)`：`schedule` 与 `setting` 进入默认 focus（胶囊/深链/openSchedule）
- `AppShell`：日程胶囊 `scheduleLabel` 由 `useCalendarView` 当日窗口派生（进行中 / 下一场 / 空态），每分钟刷新

**Schedule 模块（§6.3）**
- `ScheduleCalendarView`：`usePanelWidth()` 窄档强制 `day`、隐藏周/月 tabs、显示 `schedule-narrow-day-hint`；宽档恢复日/周/月
- `useCalendarView`：新增 `resolveScheduleCapsule` / `formatScheduleCapsuleLabel` / `ensureTodayLoaded`
- 容器查询：`StatisticsCard`、`ScheduleTaskDetailDialog` 的 `md:` → `@2xl/panel:`
- i18n：`shell.schedule.current|upcoming|currentAllDay` + `schedule.calendar.narrowDayOnly`（zh/en）
- 单测：capsule helpers + `shouldOpenInFocus`

## 验证

- ✅ app-vue lint / typecheck / test（**194** 通过，0 lint error）+ web vue-tsc
- ✅ MSW mock 真浏览器冒烟 **9/9**：胶囊显示当前事件、打开日程进 focus、split 仅日视图提示、focus 恢复周/月 tabs

## 说明

- 路由契约不变：`/schedule/calendar` 落地；`ScheduleDashboard` / week 仍 redirect 到 calendar
- 不含既有 MSW/错误边界收尾（统一修）
- 下一切片：S2-Reminder（§6.4，分组侧栏窄档收下拉；全局开关任何档位保持面板头可达）
