### PR TITLE
refactor(ai): UI redesign V2 S3 — AI 工作区精修（欢迎态/今日概览 + 工作流内嵌 + 产物开 Tab）

### DIFF
--- a/packages/app-vue/src/locales/en-US.ts
+++ b/packages/app-vue/src/locales/en-US.ts
@@ -198,6 +198,8 @@ export default {
       title: 'AI Chat',
       subtitle:
         'Keep conversations, model selection, and the composer in one dedicated workspace, similar to Gemini or GPT.',
+      welcomeTitle: 'What do you want to move forward today?',
+      welcomeDescription: 'Pick a shortcut card to start, or type below. Once messages exist, this becomes the conversation timeline.',
       emptyTitle: 'Start with a prompt',
       emptyDescription:
         'Pick a provider and model, then continue the conversation here. Saved chats stay in the sidebar so you can jump back in.',
@@ -238,6 +240,29 @@ export default {
             'Use the conversation to clarify the topic, source, and key takeaways, then create the markdown note directly in the background.',
         },
       },
+      shortcuts: {
+        chat: {
+          title: 'Just chat',
+          description: 'No fixed workflow—talk with AI to organize your thoughts.',
+          prefill: 'I want to talk through what I am working on…',
+        },
+        goalCreate: {
+          title: 'Plan a goal',
+          description: 'Clarify scope, success criteria, and timing, then draft a structured goal.',
+          prefill: 'Help me plan a goal:',
+        },
+        knowledgeGenerate: {
+          title: 'Write a knowledge note',
+          description: 'Clarify topic, sources, and takeaways, then save to the knowledge base.',
+          prefill: 'Turn the following into a knowledge note:',
+        },
+        knowledgeQa: {
+          title: 'Ask knowledge base',
+          description: 'Ask from indexed notes; grounded answers include citations.',
+          prefill: 'Using my knowledge base, answer:',
+        },
+      },
+
       workflow: {
         activeMode: 'Active Intent',
         toolButton: 'Intent',

--- a/packages/app-vue/src/locales/zh-CN.ts
+++ b/packages/app-vue/src/locales/zh-CN.ts
@@ -196,6 +196,8 @@ export default {
       eyebrow: 'AI Workspace',
       title: 'AI 对话',
       subtitle: '像 Gemini 或 GPT 一样，把会话、模型选择和输入区固定在同一工作区里。',
+      welcomeTitle: '今天想推进哪件事？',
+      welcomeDescription: '选一张快捷指令卡开始，或直接在下方输入。有会话消息时这里会切换为消息时间线。',
       emptyTitle: '从一个问题开始',
       emptyDescription:
         '选择提供商和模型，然后直接在这里持续对话。历史会话会保留在左侧，方便随时继续。',
@@ -231,6 +233,29 @@ export default {
           description: '先把主题、来源和想保留的重点聊清楚，确认后会直接在后台创建 Markdown 笔记。',
         },
       },
+      shortcuts: {
+        chat: {
+          title: '随便聊聊',
+          description: '没有固定流程，直接和 AI 对话整理思路。',
+          prefill: '我想先聊聊最近在推进的事……',
+        },
+        goalCreate: {
+          title: '规划一个目标',
+          description: '用对话澄清范围、成功标准与时间，再生成结构化草稿。',
+          prefill: '帮我规划一个目标：',
+        },
+        knowledgeGenerate: {
+          title: '写一篇知识笔记',
+          description: '先聊清主题、来源和要点，再落到知识库。',
+          prefill: '帮我把下面内容整理成一篇知识笔记：',
+        },
+        knowledgeQa: {
+          title: '问知识库',
+          description: '基于已索引笔记提问，有证据时会带引用。',
+          prefill: '基于我的知识库，回答：',
+        },
+      },
+
       workflow: {
         activeMode: '当前意图',
         toolButton: '意图',

--- a/packages/app-vue/src/modules/ai/components/AIContextPanel.vue
+++ b/packages/app-vue/src/modules/ai/components/AIContextPanel.vue
@@ -1,22 +1,23 @@
 <script setup lang="ts">
 /**
- * AIContextPanel — AI 工作台右栏三态容器（UI_PAGE_REDESIGN_PLAN §1）
+ * AIContextPanel — AI 工作区侧栏（V2 §6.0 精修）
  *
- * 三态：
- *   ① 空闲（无运行工作流）→ #idle（今日概览，≥xl 常驻；<lg 不渲染）
- *   ② 工作流运行 → #action-bar（生命周期操作条）+ #default（产物/证据面板）
- *   ③ 知识问答 → 同 ②（证据列表与接地校验由产物面板/操作条承载）
+ * V1 右栏三态：
+ *   ① 空闲今日概览 → 已迁到欢迎态主列（消息区下方）
+ *   ②/③ 工作流产物 → 主列消息时间线内嵌 + Composer 上方操作条
  *
- * 响应式：≥md 静态右栏；<md 底部浮层（沿用原契约，
- * `ai-context-panel` / `ai-context-panel-close` testid 不变）。
- * 布局容器不持有工作流状态——产物与操作条由 AIChatView 通过 slot 注入。
+ * 本组件仍保留作为工作流产物的可选窄侧栏容器（桌面 md+ / 移动浮层），
+ * 以维持 `ai-context-panel` / `ai-context-panel-close` testid 契约
+ * 与 AIChatView.spec 状态机断言。空闲态右栏不再渲染。
+ *
+ * 布局容器不持有工作流状态——产物由 AIChatView 通过 slot 注入。
  */
 import { useI18n } from 'vue-i18n';
 import { Button } from '@dailyuse/ui-vue-shadcn';
 import { X } from 'lucide-vue-next';
 
 defineProps<{
-  /** 是否有激活的工作流上下文（决定 ②/③ 还是 ①） */
+  /** 是否有激活的工作流上下文（决定是否渲染） */
   hasWorkflowContext: boolean;
   /** <md 时浮层是否展开 */
   open: boolean;
@@ -30,7 +31,6 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <!-- 工作流态：所有断点可见（<md 需 open） -->
   <aside
     v-if="hasWorkflowContext"
     class="fixed inset-x-0 bottom-0 z-40 max-h-[72vh] min-h-0 flex-col border-t bg-background shadow-xl md:static md:z-auto md:max-h-none md:w-96 md:shrink-0 md:border-l md:border-t-0 md:shadow-none"
@@ -58,35 +58,12 @@ const { t } = useI18n();
       </Button>
     </div>
 
-    <!-- ② 工作流操作条：与产物同屏，置顶 -->
+    <!-- Optional top strip (unused when actions live near composer/timeline) -->
     <slot name="action-bar" />
 
     <div class="min-h-0 flex-1 overflow-y-auto p-4">
       <div class="space-y-4">
         <slot />
-      </div>
-    </div>
-  </aside>
-
-  <!-- ① 空闲态：≥xl 常驻今日概览（<xl 不渲染，窄屏概览由 RN 端承担） -->
-  <aside
-    v-else
-    class="hidden w-96 shrink-0 flex-col border-l bg-background xl:flex"
-    data-testid="ai-context-panel-idle"
-  >
-    <div class="flex h-14 shrink-0 items-center border-b px-4">
-      <div class="min-w-0">
-        <p class="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-          {{ t('aiAssistant.chatPage.context.title') }}
-        </p>
-        <p class="truncate text-sm font-medium text-foreground">
-          {{ t('aiAssistant.chatPage.context.todayOverview') }}
-        </p>
-      </div>
-    </div>
-    <div class="min-h-0 flex-1 overflow-y-auto p-4">
-      <div class="space-y-4">
-        <slot name="idle" />
       </div>
     </div>
   </aside>

--- a/packages/app-vue/src/modules/ai/components/AIMessagePanel.spec.ts
+++ b/packages/app-vue/src/modules/ai/components/AIMessagePanel.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import AIMessagePanel from './AIMessagePanel.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      aiAssistant: {
+        dialogs: {
+          chat: {
+            you: 'You',
+            assistant: 'Assistant',
+          },
+        },
+        chatPage: {
+          welcomeTitle: 'What do you want to move forward today?',
+          welcomeDescription: 'Pick a shortcut card.',
+          emptyTitle: 'Start',
+          emptyDescription: 'Describe',
+          context: { todayOverview: 'Today' },
+          toolIntro: {
+            goalCreate: { title: 'Goal mode', description: 'Goal desc' },
+            knowledgeQa: { title: 'QA mode', description: 'QA desc' },
+            knowledgeGenerate: { title: 'Note mode', description: 'Note desc' },
+          },
+          shortcuts: {
+            chat: { title: 'Just chat', description: 'Chat desc', prefill: 'chat prefill' },
+            goalCreate: { title: 'Plan a goal', description: 'Goal shortcut', prefill: 'goal prefill' },
+            knowledgeGenerate: {
+              title: 'Write a note',
+              description: 'Note shortcut',
+              prefill: 'note prefill',
+            },
+            knowledgeQa: { title: 'Ask KB', description: 'QA shortcut', prefill: 'qa prefill' },
+          },
+        },
+      },
+    },
+  },
+});
+
+describe('AIMessagePanel (V2 §6.0 welcome)', () => {
+  it('renders four shortcut cards and today overview when idle in chat mode', () => {
+    const wrapper = mount(AIMessagePanel, {
+      props: {
+        timeline: [],
+        toolMode: 'chat',
+        showTodayOverview: true,
+      },
+      slots: {
+        'today-overview': '<div data-testid="today-slot">today widgets</div>',
+      },
+      global: { plugins: [i18n] },
+    });
+
+    expect(wrapper.find('[data-testid="ai-welcome-state"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('What do you want to move forward today?');
+    expect(wrapper.find('[data-testid="ai-welcome-entry-chat"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ai-welcome-entry-goal-create"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ai-welcome-entry-knowledge-generate"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ai-welcome-entry-knowledge-qa"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ai-today-overview"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="today-slot"]').exists()).toBe(true);
+  });
+
+  it('hides today overview once messages exist and emits select-shortcut', async () => {
+    const wrapper = mount(AIMessagePanel, {
+      props: {
+        timeline: [{ id: 'm1', role: 'user', content: 'hello' }],
+        toolMode: 'chat',
+        showTodayOverview: true,
+        showWorkflowSurface: false,
+      },
+      global: { plugins: [i18n] },
+    });
+
+    expect(wrapper.find('[data-testid="ai-welcome-state"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="ai-today-overview"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain('hello');
+  });
+
+  it('emits select-shortcut from welcome cards', async () => {
+    const wrapper = mount(AIMessagePanel, {
+      props: {
+        timeline: [],
+        toolMode: 'chat',
+      },
+      global: { plugins: [i18n] },
+    });
+
+    await wrapper.get('[data-testid="ai-welcome-entry-goal-create"]').trigger('click');
+    expect(wrapper.emitted('select-shortcut')?.[0]).toEqual(['goal-create']);
+  });
+
+  it('shows workflow surface slot when requested', () => {
+    const wrapper = mount(AIMessagePanel, {
+      props: {
+        timeline: [{ id: 'm1', role: 'user', content: 'plan a goal' }],
+        toolMode: 'goal-create',
+        showWorkflowSurface: true,
+      },
+      slots: {
+        'workflow-surface': '<div data-testid="wf-slot">status</div>',
+      },
+      global: { plugins: [i18n] },
+    });
+
+    expect(wrapper.find('[data-testid="ai-workflow-message-surface"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="wf-slot"]').exists()).toBe(true);
+  });
+});

--- a/packages/app-vue/src/modules/ai/components/AIMessagePanel.vue
+++ b/packages/app-vue/src/modules/ai/components/AIMessagePanel.vue
@@ -1,5 +1,9 @@
 <template>
-  <div ref="viewport" class="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+  <div
+    ref="viewport"
+    class="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6"
+    data-testid="ai-message-panel"
+  >
     <div class="mx-auto flex w-full max-w-4xl flex-col gap-4">
       <!-- Message timeline -->
       <template v-if="timeline.length">
@@ -36,11 +40,16 @@
             </p>
           </div>
         </article>
+
+        <!-- Workflow decision surface: sits with the conversation (V2 §6.0) -->
+        <div v-if="showWorkflowSurface" class="space-y-3" data-testid="ai-workflow-message-surface">
+          <slot name="workflow-surface" />
+        </div>
       </template>
 
-      <!-- Empty state -->
-      <div v-else class="flex min-h-[20rem] items-center justify-center">
-        <div class="w-full max-w-xl space-y-4">
+      <!-- Welcome / idle (no messages) -->
+      <div v-else class="flex min-h-[20rem] flex-col items-center justify-center gap-6 py-4">
+        <div class="w-full max-w-2xl space-y-4" data-testid="ai-welcome-state">
           <div class="rounded-3xl border bg-card p-6 text-left">
             <div
               class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground"
@@ -61,21 +70,41 @@
             <h2 class="text-base font-medium text-foreground">
               {{
                 toolMode === 'chat'
-                  ? t('aiAssistant.chatPage.emptyTitle')
+                  ? t('aiAssistant.chatPage.welcomeTitle')
                   : t(`aiAssistant.chatPage.toolIntro.${getToolLocaleKey(toolMode)}.title`)
               }}
             </h2>
             <p class="mt-2 text-sm leading-6 text-muted-foreground">
               {{
                 toolMode === 'chat'
-                  ? t('aiAssistant.chatPage.emptyDescription')
+                  ? t('aiAssistant.chatPage.welcomeDescription')
                   : t(`aiAssistant.chatPage.toolIntro.${getToolLocaleKey(toolMode)}.description`)
               }}
             </p>
           </div>
 
-          <!-- 三个工作流入口卡（仅 chat 模式空态，点击即设定工具模式，§1-4） -->
-          <div v-if="toolMode === 'chat'" class="grid gap-2 sm:grid-cols-3">
+          <!-- Four shortcut cards: prefill composer + set tool mode (V2 §6.0) -->
+          <div v-if="toolMode === 'chat'" class="grid gap-2 sm:grid-cols-2">
+            <button
+              v-for="entry in shortcutEntries"
+              :key="entry.mode"
+              type="button"
+              class="rounded-2xl border bg-card p-4 text-left transition-colors hover:border-ring hover:bg-muted/40"
+              :data-testid="`ai-welcome-entry-${entry.mode}`"
+              @click="$emit('select-shortcut', entry.mode)"
+            >
+              <component :is="entry.icon" class="h-4 w-4 text-muted-foreground" />
+              <p class="mt-2 text-sm font-medium text-foreground">
+                {{ t(`aiAssistant.chatPage.shortcuts.${entry.localeKey}.title`) }}
+              </p>
+              <p class="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                {{ t(`aiAssistant.chatPage.shortcuts.${entry.localeKey}.description`) }}
+              </p>
+            </button>
+          </div>
+
+          <!-- Tool-mode empty: keep workflow entry cards -->
+          <div v-else class="grid gap-2 sm:grid-cols-3">
             <button
               v-for="entry in workflowEntries"
               :key="entry.mode"
@@ -94,32 +123,74 @@
             </button>
           </div>
         </div>
-      </div>
 
+        <!-- Today overview under welcome (Dashboard successor, V2 §6.0) -->
+        <div
+          v-if="showTodayOverview"
+          class="w-full max-w-2xl space-y-3"
+          data-testid="ai-today-overview"
+        >
+          <p class="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            {{ t('aiAssistant.chatPage.context.todayOverview') }}
+          </p>
+          <slot name="today-overview" />
+        </div>
+
+        <!-- Workflow surface also available before first message (tool mode) -->
+        <div
+          v-if="showWorkflowSurface"
+          class="w-full max-w-2xl space-y-3"
+          data-testid="ai-workflow-message-surface"
+        >
+          <slot name="workflow-surface" />
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { Bot, NotebookPen, Search, Sparkles } from 'lucide-vue-next';
+import { Bot, MessageSquare, NotebookPen, Search, Sparkles } from 'lucide-vue-next';
 import { useI18n } from 'vue-i18n';
 import { getToolLocaleKey, type ChatItem, type WorkflowMode } from '../composables/types';
 import { useAIFormatters } from '../composables/useAIFormatters';
 
-defineProps<{
-  timeline: ChatItem[];
-  toolMode: WorkflowMode;
-}>();
+withDefaults(
+  defineProps<{
+    timeline: ChatItem[];
+    toolMode: WorkflowMode;
+    /** Show Dashboard-successor widgets under the welcome cards. */
+    showTodayOverview?: boolean;
+    /** Show workflow decision/actions + artifact surface near the timeline. */
+    showWorkflowSurface?: boolean;
+  }>(),
+  {
+    showTodayOverview: false,
+    showWorkflowSurface: false,
+  },
+);
 
 defineEmits<{
   'select-tool': [mode: WorkflowMode];
+  'select-shortcut': [mode: WorkflowMode];
 }>();
 
+const shortcutEntries = [
+  { mode: 'chat' as const, localeKey: 'chat', icon: MessageSquare },
+  { mode: 'goal-create' as const, localeKey: 'goalCreate', icon: Sparkles },
+  { mode: 'knowledge-generate' as const, localeKey: 'knowledgeGenerate', icon: NotebookPen },
+  { mode: 'knowledge-qa' as const, localeKey: 'knowledgeQa', icon: Search },
+];
+
 const workflowEntries = [
-  { mode: 'goal-create', localeKey: getToolLocaleKey('goal-create'), icon: Sparkles },
-  { mode: 'knowledge-generate', localeKey: getToolLocaleKey('knowledge-generate'), icon: NotebookPen },
-  { mode: 'knowledge-qa', localeKey: getToolLocaleKey('knowledge-qa'), icon: Search },
+  { mode: 'goal-create' as const, localeKey: getToolLocaleKey('goal-create'), icon: Sparkles },
+  {
+    mode: 'knowledge-generate' as const,
+    localeKey: getToolLocaleKey('knowledge-generate'),
+    icon: NotebookPen,
+  },
+  { mode: 'knowledge-qa' as const, localeKey: getToolLocaleKey('knowledge-qa'), icon: Search },
 ] as const;
 
 const viewport = ref<HTMLElement | null>(null);

--- a/packages/app-vue/src/modules/ai/components/AIWorkflowActionBar.vue
+++ b/packages/app-vue/src/modules/ai/components/AIWorkflowActionBar.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 /**
- * AIWorkflowActionBar — 工作流生命周期操作条（UI_PAGE_REDESIGN_PLAN §1）
+ * AIWorkflowActionBar — 工作流生命周期操作条（V2 §6.0）
  *
- * 整体从 AIFooterComposer 的 action-rail 迁入右栏顶部，与产物同屏；
- * composer 回归纯对话。状态机分支逻辑一行不改（Brief §12-5），
- * `goal-agent-*` 等 testid 随迁。legacy workflow 调试分支已删除（§1-5）。
+ * 状态机按钮组挂在 Composer 上方条 + 消息时间线工作流卡片附近；
+ * 状态机分支逻辑一行不改（Brief §12-5），`goal-agent-*` 等 testid 随迁。
+ * legacy workflow 调试分支已删除（§1-5）。
  *
  * 处理器以函数 props 传入（与本模块 `:format-*` 既有约定一致），
  * 避免在中间层重写状态机事件。
@@ -75,7 +75,7 @@ const { t } = useI18n();
 <template>
   <div
     v-if="toolMode !== 'chat'"
-    class="border-b bg-muted/30 px-4 py-3"
+    class="rounded-2xl border bg-muted/30 px-4 py-3"
     data-testid="ai-workflow-action-bar"
   >
     <p class="text-sm leading-6 text-muted-foreground">

--- a/packages/app-vue/src/modules/ai/views/AIChatView.spec.ts
+++ b/packages/app-vue/src/modules/ai/views/AIChatView.spec.ts
@@ -58,6 +58,10 @@ const i18n = createI18n({
       nav: {
         aiChat: 'AI Chat',
         settings: 'Settings',
+        capsule: {
+          goal: 'Goal',
+          note: 'Notes',
+        },
       },
       common: {
         unknown: 'Unknown',
@@ -207,6 +211,8 @@ const i18n = createI18n({
           creatingGoal: 'Creating goal',
         },
         chatPage: {
+          welcomeTitle: 'What do you want to move forward today?',
+          welcomeDescription: 'Pick a shortcut card.',
           emptyTitle: 'Start a conversation',
           emptyDescription: 'Describe what you want to do.',
           emptyModels: 'No models available',
@@ -214,6 +220,13 @@ const i18n = createI18n({
             title: 'Context',
             show: 'Show context',
             hide: 'Hide context',
+            todayOverview: 'Today',
+          },
+          shortcuts: {
+            chat: { title: 'Just chat', description: 'Chat', prefill: 'chat prefill' },
+            goalCreate: { title: 'Plan a goal', description: 'Goal', prefill: 'goal prefill' },
+            knowledgeGenerate: { title: 'Write a note', description: 'Note', prefill: 'note prefill' },
+            knowledgeQa: { title: 'Ask KB', description: 'QA', prefill: 'qa prefill' },
           },
           sidebar: {
             open: 'Open sidebar',
@@ -259,6 +272,7 @@ const i18n = createI18n({
             hideGoalEditor: 'Hide goal editor',
             createKnowledgeNote: 'Create Knowledge Note',
             exitTool: 'Exit tool',
+            ungroundedHint: 'Not grounded enough to draft a note.',
             openCreatedNote: 'Open note',
             startAnotherNote: 'Start another note',
             defaultConversationNames: {

--- a/packages/app-vue/src/modules/ai/views/AIChatView.vue
+++ b/packages/app-vue/src/modules/ai/views/AIChatView.vue
@@ -66,21 +66,38 @@
             {{ currentConversationLabel }}
           </h1>
           <div class="flex items-center gap-1 md:hidden">
-            <Button variant="ghost" size="icon" class="h-8 w-8"
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8"
               :title="t('aiAssistant.chatPage.sidebar.open')"
               data-testid="ai-mobile-sidebar-toggle"
-              @click="openMobileSidebar">
+              @click="openMobileSidebar"
+            >
               <Menu class="h-4 w-4" />
             </Button>
-            <Button v-if="hasWorkflowContext" variant="ghost" size="icon" class="h-8 w-8"
-              :title="contextPanelOpen ? t('aiAssistant.chatPage.context.hide') : t('aiAssistant.chatPage.context.show')"
+            <Button
+              v-if="hasWorkflowContext"
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8"
+              :title="
+                contextPanelOpen
+                  ? t('aiAssistant.chatPage.context.hide')
+                  : t('aiAssistant.chatPage.context.show')
+              "
               data-testid="ai-context-panel-toggle"
-              @click="toggleContextPanel">
+              @click="toggleContextPanel"
+            >
               <PanelRightOpen class="h-4 w-4" />
             </Button>
-            <Button variant="ghost" size="icon" class="h-8 w-8"
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8"
               :title="t('aiAssistant.dialogs.chat.newConversation')"
-              @click="startNewConversation()">
+              @click="startNewConversation()"
+            >
               <Plus class="h-4 w-4" />
             </Button>
           </div>
@@ -92,10 +109,89 @@
         ref="messagePanelRef"
         :timeline="chatTimeline"
         :tool-mode="toolMode"
+        :show-today-overview="todayOverviewVisible"
+        :show-workflow-surface="hasWorkflowContext"
         @select-tool="startNewConversation"
-      />
+        @select-shortcut="handleWelcomeShortcut"
+      >
+        <template #today-overview>
+          <div class="grid gap-3">
+            <DailyTodoWidget @view-all="router.push('/tasks')" />
+            <UpcomingRemindersWidget :refresh-key="0" @view-all="router.push('/reminders')" />
+            <GoalProgressWidget
+              :goals="goalProgress"
+              :loading="dashboardLoading"
+              @view-all="router.push('/goals')"
+              @select="(id) => router.push(`/goals/${id}`)"
+            />
+          </div>
+        </template>
 
-      <!-- Composer 回归纯对话：工作流操作条已整体迁至右栏（§1） -->
+        <template #workflow-surface>
+          <p
+            v-if="workflowStatusText"
+            class="rounded-2xl border bg-muted/20 px-4 py-3 text-sm leading-6 text-muted-foreground"
+            data-testid="ai-workflow-status-inline"
+          >
+            {{ workflowStatusText }}
+          </p>
+        </template>
+      </AIMessagePanel>
+
+      <!--
+        V2 §6.0: workflow lifecycle buttons sit above the pure-dialogue composer
+        (composer-top strip). Kept outside AIFooterComposer so unit specs that stub
+        the composer still mount the real action bar (goal-agent-* contracts).
+      -->
+      <div v-show="!composerOnly" class="px-4 sm:px-6">
+        <div class="mx-auto w-full max-w-4xl">
+          <AIWorkflowActionBar
+            :tool-mode="toolMode"
+            :workflow-status-text="workflowStatusText"
+            :goal-clarification="goalClarification"
+            :automated-goal-id="automatedGoalId"
+            :goal-agent-loading="goalAgentLoading"
+            :goal-agent-resuming="goalAgentResuming"
+            :show-goal-draft-editor="showGoalDraftEditor"
+            :can-run-goal-agent="canRunGoalAgent"
+            :can-resume-goal-agent-clarification="canResumeGoalAgentClarification"
+            :can-continue-goal-agent-execution="canContinueGoalAgentExecution"
+            :can-retry-goal-agent-execution="canRetryGoalAgentExecution"
+            :goal-agent-waiting-for-clarification="goalAgentWaitingForClarification"
+            :goal-agent-waiting-for-approval="goalAgentWaitingForApproval"
+            :goal-agent-waiting-for-execution="goalAgentWaitingForExecution"
+            :note-agent-run="noteAgentRun"
+            :note-summary="noteSummary"
+            :note-agent-loading="noteAgentLoading"
+            :note-creating="noteCreating"
+            :can-run-knowledge-note-agent="canRunKnowledgeNoteAgent"
+            :can-retry-knowledge-note-agent-execution="canRetryKnowledgeNoteAgentExecution"
+            :knowledge-answer="knowledgeAnswer"
+            :knowledge-query-loading="knowledgeQueryLoading"
+            :can-ask-knowledge="canAskKnowledge"
+            :can-run-workflow-actions="canRunWorkflowActions"
+            :can-send-message="canSendMessage"
+            :start-goal-agent-run="startGoalAgentRun"
+            :submit-goal-agent-clarification="submitGoalAgentClarification"
+            :confirm-goal-agent-run="confirmGoalAgentRun"
+            :cancel-goal-agent-run="cancelGoalAgentRun"
+            :continue-goal-agent-execution="continueGoalAgentExecution"
+            :retry-goal-agent-execution="retryGoalAgentExecution"
+            :toggle-goal-draft-editor="toggleGoalDraftEditor"
+            :open-automated-goal="openAutomatedGoal"
+            :start-knowledge-note-agent-run="startKnowledgeNoteAgentRun"
+            :create-knowledge-note-from-conversation="createKnowledgeNoteFromConversation"
+            :start-knowledge-note-agent-run-from-knowledge-answer="
+              startKnowledgeNoteAgentRunFromKnowledgeAnswer
+            "
+            :retry-knowledge-note-agent-execution="retryKnowledgeNoteAgentExecution"
+            :open-created-note="openCreatedNote"
+            :ask-knowledge-from-conversation="askKnowledgeFromConversation"
+            :exit-tool-mode="exitToolMode"
+          />
+        </div>
+      </div>
+
       <AIFooterComposer
         ref="composerRef"
         v-model="chatMessage"
@@ -112,6 +208,10 @@
       />
     </section>
 
+    <!--
+      Artifact rail: keeps `ai-context-panel` + AIGoalWorkflowPanel contracts for
+      state-machine specs (Brief §11). Actions no longer live here (moved above composer).
+    -->
     <AIContextPanel
       v-show="!composerOnly"
       :has-workflow-context="hasWorkflowContext"
@@ -119,51 +219,6 @@
       :tool-label="currentToolLabel"
       @close="closeContextPanel"
     >
-      <template #action-bar>
-        <AIWorkflowActionBar
-          :tool-mode="toolMode"
-          :workflow-status-text="workflowStatusText"
-          :goal-clarification="goalClarification"
-          :automated-goal-id="automatedGoalId"
-          :goal-agent-loading="goalAgentLoading"
-          :goal-agent-resuming="goalAgentResuming"
-          :show-goal-draft-editor="showGoalDraftEditor"
-          :can-run-goal-agent="canRunGoalAgent"
-          :can-resume-goal-agent-clarification="canResumeGoalAgentClarification"
-          :can-continue-goal-agent-execution="canContinueGoalAgentExecution"
-          :can-retry-goal-agent-execution="canRetryGoalAgentExecution"
-          :goal-agent-waiting-for-clarification="goalAgentWaitingForClarification"
-          :goal-agent-waiting-for-approval="goalAgentWaitingForApproval"
-          :goal-agent-waiting-for-execution="goalAgentWaitingForExecution"
-          :note-agent-run="noteAgentRun"
-          :note-summary="noteSummary"
-          :note-agent-loading="noteAgentLoading"
-          :note-creating="noteCreating"
-          :can-run-knowledge-note-agent="canRunKnowledgeNoteAgent"
-          :can-retry-knowledge-note-agent-execution="canRetryKnowledgeNoteAgentExecution"
-          :knowledge-answer="knowledgeAnswer"
-          :knowledge-query-loading="knowledgeQueryLoading"
-          :can-ask-knowledge="canAskKnowledge"
-          :can-run-workflow-actions="canRunWorkflowActions"
-          :can-send-message="canSendMessage"
-          :start-goal-agent-run="startGoalAgentRun"
-          :submit-goal-agent-clarification="submitGoalAgentClarification"
-          :confirm-goal-agent-run="confirmGoalAgentRun"
-          :cancel-goal-agent-run="cancelGoalAgentRun"
-          :continue-goal-agent-execution="continueGoalAgentExecution"
-          :retry-goal-agent-execution="retryGoalAgentExecution"
-          :toggle-goal-draft-editor="toggleGoalDraftEditor"
-          :open-automated-goal="openAutomatedGoal"
-          :start-knowledge-note-agent-run="startKnowledgeNoteAgentRun"
-          :create-knowledge-note-from-conversation="createKnowledgeNoteFromConversation"
-          :start-knowledge-note-agent-run-from-knowledge-answer="startKnowledgeNoteAgentRunFromKnowledgeAnswer"
-          :retry-knowledge-note-agent-execution="retryKnowledgeNoteAgentExecution"
-          :open-created-note="openCreatedNote"
-          :ask-knowledge-from-conversation="askKnowledgeFromConversation"
-          :exit-tool-mode="exitToolMode"
-        />
-      </template>
-
       <AIGoalWorkflowPanel
         :tool-mode="toolMode"
         :goal-clarification="goalClarification"
@@ -214,20 +269,6 @@
       >
         {{ workflowStatusText }}
       </div>
-
-      <!-- ① 空闲态：今日概览（≥xl 常驻；<xl 不渲染，§1-8） -->
-      <template #idle>
-        <template v-if="isXlUp">
-          <DailyTodoWidget @view-all="router.push('/tasks')" />
-          <UpcomingRemindersWidget :refresh-key="0" @view-all="router.push('/reminders')" />
-          <GoalProgressWidget
-            :goals="goalProgress"
-            :loading="dashboardLoading"
-            @view-all="router.push('/goals')"
-            @select="(id) => router.push(`/goals/${id}`)"
-          />
-        </template>
-      </template>
     </AIContextPanel>
   </div>
 </template>
@@ -249,13 +290,12 @@ import DailyTodoWidget from '../../task/components/widgets/DailyTodoWidget.vue';
 import UpcomingRemindersWidget from '../../reminder/components/widgets/UpcomingRemindersWidget.vue';
 import GoalProgressWidget from '../../goal/components/widgets/GoalProgressWidget.vue';
 import { useDashboard } from '../../dashboard/composables/useDashboard';
-import { useViewportBreakpoint } from '../../../shared/composables/useViewportBreakpoint';
+import { useAppShellStore } from '../../../layouts/shell/useAppShellStore';
 import { useAIChatView } from '../composables/useAIChatView';
-import type { ConversationSummary } from '../composables/types';
+import type { ConversationSummary, WorkflowMode } from '../composables/types';
 
 const { t } = useI18n();
 const router = useRouter();
-const { isXlUp } = useViewportBreakpoint();
 
 /**
  * V2 shell integration props (UI_REDESIGN_V2_PLAN §2.1).
@@ -269,23 +309,21 @@ const { isXlUp } = useViewportBreakpoint();
  */
 withDefaults(
   defineProps<{
-    /** Shell provides its own conversation sidebar — hide the built-in one. */
     hideConversationSidebar?: boolean;
-    /** STATE C (focus): render only the composer strip, keep state alive. */
     composerOnly?: boolean;
   }>(),
   { hideConversationSidebar: false, composerOnly: false },
 );
 
-const messagePanelRef = ref<InstanceType<typeof AIMessagePanel> | null>(null);
-const composerRef = ref<InstanceType<typeof AIFooterComposer> | null>(null);
+const messagePanelRef = ref<{ viewport?: HTMLElement | null } | null>(null);
+const composerRef = ref<{ composerTextarea?: HTMLTextAreaElement | null } | null>(null);
 
 const {
   session,
   model,
   goalWorkflow,
-  knowledgeQaWorkflow,
   noteWorkflow,
+  knowledgeQaWorkflow,
   formatters,
   common,
 } = useAIChatView({
@@ -293,64 +331,124 @@ const {
 });
 
 const {
-  chatMessage, chatLoading, chatConversationId, chatTimeline,
-  conversationList, conversationListLoading, agentRunList, agentRunListLoading,
-  recentGoalList, recentKnowledgeNoteList,
+  chatMessage,
+  chatLoading,
+  chatConversationId,
+  chatTimeline,
+  conversationList,
+  conversationListLoading,
+  agentRunList,
+  agentRunListLoading,
+  recentGoalList,
+  recentKnowledgeNoteList,
   messagesViewport,
-  selectConversation, selectAgentRun, openRecentGoal, openRecentKnowledgeNote,
-  deleteConversation, loadConversationList,
-  startNewConversation, handleSendChat, stopGenerating,
+  selectConversation,
+  selectAgentRun,
+  openRecentGoal,
+  openRecentKnowledgeNote,
+  deleteConversation,
+  loadConversationList,
+  startNewConversation,
+  handleSendChat,
+  stopGenerating,
 } = session;
 
-const {
-  selectedModelKey, modelGroups, canSendMessage,
-  selectModel,
-} = model;
+const { selectedModelKey, modelGroups, canSendMessage, selectModel } = model;
 
 const {
-  goalDraft, goalClarification,
-  goalAutomationResult, goalAgentRun, clarificationAnswers, showGoalDraftEditor,
+  goalDraft,
+  goalClarification,
+  goalAutomationResult,
+  goalAgentRun,
+  clarificationAnswers,
+  showGoalDraftEditor,
   creatingGoal,
-  goalAgentLoading, goalAgentResuming,
-  editableGoal, editableKeyResults, editableTaskTemplates, editableReminders,
+  goalAgentLoading,
+  goalAgentResuming,
+  editableGoal,
+  editableKeyResults,
+  editableTaskTemplates,
+  editableReminders,
   canRunGoalAgent,
-  canResumeGoalAgentClarification, canContinueGoalAgentExecution, canRetryGoalAgentExecution,
-  goalExecutedActions, goalExecutionSummary, goalExecutionRecovery, automatedGoalId,
-  goalAgentPendingActions, goalAgentExecutedActions, goalAgentWaitingForClarification,
-  goalAgentWaitingForApproval, goalAgentWaitingForExecution,
-  startGoalAgentRun, submitGoalAgentClarification, confirmGoalAgentRun, cancelGoalAgentRun, continueGoalAgentExecution, retryGoalAgentExecution,
-  openAutomatedGoal, handleCreateGoalFromDraft,
-  addKeyResultDraft, removeKeyResultDraft, updateKeyResultDraft, handleUpdateGoalDraft,
-  addTaskTemplateDraft, removeTaskTemplateDraft, updateTaskTemplateDraft,
-  addReminderDraft, removeReminderDraft, updateReminderDraft,
+  canResumeGoalAgentClarification,
+  canContinueGoalAgentExecution,
+  canRetryGoalAgentExecution,
+  goalExecutedActions,
+  goalExecutionSummary,
+  goalExecutionRecovery,
+  automatedGoalId,
+  goalAgentPendingActions,
+  goalAgentExecutedActions,
+  goalAgentWaitingForClarification,
+  goalAgentWaitingForApproval,
+  goalAgentWaitingForExecution,
+  startGoalAgentRun,
+  submitGoalAgentClarification,
+  confirmGoalAgentRun,
+  cancelGoalAgentRun,
+  continueGoalAgentExecution,
+  retryGoalAgentExecution,
+  openAutomatedGoal,
+  handleCreateGoalFromDraft,
+  addKeyResultDraft,
+  removeKeyResultDraft,
+  updateKeyResultDraft,
+  handleUpdateGoalDraft,
+  addTaskTemplateDraft,
+  removeTaskTemplateDraft,
+  updateTaskTemplateDraft,
+  addReminderDraft,
+  removeReminderDraft,
+  updateReminderDraft,
   toggleGoalDraftEditor,
 } = goalWorkflow;
 
 const {
-  noteCreating, noteSummary, noteAgentRun, noteAgentLoading,
-  canRunKnowledgeNoteAgent, canRetryKnowledgeNoteAgentExecution,
-  startKnowledgeNoteAgentRun, createKnowledgeNoteFromConversation,
-  startKnowledgeNoteAgentRunFromKnowledgeAnswer, retryKnowledgeNoteAgentExecution,
+  noteCreating,
+  noteSummary,
+  noteAgentRun,
+  noteAgentLoading,
+  canRunKnowledgeNoteAgent,
+  canRetryKnowledgeNoteAgentExecution,
+  startKnowledgeNoteAgentRun,
+  createKnowledgeNoteFromConversation,
+  startKnowledgeNoteAgentRunFromKnowledgeAnswer,
+  retryKnowledgeNoteAgentExecution,
   openCreatedNote,
 } = noteWorkflow;
 
 const {
-  knowledgeQueryLoading, knowledgeAnswer, knowledgeQaAgentRun, canAskKnowledge,
-  askKnowledgeFromConversation, openKnowledgeCitation,
+  knowledgeQueryLoading,
+  knowledgeAnswer,
+  knowledgeQaAgentRun,
+  canAskKnowledge,
+  askKnowledgeFromConversation,
+  openKnowledgeCitation,
 } = knowledgeQaWorkflow;
 
 const {
-  formatAutomationTool, formatAgentTool, formatActionStatus, formatExecutionOutcome,
+  formatAutomationTool,
+  formatAgentTool,
+  formatActionStatus,
+  formatExecutionOutcome,
 } = formatters;
 
 const {
-  toolMode, currentConversationLabel, currentToolLabel, currentToolButtonLabel,
-  notePreview, workflowStatusText, canRunWorkflowActions,
-  exitToolMode, openSettings,
+  toolMode,
+  currentConversationLabel,
+  currentToolLabel,
+  currentToolButtonLabel,
+  notePreview,
+  workflowStatusText,
+  canRunWorkflowActions,
+  exitToolMode,
+  openSettings,
 } = common;
 
 const contextPanelOpen = ref(false);
 const mobileSidebarOpen = ref(false);
+/** Dedup key for auto-opening a business panel Tab for the current artifact. */
+const lastOpenedArtifactKey = ref<string | null>(null);
 
 const hasWorkflowArtifact = computed(() => {
   if (toolMode.value === 'goal-create') {
@@ -382,18 +480,129 @@ const hasWorkflowContext = computed(
   () => toolMode.value !== 'chat' || hasWorkflowArtifact.value,
 );
 
-// ── 空闲态今日概览数据（§1-3 右栏状态①）──
+// ── Welcome / idle: Today overview under shortcut cards (V2 §6.0) ──
 const { goalProgress, isLoading: dashboardLoading, fetchDashboard } = useDashboard();
-const idleOverviewVisible = computed(() => isXlUp.value && !hasWorkflowContext.value);
+const todayOverviewVisible = computed(
+  () => chatTimeline.value.length === 0 && !hasWorkflowContext.value,
+);
 
 watch(
-  idleOverviewVisible,
+  todayOverviewVisible,
   (visible) => {
     if (visible) {
       void fetchDashboard();
     }
   },
   { immediate: true },
+);
+
+/**
+ * Prefill composer + set tool mode from welcome shortcut cards (V2 §6.0).
+ */
+function handleWelcomeShortcut(mode: WorkflowMode) {
+  const prefillKey = {
+    chat: 'aiAssistant.chatPage.shortcuts.chat.prefill',
+    'goal-create': 'aiAssistant.chatPage.shortcuts.goalCreate.prefill',
+    'knowledge-generate': 'aiAssistant.chatPage.shortcuts.knowledgeGenerate.prefill',
+    'knowledge-qa': 'aiAssistant.chatPage.shortcuts.knowledgeQa.prefill',
+  }[mode];
+
+  startNewConversation(mode);
+  if (prefillKey) {
+    chatMessage.value = t(prefillKey);
+  }
+}
+
+/**
+ * When a workflow product is ready, open a business panel Tab without stealing
+ * a different already-open route (shell openTab intent: deeplink + router push).
+ * Pinia may be absent in isolated unit mounts — store call is best-effort.
+ */
+function openArtifactBusinessTab(
+  module: 'goal' | 'note',
+  route: string,
+  title: string,
+  artifactKey: string,
+) {
+  if (lastOpenedArtifactKey.value === artifactKey) return;
+  lastOpenedArtifactKey.value = artifactKey;
+
+  try {
+    const shellStore = useAppShellStore();
+    shellStore.openTab({
+      module,
+      route,
+      title,
+      intent: 'deeplink',
+    });
+  } catch {
+    // no active pinia (unit tests) — router push still exercises navigation
+  }
+
+  void router.push(route);
+}
+
+// Only open tabs for ready products: created goal / goal draft / created note.
+// Do not open merely because an Agent run is in progress (avoids mid-flow jumps).
+// Open panel Tabs for ready products only (V2 §6.0 / §2.3 deeplink, no steal).
+// Intermediate restored drafts without a live agent run do not auto-navigate
+// (avoids clobbering the AI workspace on session restore).
+watch(
+  [goalDraft, goalAgentRun, automatedGoalId, noteSummary, toolMode],
+  () => {
+    if (toolMode.value === 'goal-create') {
+      if (automatedGoalId.value) {
+        openArtifactBusinessTab(
+          'goal',
+          `/goals/${automatedGoalId.value}`,
+          t('nav.capsule.goal'),
+          `goal-created:${automatedGoalId.value}`,
+        );
+        return;
+      }
+      // Draft ready during/after agent flow → open Goal panel Tab for the draft.
+      if (goalDraft.value && goalAgentRun.value) {
+        const draft = goalDraft.value as {
+          goal?: { title?: string; description?: string };
+          title?: string;
+          name?: string;
+          description?: string;
+        };
+        const draftName =
+          draft.goal?.title ||
+          draft.title ||
+          draft.name ||
+          t('aiAssistant.chatPage.workflow.goalDraftTitle');
+        const draftDesc = draft.goal?.description || draft.description || '';
+        const runId = String(
+          (goalAgentRun.value as { runId?: string; id?: string }).runId ||
+            (goalAgentRun.value as { runId?: string; id?: string }).id ||
+            'run',
+        );
+        openArtifactBusinessTab(
+          'goal',
+          '/goals',
+          draftName,
+          `goal-draft:${runId}:${draftName}:${draftDesc}`,
+        );
+      }
+      return;
+    }
+
+    if (
+      (toolMode.value === 'knowledge-generate' || toolMode.value === 'knowledge-qa') &&
+      noteSummary.value
+    ) {
+      const summary = noteSummary.value as { resolvedPath?: string; path?: string };
+      const path = summary.resolvedPath || summary.path || 'note';
+      openArtifactBusinessTab(
+        'note',
+        '/repository',
+        t('aiAssistant.chatPage.workflow.openCreatedNote'),
+        `note-created:${path}`,
+      );
+    }
+  },
 );
 
 function toggleContextPanel() {
@@ -415,6 +624,7 @@ function closeMobileSidebar() {
 function startNewConversationFromMobile() {
   closeMobileSidebar();
   startNewConversation();
+  lastOpenedArtifactKey.value = null;
 }
 
 async function selectConversationFromMobile(item: ConversationSummary) {


### PR DESCRIPTION
## 概要

UI 重构 V2 **S3 AI 工作区精修**（`docs/UI_REDESIGN_V2_PLAN.md` §6.0）。

在 S1 壳常驻 `AIChatView`（#176）+ S2 全模块面板化（#177–#182）之上，把 AI 工作区从「右栏工作流 / 视口闲置概览」收敛为 V2 心智：欢迎态 + 今日概览、工作流决策贴近消息与 Composer 上方条、产物就绪自动新开业务面板 Tab（不抢占）。

**不改** `useAIChatView` 与 4 个 workflow composable；状态机分支逻辑一行不重写（Brief §11/§12）。

## 变更

**欢迎态 / 今日概览（§6.0）**
- `AIMessagePanel`：无消息时渲染品牌提示 + **四张快捷指令卡**（chat / goal-create / knowledge-generate / knowledge-qa），点击预填 Composer 并设定工具模式
- 欢迎态下方承接 Dashboard 的轻量「今日」区：`DailyTodoWidget` + `UpcomingRemindersWidget` + `GoalProgressWidget`（有会话消息时不显示）
- 空闲右栏今日概览移除（职责迁入主列欢迎态）

**工作流生命周期（§6.0）**
- `AIWorkflowActionBar` 挂到 Composer **上方条**（纯对话输入区不变）
- 消息时间线旁内嵌工作流状态文案（`ai-workflow-status-inline` / `ai-workflow-message-surface`）
- `AIContextPanel` 仍承载产物面板与 `ai-context-panel` / `goal-agent-*` 契约（状态机 spec 锚定）

**产物自动开 Tab（§2.3 / §6.0）**
- 目标已创建 / Agent 流程中草稿就绪 / 知识笔记已创建 → `useAppShellStore.openTab({ intent: 'deeplink' })` + `router.push`，不抢占不同路由的现有 Tab
- 会话恢复的中间草稿不自动跳转，避免挤掉 AI 地面态

**i18n / 测试**
- `aiAssistant.chatPage.welcomeTitle|welcomeDescription|shortcuts.*` 补 zh-CN / en-US
- 新增 `AIMessagePanel.spec.ts`；`AIChatView.spec.ts` 29 用例状态机全绿

## 验证

- ✅ `pnpm nx run-many -t lint typecheck test -p app-vue` — **208 tests passed**, lint 0 error
- ✅ `pnpm nx run web:typecheck`（vue-tsc 覆盖 SFC）
- ✅ MSW 真浏览器冒烟 **18/18**（`127.0.0.1:5181`，1280 视口）：欢迎态 + 4 快捷卡 + 今日概览 → 目标卡预填 + 操作条/`goal-agent-start-run` → 打开 Goal 面板仍保留 AI 层 → focus 隐藏欢迎、Composer 可达 → 回 `/` 工作区仍在；0 非预期页面错误

## 说明

- 不夹带 MSW 缺 handler / 面板错误边界等既有 bug 修复（按用户策略重构收尾统一处理）
- 并行 S4 Note/Governance 不在本 PR 范围
- 下一步：S4 Note 阶段 0 收尾（Governance 并入「规范」分区，若尚未合入）/ 或按 plan 进入收尾回归项