### PR TITLE
refactor(note): S4 panel adaptation — notes|governance segments + two-tier (V2 §6 Note/§7)

### DIFF
--- a/packages/app-vue/src/locales/en-US.ts
+++ b/packages/app-vue/src/locales/en-US.ts
@@ -1306,6 +1306,8 @@ export default {
       list: 'Reminder List',
     },
     linear: {
+      contextRequiresFocus: 'Maximize the panel to view backlinks and the graph',
+
       allReminders: 'All Reminders',
       templateTitle: 'Reminder Templates',
       searchPlaceholder: 'Search reminders...',
@@ -3897,6 +3899,10 @@ export default {
     route: {
       workspace: 'Notes',
       noteEdit: 'Edit Note',
+    },
+    segments: {
+      notes: 'Notes',
+      governance: 'Standards',
     },
     sidebar: {
       files: 'Files',

--- a/packages/app-vue/src/locales/zh-CN.ts
+++ b/packages/app-vue/src/locales/zh-CN.ts
@@ -1267,6 +1267,8 @@ export default {
       list: '提醒列表',
     },
     linear: {
+      contextRequiresFocus: '最大化后可查看反链与图谱',
+
       allReminders: '全部提醒',
       templateTitle: '提醒模板',
       searchPlaceholder: '搜索提醒...',
@@ -3836,6 +3838,10 @@ export default {
     route: {
       workspace: '笔记',
       noteEdit: '编辑笔记',
+    },
+    segments: {
+      notes: '笔记',
+      governance: '规范',
     },
     sidebar: {
       files: '文件',

--- a/packages/app-vue/src/modules/editor/components/EditorToolbar.vue
+++ b/packages/app-vue/src/modules/editor/components/EditorToolbar.vue
@@ -75,17 +75,7 @@
       >
         <Images class="h-4 w-4" />
       </Button>
-
-      <Button
-        variant="ghost"
-        size="icon"
-        class="h-8 w-8"
-        :title="t('editor.toolbar.exportSelfContained')"
-        :aria-label="t('editor.toolbar.exportSelfContained')"
-        @click="exportSelfContained"
-      >
-        <Share2 class="h-4 w-4" />
-      </Button>
+    <!-- 阶段 0：自包含导出入口隐藏（V2 §6 Note） -->
 
       <Separator orientation="vertical" class="h-6" />
 

--- a/packages/app-vue/src/modules/editor/views/EditorLinearView.vue
+++ b/packages/app-vue/src/modules/editor/views/EditorLinearView.vue
@@ -33,9 +33,10 @@
 
     <div
       v-else-if="linearScene.editor.resource"
-      class="flex-1 overflow-hidden flex flex-col lg:flex-row"
+      class="flex flex-1 flex-col overflow-hidden"
+      :class="isNarrow ? 'flex-col' : 'flex-row'"
     >
-      <div class="min-w-0 flex-1 overflow-hidden flex flex-col lg:border-r">
+      <div class="flex min-w-0 flex-1 flex-col overflow-hidden" :class="isNarrow ? '' : 'border-r'">
         <ActiveDocumentPane
           :ref="linearScene.editor.bindPaneRef"
           :content="linearScene.editor.content"
@@ -54,7 +55,6 @@
           @insert-text="linearScene.editor.actions.insertText"
           @insert-resource="linearScene.editor.actions.openResourcePicker"
           @insert-existing-image="linearScene.editor.actions.openImagePicker"
-          @export-self-contained="linearScene.editor.actions.exportSelfContained"
           @wrap-selection="linearScene.editor.actions.wrapSelection"
           @view-mode-change="linearScene.editor.actions.setViewMode"
           @save="linearScene.editor.actions.save"
@@ -79,16 +79,25 @@
       </div>
 
       <aside
-        class="flex w-full flex-col border-t bg-muted/10 max-lg:max-h-[320px] lg:w-[360px] lg:border-t-0 xl:w-[400px]"
+        v-if="!isNarrow"
+        class="flex w-[360px] shrink-0 flex-col border-l bg-muted/10 @3xl/panel:w-[400px]"
+        data-testid="note-context-panel-host"
       >
-        <!-- 反链/图谱 Tabs：图谱点击才渲染；<lg 图谱不渲染（§10-5/§10-8） -->
+        <!-- 反链/图谱：窄档（split）隐藏并提示最大化（V2 §7） -->
         <NoteContextPanel
           :note-id="linearScene.sidecar.noteId"
-          :show-graph="isLgUp"
+          :show-graph="isWide"
           @navigate="linearScene.sidecar.actions.navigate"
           @close="linearScene.sidecar.actions.close"
         />
       </aside>
+      <div
+        v-else
+        class="border-t px-3 py-2 text-xs text-muted-foreground"
+        data-testid="note-context-narrow-hint"
+      >
+        {{ t('editor.linear.contextRequiresFocus') }}
+      </div>
     </div>
 
     <ImageResourcePickerDialog
@@ -104,13 +113,7 @@
       :recent-items="linearScene.editor.resources.recentResourceItems"
       @select="linearScene.editor.actions.insertResource"
     />
-
-    <SelfContainedExportDialog
-      v-model:open="linearScene.editor.dialogs.export.open"
-      :result="linearScene.editor.dialogs.export.result"
-      @copy="linearScene.editor.actions.copyExport"
-      @download="linearScene.editor.actions.downloadExport"
-    />
+    <!-- 阶段 0：SelfContainedExportDialog 入口隐藏（V2 §6 Note） -->
 
     <ReferenceRepairDialog
       v-model:open="linearScene.editor.dialogs.repair.open"
@@ -131,12 +134,12 @@ import ReferenceRepairDialog from '../components/ReferenceRepairDialog.vue';
 import LinkSuggestion from '../components/LinkSuggestion.vue';
 import NoteContextPanel from '../components/NoteContextPanel.vue';
 import ResourcePickerDialog from '../components/ResourcePickerDialog.vue';
-import SelfContainedExportDialog from '../components/SelfContainedExportDialog.vue';
 import AppEmptyState from '../../../components/shared/AppEmptyState.vue';
-import { useViewportBreakpoint } from '../../../shared/composables/useViewportBreakpoint';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
 import { useEditorLinearScene } from '../composables/useEditorLinearScene';
 
 const { t } = useI18n();
-const { isLgUp } = useViewportBreakpoint();
+// 面板两档（V2 §7）：窄档隐藏反链/图谱侧栏重交互。
+const { isNarrow, isWide } = usePanelWidth();
 const linearScene = useEditorLinearScene();
 </script>

--- a/packages/app-vue/src/modules/governance/components/RevisionCard.vue
+++ b/packages/app-vue/src/modules/governance/components/RevisionCard.vue
@@ -21,7 +21,7 @@
         class="rounded-md border border-muted p-3"
       >
         <p class="text-xs font-medium mb-2">{{ field }}</p>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
+        <div class="grid grid-cols-1 gap-2 text-xs @2xl/panel:grid-cols-2">
           <div class="rounded bg-destructive/5 p-2">
             <p class="text-muted-foreground mb-1">Before</p>
             <pre class="whitespace-pre-wrap break-words">{{ stringifyValue(revision.previousValues[field]) }}</pre>

--- a/packages/app-vue/src/modules/governance/router/index.ts
+++ b/packages/app-vue/src/modules/governance/router/index.ts
@@ -1,13 +1,18 @@
 /**
- * Governance module routes
+ * Governance module routes（并入 Note「规范」分区，V2 §3 / §6 Note）
+ *
+ * 路径契约不变：`/governance/**`。挂到 NoteModuleLayout 下，
+ * 顶部分区自动落「规范」。
  */
 
 import type { RouteRecordRaw } from 'vue-router';
 
+const NoteModuleLayout = () => import('../../repository/views/NoteModuleLayout.vue');
+
 export const governanceRoutes: RouteRecordRaw[] = [
   {
     path: '/governance',
-    name: 'governance',
+    component: NoteModuleLayout,
     meta: {
       title: 'governance.route.ruleList',
       showInNav: true,

--- a/packages/app-vue/src/modules/governance/views/RuleEditorView.vue
+++ b/packages/app-vue/src/modules/governance/views/RuleEditorView.vue
@@ -29,7 +29,7 @@
     </div>
 
     <form @submit.prevent="handleSubmit">
-      <div class="grid grid-cols-1 md:grid-cols-[1fr_300px] gap-6">
+      <div class="grid grid-cols-1 gap-6 @3xl/panel:grid-cols-[1fr_300px]">
         <!-- Left column: Main Info -->
         <div class="space-y-6">
           <!-- Basic Info Card -->
@@ -38,7 +38,7 @@
               <h2 class="text-sm font-medium">{{ t('governance.editor.basicInfo') }}</h2>
             </div>
             <div class="p-4 space-y-4">
-              <div class="grid grid-cols-1 sm:grid-cols-[1fr_2fr] gap-4">
+              <div class="grid grid-cols-1 gap-4 @2xl/panel:grid-cols-[1fr_2fr]">
                 <div>
                   <label class="block text-sm font-medium mb-1.5">
                     {{ t('governance.editor.ruleCode') }} <span class="text-destructive">*</span>
@@ -90,7 +90,7 @@
                 </p>
               </div>
 
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div class="grid grid-cols-1 gap-4 @2xl/panel:grid-cols-2">
                 <div>
                   <label class="block text-sm font-medium mb-1.5">
                     {{ t('governance.editor.severity') }} <span class="text-destructive">*</span>

--- a/packages/app-vue/src/modules/repository/components/NoteSegmentBar.vue
+++ b/packages/app-vue/src/modules/repository/components/NoteSegmentBar.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    class="flex h-10 shrink-0 items-center gap-1 border-b bg-sidebar/60 px-2"
+    data-testid="note-segment-bar"
+  >
+    <button
+      v-for="segment in segments"
+      :key="segment.value"
+      type="button"
+      :data-testid="`note-segment-${segment.value}`"
+      class="rounded-md px-3 py-1.5 text-sm transition-colors"
+      :class="
+        active === segment.value
+          ? 'bg-secondary font-medium text-foreground'
+          : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+      "
+      @click="$emit('select', segment.value)"
+    >
+      <component :is="segment.icon" class="mr-1.5 inline-block h-3.5 w-3.5 align-[-2px]" />
+      {{ segment.label }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * NoteSegmentBar — Note 面板顶部 [笔记 | 规范] 分区切换（UI 重构 V2 §3 / §6 Note）
+ *
+ * 笔记 = RepositoryWorkspaceView / /note/:id；规范 = /governance/**。
+ * 路由 path 不变，仅在 Note 壳内切换分区导航。
+ */
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { BookOpen, ShieldCheck } from 'lucide-vue-next';
+
+export type NoteSegment = 'notes' | 'governance';
+
+defineProps<{
+  active: NoteSegment;
+}>();
+
+defineEmits<{
+  select: [segment: NoteSegment];
+}>();
+
+const { t } = useI18n();
+
+const segments = computed(() => [
+  {
+    value: 'notes' as const,
+    label: t('repository.segments.notes'),
+    icon: BookOpen,
+  },
+  {
+    value: 'governance' as const,
+    label: t('repository.segments.governance'),
+    icon: ShieldCheck,
+  },
+]);
+</script>

--- a/packages/app-vue/src/modules/repository/components/TypedFileTree.vue
+++ b/packages/app-vue/src/modules/repository/components/TypedFileTree.vue
@@ -19,16 +19,6 @@
         <FilePlus class="h-4 w-4" />
       </Button>
 
-      <Button
-        variant="ghost"
-        size="icon"
-        class="h-8 w-8"
-        :title="t('repository.import.title')"
-        @click="$emit('import')"
-      >
-        <Upload class="h-4 w-4" />
-      </Button>
-
       <div class="flex-1" />
 
       <Button
@@ -69,10 +59,6 @@
           <Button size="sm" variant="outline" @click="$emit('create-note')">
             <FilePlus class="mr-2 h-4 w-4" />
             {{ t('repository.workspace.createNote') }}
-          </Button>
-          <Button size="sm" variant="outline" @click="$emit('import')">
-            <Upload class="mr-2 h-4 w-4" />
-            {{ t('repository.import.title') }}
           </Button>
         </div>
       </div>
@@ -320,12 +306,6 @@ function getGroupActions(groupKey: string): MenuAction[] {
   }
 
   return [
-    {
-      key: 'import',
-      label: t('repository.import.title'),
-      icon: Upload,
-      handler: () => emit('import'),
-    },
     {
       key: 'refresh',
       label: t('common.retry'),

--- a/packages/app-vue/src/modules/repository/components/index.ts
+++ b/packages/app-vue/src/modules/repository/components/index.ts
@@ -14,3 +14,4 @@ export { default as TabManager } from './TabManager.vue';
 // Dialogs
 export { default as CreateResourceDialog } from './dialogs/CreateResourceDialog.vue';
 export { default as BatchImportDialog } from './BatchImportDialog.vue';
+export { default as NoteSegmentBar } from './NoteSegmentBar.vue';

--- a/packages/app-vue/src/modules/repository/router/index.ts
+++ b/packages/app-vue/src/modules/repository/router/index.ts
@@ -1,15 +1,18 @@
 /**
- * Repository 模块路由配置
- * Obsidian 风格笔记工作区
+ * Repository / Note 模块路由配置（UI 重构 V2 §3 / §6 Note）
+ *
+ * 路径契约不变：`/repository`、`/note/:id`。
+ * 与 governance 共用 NoteModuleLayout 顶部分区 [笔记 | 规范]。
  */
 
 import type { RouteRecordRaw } from 'vue-router';
 
+const NoteModuleLayout = () => import('../views/NoteModuleLayout.vue');
+
 export const repositoryRoutes: RouteRecordRaw[] = [
   {
     path: '/repository',
-    name: 'repository',
-    component: () => import('../views/RepositoryWorkspaceView.vue'),
+    component: NoteModuleLayout,
     meta: {
       title: 'repository.route.workspace',
       showInNav: true,
@@ -17,15 +20,37 @@ export const repositoryRoutes: RouteRecordRaw[] = [
       order: 7,
       requiresAuth: true,
     },
+    children: [
+      {
+        path: '',
+        name: 'repository',
+        component: () => import('../views/RepositoryWorkspaceView.vue'),
+        meta: {
+          title: 'repository.route.workspace',
+          requiresAuth: true,
+        },
+      },
+    ],
   },
   {
     path: '/note/:id',
-    name: 'note-edit',
-    component: () => import('../../editor/views/EditorLinearView.vue'),
+    component: NoteModuleLayout,
     meta: {
       title: 'repository.route.noteEdit',
       requiresAuth: true,
       hideSidebar: true,
     },
+    children: [
+      {
+        path: '',
+        name: 'note-edit',
+        component: () => import('../../editor/views/EditorLinearView.vue'),
+        meta: {
+          title: 'repository.route.noteEdit',
+          requiresAuth: true,
+          hideSidebar: true,
+        },
+      },
+    ],
   },
 ];

--- a/packages/app-vue/src/modules/repository/views/NoteModuleLayout.vue
+++ b/packages/app-vue/src/modules/repository/views/NoteModuleLayout.vue
@@ -1,0 +1,43 @@
+<template>
+  <div
+    class="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background"
+    data-testid="note-module-layout"
+  >
+    <NoteSegmentBar :active="activeSegment" @select="selectSegment" />
+    <div class="min-h-0 flex-1 overflow-hidden">
+      <router-view />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * NoteModuleLayout — Note 模块壳（UI 重构 V2 §3 / §6 Note）
+ *
+ * 顶部固定 [笔记 | 规范] 分区切换；内容区渲染
+ * `/repository`、`/note/:id`、`/governance/**`（路径契约不变）。
+ * 深链打开 governance 时 activeSegment 自动落「规范」。
+ */
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import NoteSegmentBar, { type NoteSegment } from '../components/NoteSegmentBar.vue';
+
+const route = useRoute();
+const router = useRouter();
+
+const activeSegment = computed<NoteSegment>(() =>
+  route.path === '/governance' || route.path.startsWith('/governance/')
+    ? 'governance'
+    : 'notes',
+);
+
+function selectSegment(segment: NoteSegment) {
+  if (segment === activeSegment.value) return;
+  if (segment === 'governance') {
+    void router.push('/governance');
+    return;
+  }
+  // 回笔记分区：优先工作区落地页（不强制保留某篇 note，避免跨分区脏状态）
+  void router.push('/repository');
+}
+</script>

--- a/packages/app-vue/src/modules/repository/views/RepositoryWorkspaceView.vue
+++ b/packages/app-vue/src/modules/repository/views/RepositoryWorkspaceView.vue
@@ -1,19 +1,104 @@
 <!--
-  RepositoryWorkspaceView - Obsidian-style workspace layout
+  RepositoryWorkspaceView - Note workspace (UI 重构 V2 §6 Note / §7)
   Left: resizable sidebar with mode switcher (Files / Search / Bookmarks)
-  Right: TabManager + CodeMirror 6 editor (EditorToolbar + EditorSplitView + EditorPreview) / MediaViewer
+  Right: CodeMirror 6 editor (EditorToolbar + ActiveDocumentPane / MediaViewer)
+  面板两档：窄档收敛侧栏为顶部 mode 下拉；宽档恢复完整侧栏。
+  阶段 0：模块内 TabManager / 批量导入 / 自包含导出入口隐藏（壳级 Note Tab 承接多开）。
 -->
 
 <template>
-  <div class="flex h-full overflow-hidden bg-background">
-    <ResizablePanelGroup direction="horizontal">
-      <!-- ─── Left Sidebar ─── -->
+  <div
+    class="flex h-full overflow-hidden bg-background"
+    :class="isNarrow ? 'flex-col' : 'flex-row'"
+    data-testid="repository-workspace-view"
+  >
+    <!-- 窄档：侧栏 mode 收敛为顶部下拉（V2 §7） -->
+    <div
+      v-if="isNarrow"
+      class="flex h-10 shrink-0 items-center gap-1 border-b bg-sidebar/60 px-2"
+      data-testid="repository-sidebar-switcher"
+    >
+      <Button
+        v-for="mode in workspaceScene.sidebar.modes"
+        :key="mode.key"
+        variant="ghost"
+        size="sm"
+        class="h-8 gap-1.5 px-2"
+        :class="{ 'bg-accent font-medium': workspaceScene.sidebar.mode === mode.key }"
+        :data-testid="`repository-sidebar-mode-${mode.key}`"
+        @click="workspaceScene.sidebar.actions.setMode(mode.key)"
+      >
+        <component :is="mode.icon" class="h-4 w-4" />
+        <span class="text-xs">{{ mode.label }}</span>
+      </Button>
+      <div class="flex-1" />
+      <Button
+        size="sm"
+        class="h-8"
+        data-testid="repository-create-note-narrow"
+        @click="workspaceScene.sidebar.files.actions.createNote"
+      >
+        <FilePlus class="mr-1 h-4 w-4" />
+        {{ t('repository.workspace.createNote') }}
+      </Button>
+    </div>
+
+
+    <!-- 窄档：mode 内容区（文件树/搜索/书签），高度有限 -->
+    <div
+      v-if="isNarrow"
+      class="max-h-[40%] min-h-[160px] shrink-0 overflow-hidden border-b"
+      data-testid="repository-sidebar-narrow-body"
+    >
+      <TypedFileTree
+        v-if="workspaceScene.sidebar.mode === 'files'"
+        :resources-by-type="workspaceScene.sidebar.files.resourcesByType"
+        :tree-nodes="workspaceScene.sidebar.files.treeNodes"
+        :is-loading="workspaceScene.status.isLoading"
+        :selected-id="workspaceScene.sidebar.files.selectedId"
+        @create-note="workspaceScene.sidebar.files.actions.createNote"
+        @refresh="workspaceScene.sidebar.files.actions.refresh"
+        @open="workspaceScene.sidebar.files.actions.open"
+        @rename="workspaceScene.sidebar.files.actions.rename"
+        @delete="workspaceScene.sidebar.files.actions.delete"
+      />
+      <SearchPanel
+        v-else-if="workspaceScene.sidebar.mode === 'search'"
+        :repository-id="workspaceScene.sidebar.search.repositoryId || ''"
+        :results="workspaceScene.sidebar.search.results"
+        :searching="workspaceScene.sidebar.search.status.isSearching"
+        :has-searched="workspaceScene.sidebar.search.status.hasSearched"
+        :total-results="workspaceScene.sidebar.search.status.totalResults"
+        :total-matches="workspaceScene.sidebar.search.status.totalMatches"
+        :search-time="workspaceScene.sidebar.search.status.searchTime"
+        @close="workspaceScene.sidebar.search.actions.close"
+        @select="workspaceScene.sidebar.search.actions.select"
+        @search="workspaceScene.sidebar.search.actions.search"
+      />
+      <BookmarksPanel
+        v-else-if="workspaceScene.sidebar.mode === 'bookmarks'"
+        :bookmarks="workspaceScene.sidebar.bookmarks.items"
+        :can-rename="workspaceScene.sidebar.bookmarks.capabilities.canRename"
+        :can-reorder="workspaceScene.sidebar.bookmarks.capabilities.canReorder"
+        :can-remove="workspaceScene.sidebar.bookmarks.capabilities.canRemove"
+        @select="workspaceScene.sidebar.bookmarks.actions.select"
+        @rename="workspaceScene.sidebar.bookmarks.actions.rename"
+        @move-up="workspaceScene.sidebar.bookmarks.actions.moveUp"
+        @move-down="workspaceScene.sidebar.bookmarks.actions.moveDown"
+        @remove="workspaceScene.sidebar.bookmarks.actions.remove"
+      />
+    </div>
+
+    <ResizablePanelGroup direction="horizontal" class="min-h-0 flex-1">
+      <!-- ─── Left Sidebar（宽档） ─── -->
       <ResizablePanel
+        v-if="!isNarrow"
         :default-size="22"
         :min-size="15"
         :max-size="40"
         :collapsed-size="0"
         :collapsible="true"
+        data-testid="repository-group-sidebar"
         @collapse="workspaceScene.sidebar.actions.setCollapsed(true)"
         @expand="workspaceScene.sidebar.actions.setCollapsed(false)"
       >
@@ -63,7 +148,6 @@
               :is-loading="workspaceScene.status.isLoading"
               :selected-id="workspaceScene.sidebar.files.selectedId"
               @create-note="workspaceScene.sidebar.files.actions.createNote"
-              @import="workspaceScene.dialogs.import.open = true"
               @refresh="workspaceScene.sidebar.files.actions.refresh"
               @open="workspaceScene.sidebar.files.actions.open"
               @rename="workspaceScene.sidebar.files.actions.rename"
@@ -102,23 +186,12 @@
         </aside>
       </ResizablePanel>
 
-      <ResizableHandle with-handle />
+      <ResizableHandle v-if="!isNarrow" with-handle />
 
       <!-- ─── Main Content Area ─── -->
       <ResizablePanel :default-size="78">
         <main class="flex h-full flex-col overflow-hidden">
-          <!-- Tab Bar -->
-          <TabManager
-            v-if="workspaceScene.main.tabs.items.length > 0"
-            :tabs="(workspaceScene.main.tabs.items as import('../components/TabManager.vue').ResourceTab[])"
-            :active-tab-id="workspaceScene.main.tabs.activeId"
-            @switch-tab="workspaceScene.main.tabs.actions.switch"
-            @close-tab="workspaceScene.main.tabs.actions.close"
-            @toggle-pin="workspaceScene.main.tabs.actions.togglePin"
-            @close-others="workspaceScene.main.tabs.actions.closeOthers"
-            @close-right="workspaceScene.main.tabs.actions.closeRight"
-            @close-all="workspaceScene.main.tabs.actions.closeAll"
-          />
+          <!-- 阶段 0：模块内 TabManager 退役；多开笔记 = 壳级 Note Tab（V2 §6 Note / §9） -->
 
           <!-- Editor / Viewer -->
           <div class="flex-1 overflow-hidden relative">
@@ -149,7 +222,6 @@
                 @insert-text="workspaceScene.main.editor.actions.insertText"
                 @insert-resource="workspaceScene.main.editor.actions.openResourcePicker"
                 @insert-existing-image="workspaceScene.main.editor.actions.openImagePicker"
-                @export-self-contained="workspaceScene.main.editor.actions.exportSelfContained"
                 @wrap-selection="workspaceScene.main.editor.actions.wrapSelection"
                 @view-mode-change="workspaceScene.main.editor.actions.setViewMode"
                 @save="workspaceScene.main.editor.actions.save"
@@ -233,29 +305,13 @@
                   <FilePlus class="h-4 w-4 mr-2" />
                   {{ t('repository.workspace.createNote') }}
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  @click="workspaceScene.dialogs.import.open = true"
-                >
-                  <Upload class="h-4 w-4 mr-2" />
-                  {{ t('repository.import.title') }}
-                </Button>
               </div>
             </div>
           </div>
         </main>
       </ResizablePanel>
     </ResizablePanelGroup>
-
-    <!-- Batch Import Dialog -->
-    <BatchImportDialog
-      v-model:open="workspaceScene.dialogs.import.open"
-      :importing="workspaceScene.dialogs.import.isUploading"
-      :progress="workspaceScene.dialogs.import.progress"
-      :summary="workspaceScene.dialogs.import.summary"
-      @import="workspaceScene.dialogs.import.actions.submit"
-    />
+    <!-- 阶段 0：BatchImportDialog 退役（V2 §6 Note / V1 §9） -->
 
     <ImageResourcePickerDialog
       v-model:open="workspaceScene.main.editor.dialogs.imagePicker.open"
@@ -270,13 +326,7 @@
       :recent-items="workspaceScene.main.editor.resources.recentResourceItems"
       @select="workspaceScene.main.editor.actions.insertResource"
     />
-
-    <SelfContainedExportDialog
-      v-model:open="workspaceScene.main.editor.dialogs.export.open"
-      :result="workspaceScene.main.editor.dialogs.export.result"
-      @copy="workspaceScene.main.editor.actions.copyExport"
-      @download="workspaceScene.main.editor.actions.downloadExport"
-    />
+    <!-- 阶段 0：SelfContainedExportDialog 入口隐藏（V2 §6 Note / V1 §9） -->
 
     <ReferenceRepairDialog
       v-model:open="workspaceScene.main.editor.dialogs.repair.open"
@@ -318,7 +368,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { BookOpen, FilePlus, PanelLeftClose, Upload } from 'lucide-vue-next';
+import { usePanelWidth } from '../../../layouts/shell/usePanelWidth';
+import { BookOpen, FilePlus, PanelLeftClose } from 'lucide-vue-next';
 import {
   ResizablePanel,
   ResizablePanelGroup,
@@ -339,12 +390,9 @@ import {
 import TypedFileTree from '../components/TypedFileTree.vue';
 import SearchPanel from '../components/SearchPanel.vue';
 import BookmarksPanel from '../components/BookmarksPanel.vue';
-import TabManager from '../components/TabManager.vue';
-import BatchImportDialog from '../components/BatchImportDialog.vue';
 import ImageResourcePickerDialog from '../../editor/components/ImageResourcePickerDialog.vue';
 import ReferenceRepairDialog from '../../editor/components/ReferenceRepairDialog.vue';
 import ResourcePickerDialog from '../../editor/components/ResourcePickerDialog.vue';
-import SelfContainedExportDialog from '../../editor/components/SelfContainedExportDialog.vue';
 import MediaViewer from '../../editor/components/MediaViewer.vue';
 import ActiveDocumentPane from '../../editor/components/ActiveDocumentPane.vue';
 import { useRepositoryWorkspaceScene } from '../../editor/composables';
@@ -367,6 +415,8 @@ const props = withDefaults(
 );
 
 const { t } = useI18n();
+// 面板两档（V2 §7）：窄档收敛文件树侧栏为顶部 mode 下拉。
+const { isNarrow } = usePanelWidth();
 const workspaceScene = useRepositoryWorkspaceScene(
   computed(() => props.initialSidebarMode as EditorWorkspaceSidebarMode),
 );

--- a/packages/app-vue/src/modules/repository/views/notePanelAdaptation.spec.ts
+++ b/packages/app-vue/src/modules/repository/views/notePanelAdaptation.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { computed, defineComponent, h, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { providePanelWidth, usePanelWidth } from '../../../layouts/shell/usePanelWidth';
+
+/**
+ * Lightweight probe for S4-Note panel adaptation (V2 §6 Note / §7):
+ * - segment bar always present; deep-link path selects notes vs governance
+ * - narrow (split): repository sidebar switcher; wide restores full sidebar
+ *
+ * Mirrors NoteModuleLayout + RepositoryWorkspaceView tier surface without
+ * mounting stores/editor.
+ */
+function mountNotePanelAdaptationProbe(initialWidth: number, path = '/repository') {
+  const widthHandle: { current: number } = { current: initialWidth };
+  const currentPath = ref(path);
+
+  const Probe = defineComponent({
+    name: 'NotePanelAdaptationProbe',
+    setup() {
+      const { isNarrow } = usePanelWidth();
+      const activeSegment = computed(() =>
+        currentPath.value === '/governance' || currentPath.value.startsWith('/governance/')
+          ? 'governance'
+          : 'notes',
+      );
+      const showSwitcher = computed(() => isNarrow.value);
+      const showSidebar = computed(() => !isNarrow.value);
+
+      return () =>
+        h('div', { 'data-testid': 'note-module-layout' }, [
+          h('div', { 'data-testid': 'note-segment-bar' }, [
+            h(
+              'button',
+              {
+                'data-testid': 'note-segment-notes',
+                'data-active': String(activeSegment.value === 'notes'),
+                onClick: () => {
+                  currentPath.value = '/repository';
+                },
+              },
+              'notes',
+            ),
+            h(
+              'button',
+              {
+                'data-testid': 'note-segment-governance',
+                'data-active': String(activeSegment.value === 'governance'),
+                onClick: () => {
+                  currentPath.value = '/governance';
+                },
+              },
+              'governance',
+            ),
+          ]),
+          h('div', { 'data-testid': 'note-active-segment' }, activeSegment.value),
+          showSwitcher.value
+            ? h('div', { 'data-testid': 'repository-sidebar-switcher' }, 'switcher')
+            : null,
+          showSidebar.value
+            ? h('div', { 'data-testid': 'repository-group-sidebar' }, 'sidebar')
+            : null,
+        ]);
+    },
+  });
+
+  const Parent = defineComponent({
+    setup() {
+      const { width } = providePanelWidth();
+      width.value = widthHandle.current;
+      Object.defineProperty(widthHandle, 'current', {
+        get: () => width.value ?? initialWidth,
+        set: (value: number) => {
+          width.value = value;
+        },
+      });
+      return () => h(Probe);
+    },
+  });
+
+  const wrapper = mount(Parent);
+  return {
+    wrapper,
+    setWidth: (value: number) => {
+      widthHandle.current = value;
+    },
+    setPath: async (value: string) => {
+      currentPath.value = value;
+      await nextTick();
+    },
+  };
+}
+
+describe('Note panel adaptation (V2 §6 Note / §7)', () => {
+  it('switches notes|governance segments and two-tier sidebar navigation', async () => {
+    const { wrapper, setWidth, setPath } = mountNotePanelAdaptationProbe(450, '/repository');
+
+    expect(wrapper.find('[data-testid="note-segment-bar"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="note-active-segment"]').text()).toBe('notes');
+    expect(wrapper.find('[data-testid="repository-sidebar-switcher"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="repository-group-sidebar"]').exists()).toBe(false);
+
+    await wrapper.get('[data-testid="note-segment-governance"]').trigger('click');
+    await nextTick();
+    expect(wrapper.get('[data-testid="note-active-segment"]').text()).toBe('governance');
+
+    // Deep-link governance path lands on standards segment
+    await setPath('/governance/rule-1');
+    expect(wrapper.get('[data-testid="note-active-segment"]').text()).toBe('governance');
+
+    // Wide / focus restores full sidebar for notes workspace
+    await setPath('/repository');
+    setWidth(1200);
+    await nextTick();
+    expect(wrapper.find('[data-testid="repository-sidebar-switcher"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="repository-group-sidebar"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="note-active-segment"]').text()).toBe('notes');
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
S4 Note 阶段 0 收尾 + Governance 并入（V2 §3 / §6 Note / §7）。

- 面板顶部 **[笔记 | 规范]** 分区切换（`NoteModuleLayout` + `NoteSegmentBar`）
- 路径契约保留：`/repository`、`/note/:id`、`/governance/**`；深链 `/governance/**` 自动落「规范」
- 面板两档：窄档侧栏 mode 收敛顶栏，宽档完整侧栏；编辑器反链/图谱窄档提示最大化
- 阶段 0 残留入口隐藏：模块内 TabManager / 批量导入 / 自包含导出
- governance 表单网格改 `@*/panel` 容器查询；单测 probe 覆盖分区与窄宽导航

## 变更
- `packages/app-vue/src/modules/repository/**`：布局/分区/两档/阶段 0
- `packages/app-vue/src/modules/governance/**`：路由挂到 Note 壳 + CQ
- `packages/app-vue/src/modules/editor/**`：LinearView 两档 + Toolbar 导出隐藏（最小 diff）
- locales：仅追加 `repository.segments` / `editor.linear.contextRequiresFocus`

## 验证
- [x] `pnpm nx run-many -t lint typecheck test -p app-vue`（205 pass，含 `notePanelAdaptation`）
- [x] `pnpm nx run web:typecheck`
- [x] MSW smoke @5177 **18/18**：Note 胶囊分区切换、规范列表、`/governance` 深链、split/focus 两档导航
- [x] 写域隔离：未碰 `ai/**` / AppShell AI 层 / plan docs

## 说明
S2 已全部完成（#177–#182），S3 已合（#183）。本 PR 为 **S4**；合入后协调者勾 plan / 进入 S5 收尾。