### PR TITLE
refactor(setting): S2 panel adaptation — focus-on-enter + two-tier groups + tab contract (V2 Settings/§7)

### DIFF
--- a/packages/app-vue/src/modules/setting/components/AISettings.vue
+++ b/packages/app-vue/src/modules/setting/components/AISettings.vue
@@ -5,7 +5,7 @@
       <CardDescription>{{ t('setting.ai.description') }}</CardDescription>
     </CardHeader>
     <CardContent class="space-y-6">
-      <div class="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+      <div class="grid gap-6 @3xl/panel:grid-cols-[1.05fr_0.95fr]">
         <div class="space-y-6">
           <div class="space-y-3 rounded-lg border border-border/70 bg-muted/20 p-4">
             <div class="space-y-1">
@@ -90,7 +90,7 @@
                 </a>
               </div>
 
-              <div class="mt-3 flex flex-col gap-2 sm:flex-row">
+              <div class="mt-3 flex flex-col gap-2 @2xl/panel:flex-row">
                 <Input
                   v-model="presetApiKeys[template.id]"
                   type="password"

--- a/packages/app-vue/src/modules/setting/components/ExperimentalSettings.vue
+++ b/packages/app-vue/src/modules/setting/components/ExperimentalSettings.vue
@@ -51,7 +51,7 @@
         <AlertDescription>{{ t('setting.experimental.noFeatures') }}</AlertDescription>
       </Alert>
 
-      <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div v-else class="grid grid-cols-1 gap-4 @2xl/panel:grid-cols-2">
         <Card
           v-for="feature in availableFeatures"
           :key="feature.key"

--- a/packages/app-vue/src/modules/setting/components/LocaleSettings.vue
+++ b/packages/app-vue/src/modules/setting/components/LocaleSettings.vue
@@ -4,7 +4,7 @@
       <CardTitle>{{ t('setting.locale.title') }}</CardTitle>
     </CardHeader>
     <CardContent class="space-y-6">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="grid grid-cols-1 gap-6 @2xl/panel:grid-cols-2">
         <!-- Language -->
         <div class="space-y-2">
           <Label for="language-select">{{ t('setting.locale.language') }}</Label>

--- a/packages/app-vue/src/modules/setting/components/PrivacySettings.vue
+++ b/packages/app-vue/src/modules/setting/components/PrivacySettings.vue
@@ -117,7 +117,7 @@
           <Settings class="h-4 w-4 mr-2" />
           {{ t('setting.privacy.dataManagement') }}
         </Label>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div class="grid grid-cols-1 gap-3 @2xl/panel:grid-cols-3">
           <Button variant="outline" class="w-full" @click="emit('exportData')">
             <Download class="h-4 w-4 mr-2" />
             {{ t('setting.privacy.exportData') }}

--- a/packages/app-vue/src/modules/setting/components/SettingAdvancedActions.vue
+++ b/packages/app-vue/src/modules/setting/components/SettingAdvancedActions.vue
@@ -11,7 +11,7 @@
 
     <CardContent class="p-4 space-y-6">
       <!-- Export/Import Settings -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div class="grid grid-cols-1 gap-3 @2xl/panel:grid-cols-2">
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
             <Button variant="outline" class="w-full">
@@ -38,7 +38,7 @@
       </div>
 
       <!-- Export/Import All User Data -->
-      <div v-if="dataPortabilityAvailable" class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div v-if="dataPortabilityAvailable" class="grid grid-cols-1 gap-3 @2xl/panel:grid-cols-2">
         <Button variant="outline" class="w-full" :disabled="exportingData" @click="emit('exportAllData')">
           <Download class="h-4 w-4 mr-2" />
           {{ exportingData ? 'Exporting...' : 'Export All Data' }}
@@ -53,7 +53,7 @@
       <p v-if="dataPortabilityResult" class="text-xs text-muted-foreground">{{ dataPortabilityResult }}</p>
 
       <!-- Backup & Restore -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div class="grid grid-cols-1 gap-3 @2xl/panel:grid-cols-2">
         <Button variant="outline" class="w-full" @click="emit('createBackup')">
           <Save class="h-4 w-4 mr-2" />
           {{ t('setting.advanced.createBackup') }}
@@ -94,7 +94,7 @@
           {{ t('setting.advanced.cloudSync') }}
         </h3>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div class="grid grid-cols-1 gap-3 @2xl/panel:grid-cols-2">
           <Button variant="outline" class="w-full" :disabled="syncing" @click="emit('cloudSync')">
             <CloudUpload class="h-4 w-4 mr-2" />
             {{ syncing ? t('setting.advanced.syncing') : t('setting.advanced.syncAllDevices') }}

--- a/packages/app-vue/src/modules/setting/components/UserFilesSettings.vue
+++ b/packages/app-vue/src/modules/setting/components/UserFilesSettings.vue
@@ -50,7 +50,7 @@
       </div>
 
       <!-- Actions -->
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2">
+      <div class="grid grid-cols-1 gap-3 pt-2 @2xl/panel:grid-cols-3">
         <Button variant="outline" class="w-full" :disabled="loading" @click="pickDirectory">
           <Loader2 v-if="pickLoading" class="h-4 w-4 mr-2 animate-spin" />
           <FolderInput v-else class="h-4 w-4 mr-2" />

--- a/packages/app-vue/src/modules/setting/views/UserSettingsView.vue
+++ b/packages/app-vue/src/modules/setting/views/UserSettingsView.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 /**
- * UserSettingsView — 设置页（UI_PAGE_REDESIGN_PLAN §13）
+ * UserSettingsView — 设置页（UI 重构 V2 § Settings / §7；沿 V1 §13 分组方案）
  *
- * 10 个平铺 Tab 重组为 6 组，左侧垂直分组导航（w-48）+ 右侧内容 max-w-3xl：
+ * 10 个平铺 Tab 重组为 6 组：
  *   外观与语言 / AI / 通知与提醒 / 账户与隐私（账户中心迁入）/ 数据 / 高级
+ * 面板两档（V2 §7）：
+ *   - 窄档（split）：顶部分组横向 tabs
+ *   - 宽档（focus）：左侧垂直分组导航（w-48）+ 右侧内容 max-w-3xl
  * `?tab=` 查询参数为分组深链契约（/account/center redirect 依赖）。
- * <md 分组导航转顶部横向滚动条。
  * `settings-tab-{value}` testid 保留（appearance / notifications 被 e2e 锚定）。
+ * 进入 Settings 默认 focus 由 shell `shouldOpenInFocus('setting')` 承担。
  */
 
 import { ref, onMounted, computed, watch } from 'vue';
@@ -30,6 +33,7 @@ import { useUserSetting } from '../composables/useUserSetting';
 import { useDataPortability } from '../composables/useDataPortability';
 import { applyThemeMode } from '../composables';
 import { usePresentationPreferenceStore } from '../stores/presentation-preference-store';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
 import type { AppLocale } from '../../../plugins/i18n';
 import type { UserSettingPreferences } from '@dailyuse/contracts/setting';
 import { inject } from 'vue';
@@ -40,6 +44,8 @@ const route = useRoute();
 const router = useRouter();
 const presentationStore = usePresentationPreferenceStore();
 const desktopApi = inject(DESKTOP_AUTH_API_KEY, undefined);
+// 面板两档（V2 §7）：窄档顶部分组横向 tabs，宽档恢复左侧垂直分组导航。
+const { isNarrow } = usePanelWidth();
 
 const {
   userSetting,
@@ -355,10 +361,21 @@ onMounted(async () => {
         <Loader2 class="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
 
-      <div v-else class="mt-6 flex flex-col gap-6 md:flex-row">
-        <!-- 左侧分组导航（<md 转顶部横向滚动条，§13-8） -->
+      <div
+        v-else
+        class="mt-6 flex gap-6"
+        :class="isNarrow ? 'flex-col' : 'flex-row'"
+        data-testid="settings-panel-layout"
+      >
+        <!-- 窄档：顶部分组横向 tabs；宽档：左侧垂直分组导航（V2 §7 / V1 §13-8） -->
         <nav
-          class="flex shrink-0 gap-1 overflow-x-auto md:w-48 md:flex-col md:overflow-visible"
+          class="flex shrink-0 gap-1"
+          :class="
+            isNarrow
+              ? 'overflow-x-auto'
+              : 'w-48 flex-col overflow-visible'
+          "
+          :data-testid="isNarrow ? 'settings-group-tabs' : 'settings-group-sidebar'"
           :aria-label="t('setting.title')"
         >
           <button

--- a/packages/app-vue/src/modules/setting/views/settingsPanelAdaptation.spec.ts
+++ b/packages/app-vue/src/modules/setting/views/settingsPanelAdaptation.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { computed, defineComponent, h, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { providePanelWidth, usePanelWidth } from '../../../layouts/shell/usePanelWidth';
+
+/**
+ * Lightweight probe for S2-Settings panel adaptation (V2 Settings / §7):
+ * - narrow (split): group navigation is top horizontal tabs
+ * - wide (focus): group navigation is left vertical sidebar
+ * - `?tab=` deep-link contract remains the active group selector surface
+ *
+ * Mirrors UserSettingsView's tier surface without mounting the full settings
+ * form (stores/services/file pickers).
+ */
+function mountSettingsPanelAdaptationProbe(initialWidth: number) {
+  const widthHandle: { current: number } = { current: initialWidth };
+
+  const Probe = defineComponent({
+    name: 'SettingsPanelAdaptationProbe',
+    setup() {
+      const { isNarrow } = usePanelWidth();
+      const activeTab = ref<'appearance' | 'account'>('appearance');
+      const showTabs = computed(() => isNarrow.value);
+      const showSidebar = computed(() => !isNarrow.value);
+
+      return () =>
+        h(
+          'div',
+          {
+            'data-testid': 'settings-panel-layout',
+            'data-narrow': String(isNarrow.value),
+          },
+          [
+            showTabs.value
+              ? h('nav', { 'data-testid': 'settings-group-tabs' }, [
+                  h(
+                    'button',
+                    {
+                      'data-testid': 'settings-tab-appearance',
+                      onClick: () => {
+                        activeTab.value = 'appearance';
+                      },
+                    },
+                    'appearance',
+                  ),
+                  h(
+                    'button',
+                    {
+                      'data-testid': 'settings-tab-account',
+                      onClick: () => {
+                        activeTab.value = 'account';
+                      },
+                    },
+                    'account',
+                  ),
+                ])
+              : null,
+            showSidebar.value
+              ? h('nav', { 'data-testid': 'settings-group-sidebar' }, [
+                  h(
+                    'button',
+                    {
+                      'data-testid': 'settings-tab-appearance',
+                      onClick: () => {
+                        activeTab.value = 'appearance';
+                      },
+                    },
+                    'appearance',
+                  ),
+                  h(
+                    'button',
+                    {
+                      'data-testid': 'settings-tab-account',
+                      onClick: () => {
+                        activeTab.value = 'account';
+                      },
+                    },
+                    'account',
+                  ),
+                ])
+              : null,
+            h('div', { 'data-testid': 'settings-active-tab' }, activeTab.value),
+          ],
+        );
+    },
+  });
+
+  const Parent = defineComponent({
+    setup() {
+      const { width } = providePanelWidth();
+      width.value = widthHandle.current;
+      Object.defineProperty(widthHandle, 'current', {
+        get: () => width.value ?? initialWidth,
+        set: (value: number) => {
+          width.value = value;
+        },
+      });
+      return () => h(Probe);
+    },
+  });
+
+  const wrapper = mount(Parent);
+  return {
+    wrapper,
+    setWidth: (value: number) => {
+      widthHandle.current = value;
+    },
+  };
+}
+
+describe('Settings panel adaptation (V2 Settings / §7)', () => {
+  it('uses top group tabs in narrow (split) and sidebar groups in wide (focus)', async () => {
+    const { wrapper, setWidth } = mountSettingsPanelAdaptationProbe(450);
+
+    expect(wrapper.find('[data-testid="settings-group-tabs"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="settings-group-sidebar"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="settings-tab-appearance"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="settings-tab-account"]').exists()).toBe(true);
+
+    await wrapper.get('[data-testid="settings-tab-account"]').trigger('click');
+    await nextTick();
+    expect(wrapper.get('[data-testid="settings-active-tab"]').text()).toBe('account');
+
+    // Focus / wide restores the vertical group sidebar; tab contract remains
+    setWidth(1200);
+    await nextTick();
+    expect(wrapper.find('[data-testid="settings-group-tabs"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="settings-group-sidebar"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="settings-tab-account"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="settings-active-tab"]').text()).toBe('account');
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
S2-Settings 面板化（V2 § Settings / §7）。V1 的 6 分组与 `?tab=` 账户深链已在 main；本 PR 只做面板两档适配。

- `UserSettingsView`：`usePanelWidth` 两档——窄档顶部分组横向 tabs，宽档左侧垂直分组导航
- 设置子组件网格 `sm/md/lg` 视口断点 → `@*/panel` 容器查询
- `settings-tab-*` 与 `?tab=` 契约保持；进入默认 focus 由既有 `shouldOpenInFocus('setting')` 承担（未改 shell）
- 单测 probe：窄 tabs / 宽 sidebar + account 分组切换

## Test plan
- [x] `pnpm nx run-many -t lint typecheck test -p app-vue`（lint 0 error；test 200 pass，含 `settingsPanelAdaptation`）
- [x] `pnpm nx run web:typecheck`
- [x] MSW smoke @5176 21/21：`/settings` focus-on-enter；split=top tabs / focus=sidebar；`/account/center` → `/settings?tab=account` focus
- [x] 写域隔离：未改 notification / WindowHeader / plan docs