### PR TITLE
refactor(reminder): S2 panel adaptation — group switcher narrow + master switch always-on (V2 §6.4/§7)

### DIFF
--- a/packages/app-vue/src/modules/reminder/components/ReminderGroupSwitcherBar.vue
+++ b/packages/app-vue/src/modules/reminder/components/ReminderGroupSwitcherBar.vue
@@ -1,0 +1,127 @@
+<template>
+  <div
+    class="flex h-12 shrink-0 items-center gap-1 border-b bg-sidebar/60 px-2"
+    data-testid="reminder-group-switcher-bar"
+  >
+    <!-- 分组切换下拉：窄档形态的第二侧栏（V2 §6.4 / §7） -->
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-8 min-w-0 gap-1.5 px-2 font-medium"
+          data-testid="reminder-group-switcher-trigger"
+        >
+          <component :is="currentIcon" class="h-4 w-4 shrink-0 text-primary" />
+          <span class="truncate">{{ currentLabel }}</span>
+          <span v-if="currentCount !== null" class="text-xs text-muted-foreground">
+            {{ currentCount }}
+          </span>
+          <ChevronDown class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" class="w-56">
+        <DropdownMenuItem
+          data-testid="reminder-group-option-all"
+          :class="!selectedGroupId ? 'bg-accent' : ''"
+          @click="$emit('select-group', null)"
+        >
+          <LayoutGrid class="mr-2 h-4 w-4" />
+          <span class="flex-1 truncate">{{ t('reminder.linear.allReminders') }}</span>
+          <span class="text-xs text-muted-foreground">{{ templateCount }}</span>
+        </DropdownMenuItem>
+
+        <template v-if="groups.length > 0">
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            v-for="group in groups"
+            :key="group.id"
+            :data-testid="`reminder-group-option-${group.id}`"
+            :class="selectedGroupId === group.id ? 'bg-accent' : ''"
+            @click="$emit('select-group', group.id)"
+          >
+            <Folder class="mr-2 h-4 w-4" />
+            <span class="flex-1 truncate">{{ group.name }}</span>
+            <span class="text-xs text-muted-foreground">{{ group.stats.totalTemplates }}</span>
+          </DropdownMenuItem>
+        </template>
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem data-testid="reminder-create-group-entry" @click="$emit('create-group')">
+          <FolderPlus class="mr-2 h-4 w-4" />
+          {{ t('reminder.action.createGroup') }}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <div class="ml-auto flex items-center gap-1">
+      <!-- 主操作：新建提醒（testid 契约随迁，e2e 窄/宽两档都可用） -->
+      <Button
+        size="sm"
+        class="h-8"
+        data-testid="create-reminder-template-button"
+        :title="t('reminder.action.createReminder')"
+        @click="$emit('create-template')"
+      >
+        <Plus class="mr-1 h-4 w-4" />
+        {{ t('reminder.action.createReminder') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * ReminderGroupSwitcherBar — 提醒模块第二侧栏的窄档形态（UI 重构 V2 §6.4 / §7）
+ *
+ * split 窄档下分组侧栏（w-64）在 320–750px 面板里放不下，收敛为
+ * 一行顶栏：分组下拉（全部提醒 + 各组计数）+ 新建提醒。
+ * 与宽档侧栏共用 selectedGroupId / create 动作；由 ReminderLinearView 按
+ * 面板档位二选一渲染；`create-reminder-template-button` testid 契约随迁（V2 §8-1）。
+ */
+import { computed, type Component } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { ChevronDown, Folder, FolderPlus, LayoutGrid, Plus } from 'lucide-vue-next';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@dailyuse/ui-vue-shadcn';
+import type { ReminderGroupClientDTO } from '@dailyuse/contracts/reminder';
+
+const props = defineProps<{
+  groups: ReminderGroupClientDTO[];
+  selectedGroupId: string | null;
+  templateCount: number;
+}>();
+
+defineEmits<{
+  'select-group': [groupId: string | null];
+  'create-template': [];
+  'create-group': [];
+}>();
+
+const { t } = useI18n();
+
+const selectedGroup = computed(
+  () => props.groups.find((group) => group.id === props.selectedGroupId) ?? null,
+);
+
+const currentLabel = computed(() => {
+  if (selectedGroup.value) return selectedGroup.value.name;
+  return t('reminder.linear.allReminders');
+});
+
+const currentCount = computed<number | null>(() => {
+  if (selectedGroup.value) return selectedGroup.value.stats.totalTemplates;
+  return props.templateCount;
+});
+
+const currentIcon = computed<Component>(() => {
+  if (selectedGroup.value) return Folder;
+  return LayoutGrid;
+});
+</script>

--- a/packages/app-vue/src/modules/reminder/components/index.ts
+++ b/packages/app-vue/src/modules/reminder/components/index.ts
@@ -8,3 +8,4 @@ export { default as ReminderTemplateCard } from './ReminderTemplateCard.vue';
 export { default as GroupDialog } from './GroupDialog.vue';
 export { default as TemplateDialog } from './TemplateDialog.vue';
 export { default as TemplateMoveDialog } from './TemplateMoveDialog.vue';
+export { default as ReminderGroupSwitcherBar } from './ReminderGroupSwitcherBar.vue';

--- a/packages/app-vue/src/modules/reminder/views/ReminderLinearView.vue
+++ b/packages/app-vue/src/modules/reminder/views/ReminderLinearView.vue
@@ -1,7 +1,25 @@
 <template>
-  <div class="flex h-full overflow-hidden bg-background">
-    <!-- Sidebar: Groups -->
-    <aside class="hidden w-64 shrink-0 flex-col overflow-hidden border-r bg-sidebar md:flex">
+  <div
+    class="flex h-full overflow-hidden bg-background"
+    :class="isNarrow ? 'flex-col' : 'flex-row'"
+  >
+    <!-- 窄档（split）：分组侧栏收顶部下拉（V2 §6.4 / §7） -->
+    <ReminderGroupSwitcherBar
+      v-if="isNarrow"
+      :groups="groups"
+      :selected-group-id="selectedGroupId"
+      :template-count="templates.length"
+      @select-group="selectedGroupId = $event"
+      @create-template="handleCreateTemplate(selectedGroupId)"
+      @create-group="openCreateGroup()"
+    />
+
+    <!-- 宽档（focus）：完整分组侧栏 -->
+    <aside
+      v-else
+      class="flex w-64 shrink-0 flex-col overflow-hidden border-r bg-sidebar"
+      data-testid="reminder-group-sidebar"
+    >
       <div class="flex h-14 items-center border-b p-4">
         <div class="flex items-center gap-2 font-semibold">
           <BellRing class="h-5 w-5 text-primary" />
@@ -77,14 +95,18 @@
     <!-- Main -->
     <main class="flex min-w-0 flex-1 flex-col overflow-hidden">
       <header
-        class="z-10 flex h-14 shrink-0 items-center justify-between border-b bg-background/50 px-6 backdrop-blur-sm"
+        class="z-10 flex h-14 shrink-0 items-center justify-between gap-2 border-b bg-background/50 px-4 backdrop-blur-sm @2xl/panel:px-6"
       >
-        <h1 data-testid="reminder-linear-heading" class="text-lg font-medium text-foreground">
+        <h1 data-testid="reminder-linear-heading" class="truncate text-lg font-medium text-foreground">
           {{ t('reminder.linear.templateTitle') }}
         </h1>
-        <div class="flex items-center gap-2">
-          <div class="hidden items-center gap-3 rounded-full border bg-card px-3 py-1.5 md:flex">
-            <span class="text-xs text-muted-foreground">{{
+        <div class="flex min-w-0 items-center gap-2">
+          <!-- 全局开关任何档位保持面板头可达（V2 §6.4） -->
+          <div
+            class="flex items-center gap-2 rounded-full border bg-card px-2.5 py-1.5 @2xl/panel:gap-3 @2xl/panel:px-3"
+            data-testid="reminder-master-switch"
+          >
+            <span class="hidden text-xs text-muted-foreground @2xl/panel:inline">{{
               t('reminder.linear.masterSwitch')
             }}</span>
             <Switch
@@ -93,7 +115,7 @@
               @update:checked="handleToggleGlobalReminder"
             />
           </div>
-          <div class="relative hidden w-64 lg:block">
+          <div class="relative hidden w-48 @3xl/panel:block @5xl/panel:w-64">
             <Search
               class="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
             />
@@ -188,7 +210,10 @@
             </Button>
           </div>
 
-          <div v-else class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+          <div
+            v-else
+            class="grid grid-cols-2 gap-4 @2xl/panel:grid-cols-3 @3xl/panel:grid-cols-4 @5xl/panel:grid-cols-5"
+          >
             <GridTemplateItem
               v-for="tpl in filteredTemplates"
               :key="tpl.id"
@@ -270,10 +295,12 @@ import {
 import { ActionableWrapper, menuLabel } from '../../../components/shared';
 import type { MenuAction } from '../../../components/shared';
 import GridTemplateItem from '../components/GridTemplateItem.vue';
+import ReminderGroupSwitcherBar from '../components/ReminderGroupSwitcherBar.vue';
 import ReminderTemplateCard from '../components/ReminderTemplateCard.vue';
 import TemplateDialog from '../components/TemplateDialog.vue';
 import GroupDialog from '../components/GroupDialog.vue';
 import TemplateMoveDialog from '../components/TemplateMoveDialog.vue';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
 import { useReminder } from '../composables/useReminder';
 import {
   getGroupActiveStatusLabel,
@@ -315,6 +342,8 @@ const {
 } = useReminder();
 
 const { t } = useI18n();
+// 面板两档（V2 §7）：窄档收分组侧栏为顶部下拉，宽档恢复完整侧栏；全局开关始终在面板头。
+const { isNarrow } = usePanelWidth();
 
 const selectedGroupId = ref<string | null>(null);
 const searchQuery = ref('');

--- a/packages/app-vue/src/modules/reminder/views/reminderPanelAdaptation.spec.ts
+++ b/packages/app-vue/src/modules/reminder/views/reminderPanelAdaptation.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { computed, defineComponent, h, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { providePanelWidth, usePanelWidth } from '../../../layouts/shell/usePanelWidth';
+
+/**
+ * Lightweight probe for S2-Reminder panel adaptation (V2 §6.4 / §7):
+ * - narrow (split): group sidebar collapses to switcher bar; master switch stays in header
+ * - wide (focus): full group sidebar restored; master switch still in header
+ *
+ * Mirrors ReminderLinearView's tier surface without mounting the full view
+ * (dialogs/stores/composable network).
+ */
+function mountReminderPanelAdaptationProbe(initialWidth: number) {
+  const widthHandle: { current: number } = { current: initialWidth };
+
+  const Probe = defineComponent({
+    name: 'ReminderPanelAdaptationProbe',
+    setup() {
+      const { isNarrow } = usePanelWidth();
+      const selectedGroupId = ref<string | null>(null);
+      const showSwitcher = computed(() => isNarrow.value);
+      const showSidebar = computed(() => !isNarrow.value);
+      // 全局开关任何档位保持面板头可达
+      const showMasterSwitch = computed(() => true);
+
+      return () =>
+        h('div', { 'data-testid': 'reminder-adaptation-probe' }, [
+          showSwitcher.value
+            ? h('div', { 'data-testid': 'reminder-group-switcher-bar' }, 'switcher')
+            : null,
+          showSidebar.value
+            ? h('div', { 'data-testid': 'reminder-group-sidebar' }, 'sidebar')
+            : null,
+          showMasterSwitch.value
+            ? h('div', { 'data-testid': 'reminder-master-switch' }, 'master')
+            : null,
+          h(
+            'button',
+            {
+              'data-testid': 'select-group',
+              onClick: () => {
+                selectedGroupId.value = 'group-1';
+              },
+            },
+            selectedGroupId.value ?? 'all',
+          ),
+        ]);
+    },
+  });
+
+  const Parent = defineComponent({
+    setup() {
+      const { width } = providePanelWidth();
+      width.value = widthHandle.current;
+      Object.defineProperty(widthHandle, 'current', {
+        get: () => width.value ?? initialWidth,
+        set: (value: number) => {
+          width.value = value;
+        },
+      });
+      return () => h(Probe);
+    },
+  });
+
+  const wrapper = mount(Parent);
+  return {
+    wrapper,
+    setWidth: (value: number) => {
+      widthHandle.current = value;
+    },
+  };
+}
+
+describe('Reminder panel adaptation (V2 §6.4)', () => {
+  it('shows the group switcher bar and keeps the master switch in the narrow (split) tier', async () => {
+    const { wrapper, setWidth } = mountReminderPanelAdaptationProbe(450);
+
+    expect(wrapper.find('[data-testid="reminder-group-switcher-bar"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="reminder-group-sidebar"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="reminder-master-switch"]').exists()).toBe(true);
+
+    // Focus / wide restores the full sidebar; master switch remains reachable
+    setWidth(1200);
+    await nextTick();
+    expect(wrapper.find('[data-testid="reminder-group-switcher-bar"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="reminder-group-sidebar"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="reminder-master-switch"]').exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## 概要

UI 重构 V2 **S2 面板内容改造切片：Reminder**（`docs/UI_REDESIGN_V2_PLAN.md` §6.4 / §7）。

分组侧栏在 split 窄档收为顶部下拉；focus 档恢复完整侧栏；全局提醒总开关任何档位保持面板头可达。

## 变更

**Reminder 模块（§6.4）**
- 新增 `ReminderGroupSwitcherBar`：窄档分组下拉（全部提醒 + 各组计数 + 新建分组）+ 新建提醒；`create-reminder-template-button` testid 契约随迁
- `ReminderLinearView`：`usePanelWidth()` 驱动窄/宽二选一；宽档完整 `reminder-group-sidebar`，窄档顶部 switcher
- 全局 master switch 始终渲染在面板头（`reminder-master-switch`），不再被 `md:flex` 视口断点隐藏
- 搜索框 / 模板网格改为 `@*/panel` 容器查询
- 单测 `reminderPanelAdaptation.spec.ts`：narrow=switcher、wide=sidebar、master 始终可达

## 验证

- ✅ app-vue lint / typecheck / test（**199** 通过，0 lint error）+ web vue-tsc
- ✅ MSW mock 真浏览器冒烟 **14/14**（同 1280px 视口）：
  - split：`reminder-group-switcher-bar` 可见、sidebar 隐藏、master switch 可达、create testid 在
  - focus：switcher 隐藏、sidebar 可见、master 仍可达、网格容器查询 class 生效（focus 下 5 列）

## 说明

- 路由契约不变：`/reminders` 落地
- testid 契约保留并随迁（`create-reminder-template-button` / `reminder-linear-heading`）
- 不含既有 MSW/错误边界收尾（统一修）
- 下一切片：S2-Notification（§6.6，胶囊预览浮层 + 完整信箱归档页）