### PR TITLE
fix(api): E5b bootstrap LegacyAccountModule → AccountApiModule

### DIFF
--- a/apps/api/src/bootstrap-module-names.surface.spec.ts
+++ b/apps/api/src/bootstrap-module-names.surface.spec.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Elegance E5b: API bootstrap docs must not invent dead Legacy* module names.
+ * Production registration lives in main.ts via AccountApiModule (and peers).
+ */
+describe('api bootstrap module names (elegance E5b)', () => {
+  const dir = __dirname;
+  const bootstrap = readFileSync(resolve(dir, 'bootstrap.ts'), 'utf8');
+  const main = readFileSync(resolve(dir, 'main.ts'), 'utf8');
+
+  it('example registers AccountApiModule; no retired account module alias in bootstrap', () => {
+    expect(bootstrap).toContain('.register(AccountApiModule)');
+    expect(bootstrap).toContain('Residual E5b');
+    // Ban the historical fake module name in docs/example (E5 dead-domain).
+    expect(bootstrap).not.toMatch(/LegacyAccountModule/);
+    expect(bootstrap).not.toMatch(/\.register\(\s*Legacy\w*Module\s*\)/);
+  });
+
+  it('main wires AccountApiModule as the account API module', () => {
+    expect(main).toContain("from '@dailyuse/account/api'");
+    expect(main).toContain('.register(AccountApiModule)');
+    expect(main).not.toMatch(/LegacyAccountModule/);
+  });
+});

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -8,11 +8,14 @@
  * ```typescript
  * const app = await new ApiBootstrapper()
  *   .register(GovernanceApiModule)
- *   .register(LegacyAccountModule)
+ *   .register(AccountApiModule)
  *   .init();
  *
  * app.listen(3000);
  * ```
+ *
+ * Residual E5b (elegance): example must name real modules registered from
+ * `main.ts` (e.g. `AccountApiModule`). Do not document retired account module aliases.
  */
 
 import express, { type Express, Router } from 'express';

--- a/docs/plan/active/2026-07-25-nightly-hygiene-and-agent-host.md
+++ b/docs/plan/active/2026-07-25-nightly-hygiene-and-agent-host.md
@@ -128,6 +128,7 @@ residual 记本文件 §9 与 elegance plan §9。
 | N1b | 2026-07-25 | dual 扫描：`formatFileSize` 等仍为 L keep-boundary（1145），**不 merge** | hygiene L | 跳过微 dual |
 | N2 | 2026-07-25 | AH-2：Conversation↔Host association surface（open-chat ≠ listAgentRuns；§20 不勾） | agent-host | surface 绿 |
 | E-PR189 | 2026-07-26 | elegance A+B+C：archive vault；Dual Registry；dual 237→84；AI path map；AH-2 书面不做 | elegance | merge 门槛 |
+| E5b | 2026-07-26 | bootstrap LegacyAccountModule → AccountApiModule + surface（#189 后真 E5 S） | elegance | 死域 S |
 | N3 | 2026-07-25 | AH-3：ProposalKernel stale 禁 approve；revise 清 stale→draft；STALE_REVISION 仍在 | agent-host | kernel tests |
 
 ## 10. 完成 / 归档

--- a/docs/plan/active/2026-07-26-codebase-elegance-foundation.md
+++ b/docs/plan/active/2026-07-26-codebase-elegance-foundation.md
@@ -278,7 +278,8 @@ GOAL_PRIORITY（优雅阶段期间调整为）=
 | E2 | 2026-07-26 | Dual Registry：`tools/governance/dual-registry.json` + `docs/governance/dual-registry.md`；150 条目全部分类（retired/keep_boundary）；path surface 锁 | B | E2 达标 |
 | E3b | 2026-07-26 | dual-surface 237→84（**-64.6%**）；25 个 `dual-registry.surface.spec.ts` suite；open_S/M/X=0（E3a 亦满足） | B | E3 达标 |
 | E4 | 2026-07-26 | AI 路径地图 `docs/architecture/ai-runtime-path-map.md` + host-dispatch surface 加强 | C | E4 达标 |
-| E5 | 2026-07-26 | 死域 S：沿用/核验 result-helpers-dead 等；无新增假 dual；Legacy 注释仅保留真语义 | C | 一轮完成 |
+| E5 | 2026-07-26 | 死域 S 初核：result-helpers-dead 等既有锁；**未**改 bootstrap（E5 当时过宽宣称） | C | 部分 |
+| E5b | 2026-07-26 | **真 E5 S**：`apps/api/src/bootstrap.ts` 示例 `LegacyAccountModule` → `AccountApiModule`；surface 锁与 main 一致 | C | 死域 S 落地 |
 | E6 | 2026-07-26 | AH-2 **本轮不做**（书面决策进 agent-host）；AH-4/5/6 follow-up/external | D 轻量 | 决策落盘 |
 | E7 | 2026-07-26 | governance-check 绿；contracts/utils/ai/auth/governance/goal/app-vue/desktop:test:main 绿 | E | 门禁 |
 | E-merge | 2026-07-26 | PR #189 达 merge 门槛后合 main | E | merge |

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -15,7 +15,7 @@ updated: 2026-07-26T00:00:00
 
 | 计划                                                                                                | 当前状态                                                                                                                                                           |
 | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [代码优雅化与后续实施地基](./2026-07-26-codebase-elegance-foundation.md) | **主目标**：Dual Registry + dual 清理 / 路径地图；**PR #189 执行完再合**（A+B 必达，宜 C）；§3.1 + §10 提示词 |
+| [代码优雅化与后续实施地基](./2026-07-26-codebase-elegance-foundation.md) | **主目标**：Dual Registry + dual 清理 / 路径地图；**PR #189 已合 main**；E5b bootstrap 死域 follow-up；§3.1 |
 | [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md) | **执行协议**：GOAL_PRIORITY 对齐 #189 merge 门槛；服务 elegance dual 清理 |
 | [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)                         | **实施中**（完成定义未宣称）：统一助手、右侧工作台、Workflow/Turn/Model；产品主能力线                                                                                                       |
 | [Auth + Account 收敛与安全闭环](./2026-07-17-auth-account-security-closure.md)                      | **实施中**：A–E 源码闭环；待 e2e 真跑与生产发信                                                                                                                    |


### PR DESCRIPTION
## Summary

Follow-up to #189 elegance E5 honesty gap (skeptic):

- `apps/api/src/bootstrap.ts` JSDoc example used non-existent `LegacyAccountModule` while `main.ts` registers `AccountApiModule`.
- Add `bootstrap-module-names.surface.spec.ts` lock.
- Residual E5/E5b corrected in elegance + nightly plans.

## Test plan

- [x] `vitest` `apps/api/src/bootstrap-module-names.surface.spec.ts` (2/2)
- [x] host-dispatch surface (4/4)
- [x] governance dual-registry-path
- [x] contracts ai dual-registry suite sample
- [x] `pnpm nx run daily-use:governance-check`