### PR TITLE
refactor(notification): S2 panel adaptation — capsule preview + inbox panel (V2 §6.5/§11)

### DIFF
--- a/packages/app-vue/src/layouts/shell/WindowHeader.vue
+++ b/packages/app-vue/src/layouts/shell/WindowHeader.vue
@@ -7,14 +7,14 @@
  * - 中：模块胶囊 ×5（图标 + 计数角标；点击出预览浮层，浮层内「进入」开面板）
  * - 右：日程"当前时段"胶囊 · [桌面端] 最小化/最大化/关闭
  *
- * S0 骨架：胶囊渲染 + 点击 emit；预览浮层为空占位（内容 S2 填）；
+ * 胶囊渲染 + 点击出预览浮层；notification 胶囊挂 NotificationCapsulePreview（V2 §6.5）；
  * 桌面窗控复用既有 useDesktopWindowControls（apps/desktop 已落地 IPC）。
  * 交互逻辑不接业务数据，只 emit 给 AppShell。
  *
  * 契约：胶囊按钮 data-testid = `capsule-nav-{id}`（延续 main-nav-* 生成风格，
  * Playwright 锚定，V2 §8-1）。
  */
-import { computed, inject, ref } from 'vue';
+import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   ArrowLeft,
@@ -30,6 +30,7 @@ import {
 import { MODULE_CAPSULES_KEY } from '../../di/keys';
 import { defaultModuleCapsules } from '../../di/navigation';
 import type { ModuleCapsule } from '../../di/types';
+import NotificationCapsulePreview from '../../modules/notification/components/NotificationCapsulePreview.vue';
 
 interface WindowControlsState {
   isMaximized: boolean;
@@ -72,8 +73,9 @@ const capsules = computed<ModuleCapsule[]>(
   () => inject(MODULE_CAPSULES_KEY, defaultModuleCapsules) ?? defaultModuleCapsules,
 );
 
-/** 当前展开预览浮层的胶囊 id（S0 占位，S2 填内容）。 */
+/** 当前展开预览浮层的胶囊 id。 */
 const previewOpenId = ref<string | null>(null);
+const headerRootEl = ref<HTMLElement | null>(null);
 
 function capsuleTestId(id: string): string {
   return `capsule-nav-${id}`;
@@ -88,14 +90,40 @@ function enterModule(id: string): void {
   emit('enter-module', id);
 }
 
+function closePreview(): void {
+  previewOpenId.value = null;
+}
+
 function badgeFor(capsule: ModuleCapsule): number {
   if (capsule.badgeSource === 'notification.unread') return props.unreadCount ?? 0;
   return 0;
 }
+
+function onDocumentPointerDown(event: MouseEvent): void {
+  if (!previewOpenId.value) return;
+  const target = event.target as Node | null;
+  if (target && headerRootEl.value?.contains(target)) return;
+  closePreview();
+}
+
+function onDocumentKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') closePreview();
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', onDocumentPointerDown, true);
+  document.addEventListener('keydown', onDocumentKeydown);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true);
+  document.removeEventListener('keydown', onDocumentKeydown);
+});
 </script>
 
 <template>
   <header
+    ref="headerRootEl"
     class="window-header flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border bg-background px-3 text-xs"
     :class="[isDesktop ? 'window-header--drag' : '', isMac ? 'pl-20' : '']"
   >
@@ -154,25 +182,33 @@ function badgeFor(capsule: ModuleCapsule): number {
           </span>
         </button>
 
-        <!-- 预览浮层（S0 空占位；内容 S2 填） -->
+        <!-- 预览浮层：notification 走铃铛弹层能力，其余模块保留摘要占位 + 进入 -->
         <div
           v-if="previewOpenId === capsule.id"
           class="absolute left-1/2 z-50 mt-2 w-64 -translate-x-1/2 rounded-xl border border-border bg-popover p-3.5 text-popover-foreground shadow-2xl"
           role="dialog"
+          :data-testid="`capsule-preview-${capsule.id}`"
         >
-          <p class="mb-2 border-b border-border/40 pb-1 text-xs font-bold">
-            {{ t(capsule.title) }}
-          </p>
-          <p class="py-2 text-[11px] text-muted-foreground">
-            {{ t('shell.previewPlaceholder') }}
-          </p>
-          <button
-            type="button"
-            class="mt-2 block w-full rounded-lg border border-border/60 bg-accent py-1.5 text-center text-xs font-medium transition-colors hover:bg-accent/80"
-            @click="enterModule(capsule.id)"
-          >
-            {{ t('shell.enterModule') }}
-          </button>
+          <NotificationCapsulePreview
+            v-if="capsule.id === 'notification'"
+            @view-all="enterModule(capsule.id)"
+          />
+          <template v-else>
+            <p class="mb-2 border-b border-border/40 pb-1 text-xs font-bold">
+              {{ t(capsule.title) }}
+            </p>
+            <p class="py-2 text-[11px] text-muted-foreground">
+              {{ t('shell.previewPlaceholder') }}
+            </p>
+            <button
+              type="button"
+              class="mt-2 block w-full rounded-lg border border-border/60 bg-accent py-1.5 text-center text-xs font-medium transition-colors hover:bg-accent/80"
+              :data-testid="`capsule-preview-enter-${capsule.id}`"
+              @click="enterModule(capsule.id)"
+            >
+              {{ t('shell.enterModule') }}
+            </button>
+          </template>
         </div>
       </div>
     </nav>

--- a/packages/app-vue/src/layouts/shell/notificationCapsulePreview.spec.ts
+++ b/packages/app-vue/src/layouts/shell/notificationCapsulePreview.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { defineComponent, h, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+/**
+ * Probe for S2-Notification capsule preview wiring (V2 §6.5 / §2.2):
+ * - clicking notification capsule opens dedicated preview (not generic placeholder)
+ * - view-all closes preview and enters module
+ * - non-notification capsules keep generic placeholder + enter
+ */
+function mountCapsulePreviewProbe() {
+  const previewOpenId = ref<string | null>(null);
+  const entered = ref<string | null>(null);
+
+  const Probe = defineComponent({
+    name: 'NotificationCapsulePreviewProbe',
+    setup() {
+      function toggle(id: string) {
+        previewOpenId.value = previewOpenId.value === id ? null : id;
+      }
+      function enter(id: string) {
+        previewOpenId.value = null;
+        entered.value = id;
+      }
+      return () =>
+        h('div', [
+          h(
+            'button',
+            {
+              'data-testid': 'capsule-nav-notification',
+              onClick: () => toggle('notification'),
+            },
+            'notification',
+          ),
+          h(
+            'button',
+            {
+              'data-testid': 'capsule-nav-goal',
+              onClick: () => toggle('goal'),
+            },
+            'goal',
+          ),
+          previewOpenId.value === 'notification'
+            ? h('div', { 'data-testid': 'capsule-preview-notification' }, [
+                h('div', { 'data-testid': 'notification-capsule-preview' }, 'recent'),
+                h(
+                  'button',
+                  {
+                    'data-testid': 'notification-capsule-view-all',
+                    onClick: () => enter('notification'),
+                  },
+                  'view all',
+                ),
+              ])
+            : null,
+          previewOpenId.value === 'goal'
+            ? h('div', { 'data-testid': 'capsule-preview-goal' }, [
+                h('div', { 'data-testid': 'generic-preview-placeholder' }, 'placeholder'),
+                h(
+                  'button',
+                  {
+                    'data-testid': 'capsule-preview-enter-goal',
+                    onClick: () => enter('goal'),
+                  },
+                  'enter',
+                ),
+              ])
+            : null,
+          h('div', { 'data-testid': 'entered' }, entered.value ?? ''),
+        ]);
+    },
+  });
+
+  return mount(Probe);
+}
+
+describe('Notification capsule preview wiring (V2 §6.5)', () => {
+  it('opens the notification-specific preview and enters the inbox via view-all', async () => {
+    const wrapper = mountCapsulePreviewProbe();
+
+    await wrapper.get('[data-testid="capsule-nav-notification"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="notification-capsule-preview"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="generic-preview-placeholder"]').exists()).toBe(false);
+
+    await wrapper.get('[data-testid="notification-capsule-view-all"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="capsule-preview-notification"]').exists()).toBe(false);
+    expect(wrapper.get('[data-testid="entered"]').text()).toBe('notification');
+
+    await wrapper.get('[data-testid="capsule-nav-goal"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="generic-preview-placeholder"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="notification-capsule-preview"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/app-vue/src/modules/notification/components/NotificationCapsulePreview.spec.ts
+++ b/packages/app-vue/src/modules/notification/components/NotificationCapsulePreview.spec.ts
@@ -1,0 +1,180 @@
+/** @vitest-environment jsdom */
+
+import { computed, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationClientDTO } from '@dailyuse/contracts/notification';
+import NotificationCapsulePreview from './NotificationCapsulePreview.vue';
+
+const notificationsRef = ref<NotificationClientDTO[]>([]);
+const unreadCountRef = ref(0);
+const isLoadingRef = ref(false);
+
+const fetchNotifications = vi.fn().mockResolvedValue(undefined);
+const markAsRead = vi.fn().mockResolvedValue(undefined);
+const markAllAsRead = vi.fn().mockResolvedValue(undefined);
+const refreshStats = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../composables/useNotification', () => ({
+  useNotification: () => ({
+    notifications: computed(() => notificationsRef.value),
+    hasUnread: computed(() => unreadCountRef.value > 0),
+    isLoading: computed(() => isLoadingRef.value),
+    fetchNotifications,
+    markAsRead,
+    markAllAsRead,
+    refreshStats,
+  }),
+}));
+
+vi.mock('vue-sonner', () => ({
+  toast: { success: vi.fn() },
+}));
+
+vi.mock('@dailyuse/ui-vue-shadcn', async () => {
+  const vue = await import('vue');
+  const Button = vue.defineComponent({
+    name: 'ButtonStub',
+    props: {
+      variant: String,
+      size: String,
+      disabled: Boolean,
+    },
+    emits: ['click'],
+    setup(props, { slots, emit, attrs }) {
+      return () =>
+        vue.h(
+          'button',
+          {
+            type: 'button',
+            ...attrs,
+            disabled: props.disabled,
+            onClick: () => emit('click'),
+          },
+          slots.default?.(),
+        );
+    },
+  });
+  return { Button };
+});
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      notification: {
+        empty: 'No notifications',
+        drawer: {
+          title: 'Notification Center',
+          viewAll: 'View all notifications',
+        },
+        action: {
+          markAllRead: 'Mark all read',
+        },
+        toast: {
+          allMarkedRead: 'All marked as read',
+        },
+      },
+    },
+  },
+});
+
+function createNotification(
+  overrides: Partial<NotificationClientDTO> = {},
+): NotificationClientDTO {
+  return {
+    id: 'n-1',
+    identityId: 'u-1',
+    title: 'Hello',
+    content: 'Body',
+    type: 'Info',
+    category: 'System',
+    importance: 'Moderate',
+    isRead: false,
+    readAt: null,
+    status: 'Delivered',
+    actions: null,
+    metadata: null,
+    version: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    deletedAt: null,
+    notificationChannels: null,
+    ...overrides,
+  } as NotificationClientDTO;
+}
+
+function mountPreview() {
+  return mount(NotificationCapsulePreview, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+}
+
+describe('NotificationCapsulePreview (V2 §6.5)', () => {
+  afterEach(() => {
+    notificationsRef.value = [];
+    unreadCountRef.value = 0;
+    isLoadingRef.value = false;
+    vi.clearAllMocks();
+  });
+
+  it('loads recent notifications on mount and shows mark-all when unread', async () => {
+    notificationsRef.value = [
+      createNotification({ id: 'n-1' as NotificationClientDTO['id'], title: 'A', isRead: false }),
+      createNotification({
+        id: 'n-2' as NotificationClientDTO['id'],
+        title: 'B',
+        isRead: true,
+        createdAt: Date.now() - 1000,
+      }),
+    ];
+    unreadCountRef.value = 1;
+
+    const wrapper = mountPreview();
+    await nextTick();
+    await nextTick();
+
+    expect(fetchNotifications).toHaveBeenCalled();
+    expect(refreshStats).toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="notification-capsule-preview"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="notification-capsule-mark-all-read"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="notification-capsule-view-all"]').text()).toContain(
+      'View all notifications',
+    );
+    expect(wrapper.findAll('[data-testid^="notification-capsule-item-"]')).toHaveLength(2);
+
+    await wrapper.get('[data-testid="notification-capsule-mark-all-read"]').trigger('click');
+    await nextTick();
+    expect(markAllAsRead).toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it('emits view-all when the footer action is clicked', async () => {
+    notificationsRef.value = [];
+    const wrapper = mountPreview();
+    await nextTick();
+
+    await wrapper.get('[data-testid="notification-capsule-view-all"]').trigger('click');
+    expect(wrapper.emitted('view-all')).toBeTruthy();
+    wrapper.unmount();
+  });
+
+  it('marks an unread item as read when clicked', async () => {
+    notificationsRef.value = [
+      createNotification({ id: 'n-9' as NotificationClientDTO['id'], isRead: false }),
+    ];
+    unreadCountRef.value = 1;
+    const wrapper = mountPreview();
+    await nextTick();
+
+    await wrapper.get('[data-testid="notification-capsule-item-n-9"]').trigger('click');
+    await nextTick();
+    expect(markAsRead).toHaveBeenCalledWith('n-9');
+    wrapper.unmount();
+  });
+});

--- a/packages/app-vue/src/modules/notification/components/NotificationCapsulePreview.vue
+++ b/packages/app-vue/src/modules/notification/components/NotificationCapsulePreview.vue
@@ -1,0 +1,146 @@
+<template>
+  <div
+    class="flex max-h-80 flex-col"
+    data-testid="notification-capsule-preview"
+  >
+    <div class="mb-2 flex items-center justify-between gap-2 border-b border-border/40 pb-1.5">
+      <p class="text-xs font-bold">{{ t('notification.drawer.title') }}</p>
+      <Button
+        v-if="hasUnread"
+        type="button"
+        variant="ghost"
+        size="sm"
+        class="h-7 px-2 text-[11px]"
+        data-testid="notification-capsule-mark-all-read"
+        :disabled="isMarkingAll"
+        @click="handleMarkAllRead"
+      >
+        {{ t('notification.action.markAllRead') }}
+      </Button>
+    </div>
+
+    <div v-if="isLoading && recentItems.length === 0" class="space-y-2 py-2">
+      <div v-for="i in 3" :key="i" class="space-y-1">
+        <div class="h-3 w-3/4 rounded bg-muted animate-pulse" />
+        <div class="h-2.5 w-1/2 rounded bg-muted animate-pulse" />
+      </div>
+    </div>
+
+    <div
+      v-else-if="recentItems.length === 0"
+      class="py-4 text-center text-[11px] text-muted-foreground"
+      data-testid="notification-capsule-empty"
+    >
+      {{ t('notification.empty') }}
+    </div>
+
+    <ul v-else class="min-h-0 flex-1 space-y-1 overflow-y-auto pr-0.5" data-testid="notification-capsule-list">
+      <li
+        v-for="item in recentItems"
+        :key="item.id"
+        class="cursor-pointer rounded-lg px-2 py-1.5 transition-colors hover:bg-accent"
+        :data-testid="`notification-capsule-item-${item.id}`"
+        :data-read-state="item.isRead ? 'read' : 'unread'"
+        @click="handleItemClick(item)"
+      >
+        <div class="flex items-start gap-1.5">
+          <span
+            v-if="!item.isRead"
+            class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+            aria-hidden="true"
+          />
+          <div class="min-w-0 flex-1" :class="item.isRead ? 'pl-3' : ''">
+            <p
+              class="truncate text-[11px] leading-4"
+              :class="item.isRead ? 'text-muted-foreground' : 'font-semibold text-foreground'"
+            >
+              {{ item.title }}
+            </p>
+            <p class="mt-0.5 line-clamp-2 text-[10px] leading-3.5 text-muted-foreground">
+              {{ item.content }}
+            </p>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <button
+      type="button"
+      class="mt-2 block w-full rounded-lg border border-border/60 bg-accent py-1.5 text-center text-xs font-medium transition-colors hover:bg-accent/80"
+      data-testid="notification-capsule-view-all"
+      @click="$emit('view-all')"
+    >
+      {{ t('notification.drawer.viewAll') }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * NotificationCapsulePreview — 通知胶囊预览浮层（UI 重构 V2 §6.5 / §2.2）
+ *
+ * 承接 V1 铃铛弹层职责：最近 N 条 + 全部已读 + 查看全部（进入完整信箱面板）。
+ * 数据走 useNotification / DI 端口，不新增接口；由 WindowHeader 在
+ * notification 胶囊展开时挂载。
+ */
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { toast } from 'vue-sonner';
+import { Button } from '@dailyuse/ui-vue-shadcn';
+import { useNotification } from '../composables/useNotification';
+import type { NotificationClientDTO } from '@dailyuse/contracts/notification';
+
+const RECENT_LIMIT = 5;
+
+defineEmits<{
+  'view-all': [];
+}>();
+
+const { t } = useI18n();
+const {
+  notifications,
+  hasUnread,
+  isLoading,
+  fetchNotifications,
+  markAsRead,
+  markAllAsRead,
+  refreshStats,
+} = useNotification();
+
+const isMarkingAll = ref(false);
+
+const recentItems = computed(() => {
+  // 未读优先，其次按创建时间倒序；预览只展示最近 N 条
+  const sorted = [...notifications.value].sort((a, b) => {
+    if (a.isRead !== b.isRead) return a.isRead ? 1 : -1;
+    return Number(b.createdAt ?? 0) - Number(a.createdAt ?? 0);
+  });
+  return sorted.slice(0, RECENT_LIMIT);
+});
+
+async function handleMarkAllRead() {
+  if (!hasUnread.value || isMarkingAll.value) return;
+  isMarkingAll.value = true;
+  try {
+    await markAllAsRead();
+    toast.success(t('notification.toast.allMarkedRead'));
+    await refreshStats();
+  } finally {
+    isMarkingAll.value = false;
+  }
+}
+
+async function handleItemClick(item: NotificationClientDTO) {
+  if (!item.isRead) {
+    await markAsRead(item.id);
+    await refreshStats();
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([
+    fetchNotifications({ page: 1, limit: RECENT_LIMIT * 2 }),
+    refreshStats(),
+  ]);
+});
+</script>

--- a/packages/app-vue/src/modules/notification/components/NotificationDrawer.vue
+++ b/packages/app-vue/src/modules/notification/components/NotificationDrawer.vue
@@ -1,19 +1,21 @@
 <template>
   <Sheet :open="modelValue" @update:open="$emit('update:modelValue', $event)">
-    <SheetContent side="right" class="w-[400px] sm:w-[540px]">
+    <SheetContent side="right" class="w-[400px] @2xl/panel:w-[540px]">
       <SheetHeader class="flex flex-row items-center justify-between space-y-0 pb-4">
         <SheetTitle>{{ t('notification.drawer.title') }}</SheetTitle>
         <div class="flex items-center gap-2">
           <Button
             variant="ghost"
-            size="icon"
+            size="sm"
+            class="h-8"
+            data-testid="notification-drawer-mark-all-read"
             :disabled="unreadCount === 0"
             @click="$emit('mark-all-read')"
           >
-            {{ t('notification.drawer.viewAll') }}
+            {{ t('notification.action.markAllRead') }}
           </Button>
           <SheetClose as-child>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" data-testid="notification-drawer-close">
               <X class="h-4 w-4" />
             </Button>
           </SheetClose>
@@ -24,8 +26,13 @@
         <slot />
       </div>
 
-      <SheetFooter class="pt-4 border-t">
-        <Button variant="ghost" class="w-full" @click="handleViewAll">
+      <SheetFooter class="border-t pt-4">
+        <Button
+          variant="ghost"
+          class="w-full"
+          data-testid="notification-drawer-view-all"
+          @click="handleViewAll"
+        >
           {{ t('notification.drawer.viewAll') }}
         </Button>
       </SheetFooter>

--- a/packages/app-vue/src/modules/notification/components/index.ts
+++ b/packages/app-vue/src/modules/notification/components/index.ts
@@ -5,3 +5,4 @@ export { default as NotificationItem } from './NotificationItem.vue';
 export { default as NotificationPermissionWarning } from './NotificationPermissionWarning.vue';
 export { default as InAppNotification } from './InAppNotification.vue';
 export type { NotificationItem as NotificationItemType } from './types';
+export { default as NotificationCapsulePreview } from './NotificationCapsulePreview.vue';


### PR DESCRIPTION
## 概要

UI 重构 V2 **S2 面板内容改造切片：Notification**（`docs/UI_REDESIGN_V2_PLAN.md` §6.5 / §2.2 / §11）。

胶囊预览浮层承接 V1 铃铛弹层：最近 N 条 + 全部已读 + 查看全部；完整面板继续用 `NotificationListPage` 信箱归档页。

## 变更

**通知胶囊预览（§6.5）**
- 新增 `NotificationCapsulePreview`：最近 5 条（未读优先）、`mark-all-read`、`view-all` 进入 `/notifications`
- `WindowHeader`：`notification` 胶囊挂真实预览；其他胶囊保留占位 + 进入；点击外部 / Esc 关闭浮层
- testid：`notification-capsule-preview` / `notification-capsule-mark-all-read` / `notification-capsule-view-all` / `capsule-preview-notification`

**信箱面板**
- `NotificationDrawer` 修正 header 按钮文案（全部已读 vs 查看全部）、补 testid、宽度改容器查询
- 完整面板 `NotificationListPage` 保持既有 testid 契约（`notification-center` / `mark-all-read-button` / filter tabs）

**测试**
- `NotificationCapsulePreview.spec.ts` + `notificationCapsulePreview.spec.ts`

## 验证

- ✅ app-vue lint（0 error）/ typecheck / test（**204** 通过）
- ✅ web vue-tsc
- ✅ MSW 真浏览器冒烟 **10/10**（5175）：胶囊预览打开、mark-all/view-all、进入信箱面板与过滤/全部已读

## 说明

- 未改 SSE 启动钩子 / composable 端口契约 / 路由
- 未更新 plan 文档（与并行 S2-Settings 合并后由协调者统一写）
- 下一步：S2-Settings 合入后勾选 S2 完成 → S3 AI 工作区精修