### PR TITLE
docs(adr): ADR-037 product time system

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -28,3 +28,8 @@ updated: 2026-04-26T00:00:00
 - 分阶段迁移计划
 - 与代码重复的一次性实现说明
 - 模块级的长篇操作手册
+
+## 产品时间
+
+- [ADR-037 产品时间体系](./adr/ADR-037-product-time-system.md)
+- [产品时间体系详设](./product-time-system.md)

--- a/docs/architecture/adr/ADR-037-product-time-system.md
+++ b/docs/architecture/adr/ADR-037-product-time-system.md
@@ -1,0 +1,257 @@
+---
+tags:
+  - adr
+  - time
+  - contracts
+  - domain
+  - utils
+  - style
+  - date-fns
+description: ADR-037 - 产品时间体系：Instant/Ymd 契约、TransferDate 对齐、DomainDate 退役、门面与风格治理
+created: 2026-07-26T00:00:00
+updated: 2026-07-26T00:00:00
+---
+
+# ADR-037: 产品时间体系（Product Time System）
+
+**状态：** 已采纳  
+**日期：** 2026-07-26  
+**影响范围：** contracts primitives、全体 domain VO/Entity、`@dailyuse/utils` 时间相关 API、app-vue / app-react / desktop / api、展示与表单、Prisma/PowerSync mapper、Dual/Time Registry、ESLint 治理
+
+**配套详述：** [`../product-time-system.md`](../product-time-system.md)
+
+---
+
+## 1. 背景
+
+### 1.1 现象
+
+仓库已选定 **date-fns** 作为主要日期库，并在多轮 dual 清理中收敛了大量本地 `format*`。但时间能力仍分裂为多套并行事实：
+
+1. **开源库直连**：业务与 UI 大量 `import { format } from 'date-fns'`，locale/空值/pattern 各写各的。  
+2. **薄封装未成产品入口**：`@dailyuse/utils` 的 `shared/date.ts` 能力窄，且 UI 主路径很少走它。  
+3. **组件私有 format**：Vue/React 卡片与 Screen 内仍大量 `function formatDate` / `toLocaleString`。  
+4. **契约双轨**：`DomainDate = Date` 与 `TransferDate = number`（epoch ms）在 contracts 与 domain VO 中广泛使用；VO 内部存 number、getter 返回 `new Date(ms)`；Domain shape 与 DTO shape 用双 interface 锁住（residual 859 类 keep-boundary）。  
+5. **日历日与瞬时混淆**：全天任务日、生日、目标日等被 `Date`/epoch 表达，导致 TaskTimeConfig 等「形状有意不同」却缺少一等日历类型。  
+6. **PersistenceDate** 已从 contracts 移除（正确）；infra 转换仍易散落 `getTime()` / `new Date`。
+
+### 1.2 非目标回顾
+
+- 优雅 ≠ dual-surface 文件数为 0。  
+- 不强制 merge 语义不同的 keep-boundary。  
+- 不在本 ADR 宣称换掉 date-fns 或上线 Temporal 为默认引擎。
+
+### 1.3 要回答的问题
+
+- 时间是否应作为**一等产品能力**受风格治理？  
+- 开源库、门面、领域、contracts 各处什么层？  
+- `DomainDate` / `TransferDate` 是否纳入、如何长期演进？  
+- 如何在「高质量、可长期维护」前提下大刀阔斧落地？
+
+---
+
+## 2. 决策总览
+
+1. **采纳产品时间体系（Product Time System）** 为全仓时间横切的唯一宪法。  
+2. **规范瞬时类型为品牌化 `Instant`（epoch 毫秒）**；**`TransferDate` 与 `Instant` 同构对齐**（wire 主型）。  
+3. **引入一等日历日 `Ymd` 与钟面 `Hm`**，禁止用「某时区午夜 Date」长期冒充日历日。  
+4. **`DomainDate = Date` 别名定为过渡态，长期退役**；领域主型收敛为 `Instant` 和/或 `Ymd`（及必要的不可变日历/区间值对象），禁止无限期依赖可变 `Date` 别名。  
+5. **新建一等包 `@dailyuse/time`**（产品时间门面 + Style + Codec + Calendar + 可替换 Engine）；业务与 UI **禁止**直连 date-fns / 散落产品级 `toLocale*`（白名单仅引擎与登记 exemption）。  
+6. **所有 Domain↔Transfer↔展示 转换只允许经 Codec（及经其生成的 mapper）**；展示只经 Format + `TimeStyle`。  
+7. **保留「domain shape ≠ transfer shape」原则**，但升级为**语义化类型差**（例如日 vs 瞬时），而非永远 `Date` vs `number` 别名差。  
+8. **Persistence 时间类型不重回 contracts**；infra 只经 Codec 与本地列类型。  
+9. **治理**：Time Registry + ESLint 断供 + surface 契约；与 Dual Registry 分工（dual 锁 ≠ 时间宪法）。
+
+---
+
+## 3. 详细决策
+
+### 3.1 分层（逻辑）
+
+```text
+L5 UI / Application     → 只消费 @dailyuse/time（+ 可选模块 presentation）
+L4 Module Presentation  → i18n/业务句子；原子时间串只来自门面
+L3 Product Time Facade  → Clock · Style · Codec · Format · Input · Calendar
+L2 Time Engine          → date-fns / Intl 等，仅 L3 引用
+L1 Platform             → Date / Intl / 可注入 Clock
++ contracts primitives  → Instant/TransferDate/Ymd/Hm 等类型真相（见 3.3）
++ Domain VO/Entity      → 存储与对外 API 遵守 primitives；运算走 Calendar/Clock
++ Infra mappers         → 只经 Codec
+```
+
+**展示风格（人眼）**、**日历/时钟策略（领域）**、**边界形态（wire/domain）** 是三件事，同属时间体系，职责不可混写进一个 `formatDate(any)`。
+
+### 3.2 规范类型
+
+| 类型 | 含义 | 长期角色 |
+|------|------|----------|
+| **`Instant`** | 品牌化 epoch **毫秒** | 规范瞬时；比较、排序、API 瞬时字段 |
+| **`TransferDate`** | wire/DTO/VO 内部传输名 | **≡ `Instant`**（同构；可保留名作 API 文档用语） |
+| **`Ymd`** | 品牌化 `YYYY-MM-DD` **本地日历日**（或产品约定日历） | 生日、全天、目标「日期」、日历格键 |
+| **`Hm`** | 品牌化 `HH:mm` 本地钟面 | 表单 time input、日内时刻 |
+| **`IsoUtc`** | UTC ISO 字符串 | 日志、需互操作的外部文本 |
+| **`DurationMs` / `DurationMin`** | 时长 | 算法与展示分流 |
+| **`DomainDate`** | 今日 `= Date` | **Deprecated 过渡**；禁止新字段 |
+
+**禁止**无品牌 `number` 同时表示秒、毫秒、时长、日期键。  
+**禁止**新代码用 `string` 无 brand 表示「可能是 ISO 也可能是 YMD」。
+
+#### 时区（第一版拍板，预留扩展）
+
+| 场景 | 策略 |
+|------|------|
+| 存储 / API 瞬时 | `Instant`（UTC 瞬间） |
+| 用户日历日 / 日程格 / Ymd | **设备本地时区**（Local Calendar），第一版 |
+| 多用户「业务时区」 | 接口预留 `TimeZonePolicy`；**不**在第一版 entangle 进默认路径 |
+| 日志 | `IsoUtc` |
+
+### 3.3 `TransferDate` 与 `DomainDate`
+
+#### TransferDate（保留名、升级语义）
+
+- **决策：** `TransferDate` **正式等于** 品牌化 `Instant`（epoch ms）。  
+- OpenAPI/JSON 继续传 number ms；类型层消除「普通 number」。  
+- 所有 DTO、客户端投影、VO **内部 props** 的瞬时字段使用 `TransferDate` / `Instant`。  
+- 文档与口语统一 **TransferDate**；废弃 **TransportDate** 第三名词。
+
+#### DomainDate（退役路径）
+
+- **决策：长期不保留 `type DomainDate = Date`。**  
+- **理由（质量优先）：**  
+  - `Date` 可变，破坏值对象不变量；  
+  - getter `new Date(ms)` 制造分配与相等陷阱；  
+  - 与 wire 双栈，迫使每层手写 `getTime`；  
+  - 类型别名在 TS 结构上等于 `Date`，**无真正防错**。  
+- **迁移期：** 保留符号与现有字段，标注 deprecated；**新字段禁止** `DomainDate`。  
+- **目标态领域 API：**  
+  - 瞬时：`Instant`（或只读访问器返回 `Instant`）；  
+  - 日历日：`Ymd`；  
+  - 需要「富领域行为」时用 **不可变值对象**（如 `CalendarDay`、`TimeRange`），**内部仍存 Instant/Ymd**，不暴露可变 `Date`。  
+- **拒绝**长期 R2「继续 Date 别名」；若需对象感，必须不可变包装，且出生只经 Codec。
+
+#### Domain shape ≠ Transfer shape
+
+- **保留原则：** 领域视图与传输 DTO **可以**字段集合或语义不同（residual 859 精神）。  
+- **升级判据：** 差异必须是 **语义**（例：领域 `startDay: Ymd` vs 传输 `startInstant: TransferDate`，或区间表达不同），**不是**同一瞬时的 `Date` vs `number` 换皮。  
+- 当两侧字段语义与类型 **完全同构（皆 Instant 或皆 Ymd）** 时，允许 DTO 与 Domain 类型别名合并，减少假 dual。  
+- contracts surface / Time Registry 重写 859 类文案，避免「永远 Date≠number」。
+
+#### Persistence
+
+- **不**恢复 contracts 级 `PersistenceDate`。  
+- Prisma `DateTime` 等 ↔ `Instant` **仅**经 `@dailyuse/time` Codec 或模块 mapper（调用 Codec）。
+
+### 3.4 包与依赖
+
+| 决策 | 说明 |
+|------|------|
+| **`@dailyuse/time`** | 新建一等 package：Facade、Style、Clock、Codec、Format、Input、Calendar、Engine |
+| **类型放置** | `Instant` / `TransferDate` / `Ymd` / `Hm` 的 **品牌类型** 以 **contracts primitives（或极薄 shared types）为真相**；`@dailyuse/time` 实现行为并 re-export 便利入口，**避免** time ↔ 业务 module 循环依赖 |
+| **`@dailyuse/utils` 时间 API** | `shared/date.ts` 等迁入 time 后删除或短命 re-export；utils 不再作为产品时间主入口 |
+| **app-vue `shared/utils/format-*`** | sole 上提至 `@dailyuse/time` 后删除；过渡 re-export 有明确到期 |
+| **引擎** | 默认 **date-fns** 实现 Calendar/部分 format；展示可组合 **Intl**；均仅存在于 `packages/time/engine/**` |
+
+### 3.5 产品门面能力（必须具备的稳定面）
+
+调用方稳定依赖以下命名空间（具体函数名在 `product-time-system.md` 冻结）：
+
+- **Clock** — `now()`；测试可注入；领域默认「现在」禁止静默 `new Date()`  
+- **Codec** — Transfer/Domain(迁移)/Ymd/Hm/Iso 互转；**非法输入策略显式**（null/throw），禁止 `ensureDate` 变 now  
+- **Format** — `hm` / `date` / `dateTime` / `relative` / `duration` / `range` / `ymdDisplay`… 全部吃 **TimeStyle**  
+- **Input** — date/time 控件值与 parse/combine（消化 formatDateToInput 的 Date vs ms 分裂）  
+- **Calendar** — start/endOfDay、addDays、diffCalendarDays、周起始、同日、isToday  
+
+**模块 presentation（L4）** 只做 i18n 与业务拼装，禁止 pad/parse/date-fns。
+
+### 3.6 TimeStyle（风格一等公民）
+
+凡 **给人看的时间** 与 **日历键/表单时间** 默认受 `TimeStyle` 管理：
+
+- locale、timeZone policy、空值（display/input/unknown）、pattern/密度、相对时间阈值、时长偏好、周起始与日界  
+
+优先级：调用参数 > 局部 partial > 会话 preference > 应用默认。  
+
+**领域不引用 UI locale 做展示**；领域只消费日历/时钟**策略**（与 Style 中 calendar 段对齐的同一政策源，避免日界两套）。
+
+### 3.7 开源库与「再封装」
+
+- **只认 date-fns 为默认算术/ pattern 引擎**（可替换的是 Engine，不是调用方 import）。  
+- **禁止** L1 式「仅 re-export date-fns」冒充门面。  
+- **采纳 L3 门面 + L2 Engine**：换库改 Engine；换产品口味改 Style；换业务措辞改 L4。  
+- **直连 date-fns** 仅允许 `packages/time/engine/**`（及登记的临时 legacy，有 `retire_by`）。
+
+### 3.8 治理
+
+| 机制 | 作用 |
+|------|------|
+| **Time Registry** | canonical / boundary / legacy / exemption；承接 format keep-boundary 与 Domain/Transfer 语义边界 |
+| **ESLint** | 断供业务 `date-fns`、限制产品级 `toLocaleDateString`、限制组件内 `function formatDate` 等 |
+| **Surface** | 门面契约、Ymd 本地日、空值、combine(date+time)、Transfer brand |
+| **Dual Registry** | 继续管 dual-retired 锁文件税；**不**替代时间宪法 |
+| **新字段门禁** | 禁止新增 `DomainDate`；瞬时用 TransferDate/Instant，日用 Ymd |
+
+### 3.9 迁移原则（大刀阔斧但可证伪）
+
+1. **先宪法与断供，再搬迁 sole，再屠龙私有 format，再改领域 getter。**  
+2. **绞杀式：** legacy 名单有到期日；到期 CI 失败。  
+3. **Codemod + 人工：** 同契约自动收；异契约改名进 Registry，禁止静默 merge。  
+4. **不**与 agent-host 产品完成定义捆绑；时间体系独立里程碑。  
+5. **质量优先于速度：** 允许大 PR 分波次合并，但每一波必须门面测试与关键路径绿，禁止「删锁充数」。
+
+---
+
+## 4. 后果
+
+### 4.1 正面
+
+- 全仓时间**单一入口**与**可配置风格**，展示与表单一致。  
+- wire / 领域 / 日历日 **类型诚实**，减少 Date≠number 假 dual 与静默 bug。  
+- 换引擎、换口味、换文案职责清晰，长期可维护。  
+- 与现有 dual 清理成果衔接：sole 上提为 canonical，而非再刷 micro dual。
+
+### 4.2 代价与风险
+
+- 新建包与全域 import 迁移成本高（app-react 私有 format、domain getter 尤重）。  
+- brand 类型在 TS 中需纪律（构造只经 Codec）。  
+- 短期 lint 断供会暴露大量存量，需要 legacy 配额而不是关规则。  
+- 日历日 vs 瞬时的产品语义需在 task/goal/account 字段级清理，有行为变化风险——必须契约测试与抽检。
+
+### 4.3 明确不做什么
+
+- 不引入 dayjs/moment 并行。  
+- 不恢复 PersistenceDate 进 contracts。  
+- 不强制第一版多用户业务时区。  
+- 不 force-merge 真异语义 boundary。  
+- 不把 fileSize、快捷键等非时间 format 塞进 `@dailyuse/time`。
+
+---
+
+## 5. 合规检查（采纳后）
+
+新代码审查至少问：
+
+1. 是否绕过 `@dailyuse/time` 做了产品格式化或日期算术？  
+2. 新字段是 `Instant`/`Ymd` 还是又引入了 `DomainDate`/`Date`？  
+3. DTO 与 Domain 若分形，差异是否语义诚实？  
+4. 空值/locale 是否来自 Style 而非魔数？  
+5. mapper 是否只经 Codec？
+
+---
+
+## 6. 参考
+
+- 详设：[`../product-time-system.md`](../product-time-system.md)  
+- AI 路径地图（展示无关，边界参考）：[`../ai-runtime-path-map.md`](../ai-runtime-path-map.md)  
+- Dual Registry：[`../../governance/dual-registry.md`](../../governance/dual-registry.md)  
+- 优雅化 plan：[`../../plan/active/2026-07-26-codebase-elegance-foundation.md`](../../plan/active/2026-07-26-codebase-elegance-foundation.md)  
+- 现状 primitives：`packages/contracts/src/primitives/domain-date.ts`、`transfer-date.ts`  
+- 现状 VO 模式：`packages/goal/src/server/domain/value-objects/goal-time-range.ts`  
+- 历史：PersistenceDate 移除 plan archive `2026-05-03-contracts-persistence-dto-removal.md`；residual 859 DomainDate≠TransferDate keep-boundary  
+
+---
+
+## 7. 修订
+
+| 日期 | 说明 |
+|------|------|
+| 2026-07-26 | 初版采纳：产品时间体系 + Transfer≡Instant + DomainDate 退役 + `@dailyuse/time` |

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -4,7 +4,7 @@ tags:
   - index
 description: 架构决策记录索引
 created: 2025-11-23T15:00:00
-updated: 2026-07-17T00:00:00
+updated: 2026-07-26T00:00:00
 ---
 
 # ADR 索引
@@ -51,6 +51,7 @@ updated: 2026-07-17T00:00:00
 | [ADR-034](./ADR-034-obsidian-vault-repository.md)                   | 本地 Obsidian Vault 与可选 GitHub 知识仓库               | 已采纳 | 2026-07-16 |
 | [ADR-035](./ADR-035-unified-assistant-agent-host.md)                | 统一助手与可插拔 Agent Host                              | 已采纳 | 2026-07-17 |
 | [ADR-036](./ADR-036-auth-account-boundary-and-verification.md)                | Auth / Account 边界与验证安全模型                          | 已采纳 | 2026-07-17 |
+| [ADR-037](./ADR-037-product-time-system.md)                       | 产品时间体系（Instant/Ymd、TransferDate、门面与风格） | 已采纳 | 2026-07-26 |
 
 ## 维护规则
 

--- a/docs/architecture/product-time-system.md
+++ b/docs/architecture/product-time-system.md
@@ -1,0 +1,446 @@
+---
+tags:
+  - architecture
+  - time
+  - contracts
+  - domain
+  - style
+description: 产品时间体系详设——类型谱、门面 API、Style、Codec 与 DomainDate/TransferDate、治理与迁移波次
+created: 2026-07-26T00:00:00
+updated: 2026-07-26T00:00:00
+---
+
+# 产品时间体系（Product Time System）
+
+> **宪法：** [ADR-037](./adr/ADR-037-product-time-system.md)（已采纳）  
+> 本文是可实施的详设；与 ADR 冲突时以 ADR 决策为准，并回头修正本文。
+
+---
+
+## 1. 目标一句话
+
+> **开源库只做引擎；`@dailyuse/time` 做产品时钟、契约编解码与风格；contracts 持有品牌类型真相；领域存 Instant/Ymd；模块 presentation 只拼业务句子；组件禁止私养 formatDate、禁止直连 date-fns。**
+
+---
+
+## 2. 逻辑分层
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│ L5  UI / Application（Vue · React · Desktop · 脚本消费者）                 │
+│     只 import @dailyuse/time（及 L4 presentation）                         │
+├──────────────────────────────────────────────────────────────────────────┤
+│ L4  Module Presentation                                                    │
+│     schedule-presentation / task-presentation …                            │
+│     允许：i18n、多字段文案、业务 label                                      │
+│     禁止：pad、parse、date-fns、toLocale*、私有 formatDate                  │
+├──────────────────────────────────────────────────────────────────────────┤
+│ L3  @dailyuse/time  Product Facade                                         │
+│     Clock · TimeStyle · Codec · Format · Input · Calendar                  │
+│     + Time Registry 友好 API（查询 boundary/legacy 可选）                    │
+├──────────────────────────────────────────────────────────────────────────┤
+│ L2  Engine Adapters（可替换）                                              │
+│     DateFnsEngine · IntlDisplayEngine · (future TemporalEngine)            │
+├──────────────────────────────────────────────────────────────────────────┤
+│ L1  Platform：ECMAScript Date / Intl / performance（经 Clock 注入）         │
+└──────────────────────────────────────────────────────────────────────────┘
+
+横向：
+  contracts/primitives  →  Instant ≡ TransferDate · Ymd · Hm ·（deprecated DomainDate）
+  Domain VO/Entity      →  props 存 TransferDate/Ymd；行为经 Calendar/Clock
+  Infra mappers         →  只调用 Codec
+```
+
+---
+
+## 3. 类型谱（长期）
+
+### 3.1 规范类型
+
+| 类型 | 底层 | 语义 |
+|------|------|------|
+| `Instant` | brand `number`（ms） | UTC 时间轴上的瞬时 |
+| `TransferDate` | **≡ `Instant`** | API/DTO/VO 内部传输名（保留名降低迁移噪音） |
+| `Ymd` | brand `` `${number}-${number}-${number}` `` 或 opaque string | **本地**日历日键 `YYYY-MM-DD` |
+| `Hm` | brand string | 本地 `HH:mm` |
+| `IsoUtc` | brand string | 互操作/日志 |
+| `DurationMs` | brand number | 时长毫秒 |
+| `DurationMin` | brand number | 时长分钟（表单） |
+| `LocaleId` | BCP 47 string | 来自 preference |
+| `TimeZoneId` | IANA string | 预留；第一版默认 local |
+
+### 3.2 过渡类型
+
+| 类型 | 现状 | 长期 |
+|------|------|------|
+| `DomainDate` | `type DomainDate = Date` | **Deprecated**；禁止新字段；迁到 Instant/Ymd 后删除 |
+
+### 3.3 已删除 / 禁止回潮
+
+| 类型 | 状态 |
+|------|------|
+| `PersistenceDate` | 不进 contracts；infra 本地 |
+| `TransportDate` | 非官方名；文档一律 TransferDate |
+
+### 3.4 类型放置与依赖
+
+```text
+@dailyuse/contracts/primitives
+  - 定义 brand 类型与（可选）zod 扩展
+  - 不依赖 app-vue / 业务实现
+
+@dailyuse/time
+  - 依赖 contracts primitives（types only + 实现）
+  - 不依赖 goal/task/account 业务 module
+
+业务 domain / app
+  - 依赖 contracts + @dailyuse/time
+```
+
+**构造纪律：** brand 值只允许从 Codec / 经测试的 `unsafe` 测试辅助创建；业务禁止 `as Instant` 散落（测试与 codec 内部除外并登记）。
+
+---
+
+## 4. DomainDate / TransferDate 专题
+
+### 4.1 现状模式（例：GoalTimeRange）
+
+```text
+DTO / VO props : TransferDate (number ms)
+getter         : DomainDate = new Date(ms)
+setter 参数    : DomainDate → getTime()
+contracts      : GoalTimeRange vs GoalTimeRangeDTO 双 interface（859）
+```
+
+### 4.2 目标模式
+
+**瞬时字段：**
+
+```text
+DTO / VO props : TransferDate (= Instant)
+getter         : Instant（同一品牌 number，或返回拷贝语义下的 brand）
+setter         : Instant
+UI             : format.*(instant) / input.*(instant)
+```
+
+**日历日字段（生日、全天 start、目标日）：**
+
+```text
+DTO / VO props : Ymd
+getter/setter  : Ymd
+UI             : format.ymdDisplay / input.dateValue 基于 Ymd
+```
+
+**区间：** 优先显式 `start: Instant, end: Instant` 或 `startDay: Ymd, endDay: Ymd`，避免「Date 午夜」假装全天。
+
+### 4.3 双 shape 保留规则
+
+| 情况 | 做法 |
+|------|------|
+| 两侧同语义同类型 | 允许 type alias，消灭假 dual |
+| 领域要日历日、传输要瞬时 | **保持双 shape**，字段名也应反映（`startDay` vs `startAt`） |
+| 仅 Date vs number 换皮 | **不允许**作为长期边界；属迁移债 |
+
+### 4.4 Codec 接缝（必须）
+
+```text
+fromTransfer(t: TransferDate): Instant        // 恒等 + 校验有限
+toTransfer(i: Instant): TransferDate
+
+fromDomainDate(d: DomainDate): Instant        // 迁移期：Date → ms
+toDomainDate(i: Instant): DomainDate          // 迁移期 only；目标删除
+
+fromYmd / toYmd / parseYmd
+combineYmdHm(ymd, hm, tzPolicy) → Instant
+startOfYmd(ymd) → Instant                     // 该本地日 00:00
+
+// Prisma
+fromJsDate(d: Date): Instant
+toJsDate(i: Instant): Date                    // 仅 infra
+```
+
+**非法输入：** `onInvalid: 'null' | 'throw'`，**禁止**默认 now。
+
+---
+
+## 5. TimeStyle
+
+### 5.1 配置面（概念）
+
+```text
+TimeStyle {
+  locale: LocaleId
+  timeZone: 'local' | TimeZoneId
+  calendar: {
+    dayBoundary: 'local-midnight'
+    weekStartsOn: 0 | 1 | ...
+  }
+  empty: {
+    display: '-' | '' | '—'
+    input: ''
+    unknown: '—'   // 或 i18n key 由 L4 解释
+  }
+  display: {
+    date: 'short' | 'medium' | 'long' | Intl options bag
+    dateTime: ...
+    hm: 'HH:mm'
+  }
+  relative: {
+    enabled: boolean
+    maxAge: DurationMs    // 超过改绝对
+    numeric: 'auto' | 'always'
+  }
+  duration: {
+    style: 'narrow' | 'long'
+    zero: string
+  }
+}
+```
+
+### 5.2 解析优先级
+
+```text
+call-site override
+  > module/ partial style
+    > session preference（语言/地区）
+      > app default TimeStyle
+```
+
+### 5.3 受管范围
+
+| 受管 | 例子 |
+|------|------|
+| ✅ | 列表时间、相对时间、表单 date/time、Ymd 键、时长文案、range 展示 |
+| ✅ 策略 | 日界、周起始、clock.now |
+| ❌ | CSS transition ms、与产品无关的 performance 标记（可保留原始 number） |
+| ⚠️ | cron 表达式：领域 + Calendar，不进 UI Format |
+
+---
+
+## 6. 门面 API 冻结草案
+
+实施时以 package 导出为准；此处为稳定意图。
+
+### 6.1 Clock
+
+```text
+clock.now(): Instant
+createFixedClock(instant): Clock
+withClock(clock, fn)
+```
+
+### 6.2 Codec
+
+见 §4.4；另：
+
+```text
+isInstant(n): n is Instant
+assertInstant(n): asserts n is Instant
+```
+
+### 6.3 Format
+
+```text
+format.hm(instant | null, style?)
+format.date(instant | null, style?)
+format.dateTime(instant | null, style?)
+format.monthDay(instant | null, style?)
+format.ymdDisplay(ymd | null, style?)
+format.relative(instant | null, style?)
+format.durationMs(ms | null, style?)
+format.durationMin(min | null, style?)
+format.range(start, end, style?)
+```
+
+`null` → `style.empty.*`，不调用引擎。
+
+### 6.4 Input
+
+```text
+input.dateValue(instant | ymd | null): string
+input.timeValue(instant | null): string
+input.parseDateValue(raw: string): Ymd | null
+input.parseTimeValue(raw: string): Hm | null
+input.combine(ymd, hm): Instant | null
+```
+
+### 6.5 Calendar
+
+```text
+calendar.startOfDay(instant): Instant
+calendar.endOfDay(instant): Instant
+calendar.addDays(instant, n): Instant
+calendar.diffCalendarDays(a, b): number
+calendar.startOfWeek(instant): Instant
+calendar.toYmd(instant): Ymd
+calendar.isSameDay(a, b): boolean
+calendar.isToday(instant): boolean
+```
+
+### 6.6 装配
+
+```text
+createTimeFacade({ style, clock, engine }): TimeFacade
+time.withStyle(partial): TimeFacade
+```
+
+App bootstrap `provide` / React Context；Server 请求级 `withStyle({ locale })`。
+
+---
+
+## 7. 物理包结构
+
+```text
+packages/time/                          @dailyuse/time
+  src/
+    types.ts                            re-export primitives + 本地辅助
+    style/
+    clock/
+    codec/
+    format/
+    input/
+    calendar/
+    engine/
+      date-fns-engine.ts
+      intl-display-engine.ts
+      types.ts
+    facade.ts
+    index.ts
+    legacy/                             有 retire_by 的桥
+  README.md
+  TIME_STYLE.md                         给产品/设计
+
+packages/contracts/src/primitives/
+  instant.ts / transfer-date.ts         brand ≡
+  ymd.ts / hm.ts
+  domain-date.ts                        deprecated 注释 + 迁移链
+
+packages/utils/src/shared/date.ts       → 迁出后删除
+packages/app-vue/src/shared/utils/format-*  → 迁出后删除
+```
+
+Nx：`time` project；依赖 `contracts`、`date-fns`；被 app-*、domain packages 依赖。
+
+---
+
+## 8. 治理
+
+### 8.1 Time Registry（`tools/governance/time-registry.json` + 人读 md）
+
+```text
+kind: canonical | boundary | legacy | exemption
+path / symbol
+reason
+owner
+retire_by?   // legacy/exemption 必填
+```
+
+### 8.2 ESLint（目标）
+
+1. `no-restricted-imports`: `date-fns`、`date-fns/*` → 仅 `packages/time/engine/**`  
+2. apps 内限制 `toLocaleDateString` / `toLocaleString`（测试/story exemption）  
+3. 限制组件内新建 `function formatDate|formatTime|formatTimestamp`  
+4. 限制业务 `new Date()` 作为「现在」（鼓励 clock.now）；infra/codec 白名单  
+
+分阶段：warn → error + legacy 名单。
+
+### 8.3 Surface / 测试
+
+- Codec round-trip Transfer ↔ Instant  
+- Ymd 本地日不因 UTC 偏移错日（固定 TZ 测试）  
+- empty style  
+- combine Ymd+Hm  
+- 断供：抽查高流量模块 import 图  
+- 固定 Clock 的展示快照（关键列表）
+
+### 8.4 与 Dual Registry
+
+| Dual Registry | Time Registry / ADR-037 |
+|---------------|-------------------------|
+| dual-retired 文件锁税 | 时间宪法与调用合法性 |
+| keep_boundary 语义双实现 | 时间 boundary 与 Domain/Transfer 语义 |
+
+format 类 keep-boundary 迁移期双写，长期以 Time Registry + canonical API 为准。
+
+---
+
+## 9. 迁移波次（实施顺序）
+
+| 波次 | 内容 | 完成定义 |
+|------|------|----------|
+| **W0** | ADR 已采纳；本文；package 骨架；默认 Style；Clock/Codec/Format.hm 最小集；引擎 date-fns | 可编译；样例测试绿 |
+| **W1** | brand Instant≡TransferDate；Codec；文档 primitives | 类型可被新代码使用 |
+| **W2** | 上提 app-vue sole（hm、ymd、pad、display…） | app-vue 主路径改 import |
+| **W3** | ESLint 断供 date-fns（error + legacy 表） | CI 强制 |
+| **W4** | 屠龙组件/Screen 私有 format（含 app-react） | rg 归零（白名单 0） |
+| **W5** | Ymd 引入高优先级字段（生日、全天） | 字段级合约测试 |
+| **W6** | Domain getter 迁 Instant；deprecated DomainDate | 核心 VO 完成 |
+| **W7** | 删除 legacy re-export、utils/date 旧 API | 主路径单一 |
+| **W8** | Style 接 presentation preference | 一处改全局可演示 |
+
+**每一波：** 最近 nx test + 相关 surface +（触及治理时）governance-check。  
+**禁止：** 为减 dual 文件数删除仍保护真旁路的断言。
+
+---
+
+## 10. 调用拓扑（目标态）
+
+```text
+JSON TransferDate
+  → codec (恒等校验)
+  → domain 运算 calendar.*
+  → 仍 TransferDate 出站
+  → UI format.* / input.*
+
+用户选 Ymd + Hm
+  → input.combine
+  → Instant
+  → API TransferDate
+
+通知相对时间
+  → format.relative →（阈值外）format.dateTime
+```
+
+Infra：
+
+```text
+Prisma DateTime → codec.fromJsDate → Instant → 领域
+```
+
+---
+
+## 11. 反模式（杀死清单）
+
+| 反模式 | 替代 |
+|--------|------|
+| `formatDate(value: any, fmt: string)` | 具名 format.* + 显式类型 |
+| 仅 re-export date-fns | 真 Facade + Style |
+| `ensureDate` → 非法变 now | ParsePolicy null/throw |
+| 新字段 `DomainDate` | Instant 或 Ymd |
+| 组件 `function formatDate` | 门面 |
+| 业务 `from 'date-fns'` | engine only |
+| PersistenceDate 回 contracts | infra + codec |
+| fileSize 进 time 包 | 仍 utils/frontend |
+| 静默 merge keep-boundary | Registry + 改名 |
+
+---
+
+## 12. 成功图像
+
+1. `date-fns` importers ⊆ `packages/time/engine`（+ 空 legacy 表）。  
+2. apps 无产品私有 `formatDate`/`formatTime`（测试除外）。  
+3. 改 `TimeStyle.empty.display` 一处，列表空时间全局变。  
+4. FixedClock 下关键文案稳定可测。  
+5. 新 contracts 字段无 `DomainDate`；TransferDate 为 brand Instant。  
+6. 全天/生日为 Ymd，不再用午夜 Date 冒充。  
+7. Time Registry legacy → 0 有截止日期趋势。  
+8. 设计/产品能读 `packages/time/TIME_STYLE.md` 提相对时间阈值而不改业务代码。
+
+---
+
+## 13. 相关
+
+- [ADR-037](./adr/ADR-037-product-time-system.md)  
+- [Dual Registry](../governance/dual-registry.md)  
+- [AI runtime path map](./ai-runtime-path-map.md)（编排边界，非时间）  
+- 优雅化 plan：`docs/plan/active/2026-07-26-codebase-elegance-foundation.md`  

--- a/docs/plan/active/2026-07-26-codebase-elegance-foundation.md
+++ b/docs/plan/active/2026-07-26-codebase-elegance-foundation.md
@@ -355,6 +355,10 @@ D 与完整 E 勾选可 follow-up，但须在 residual 写明未做项。
 
 ## 12. 相关资料
 
+- [ADR-037 产品时间体系](../../architecture/adr/ADR-037-product-time-system.md)（后续时间横切主宪法；与 dual 税减负分工）
+- [产品时间体系实施](./2026-07-26-product-time-system.md)
+
+
 - [夜间 hygiene + Agent Host](./2026-07-25-nightly-hygiene-and-agent-host.md)
 - [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)
 - [ADR-035](../../architecture/adr/ADR-035-unified-assistant-agent-host.md)

--- a/docs/plan/active/2026-07-26-product-time-system.md
+++ b/docs/plan/active/2026-07-26-product-time-system.md
@@ -1,0 +1,89 @@
+---
+tags:
+  - plan
+  - active
+  - time
+  - architecture
+  - contracts
+description: 产品时间体系实施计划（ADR-037）——@dailyuse/time、Transfer≡Instant、DomainDate 退役
+created: 2026-07-26T00:00:00
+updated: 2026-07-26T00:00:00
+---
+
+# 产品时间体系实施计划
+
+## 1. 文档地位
+
+| 角色 | 文档 |
+|------|------|
+| **宪法（已采纳）** | [`../../architecture/adr/ADR-037-product-time-system.md`](../../architecture/adr/ADR-037-product-time-system.md) |
+| **详设** | [`../../architecture/product-time-system.md`](../../architecture/product-time-system.md) |
+| **本文件** | 实施波次、完成定义、与 elegance 边界 |
+| 并行 | elegance foundation（dual 税）；**不**用 dual 刷数代替本 plan |
+
+真值：代码/配置/测试 > ADR-037 > 本 plan。
+
+## 2. 目标
+
+按 ADR-037 **高质量、长期**落地产品时间体系：
+
+1. `@dailyuse/time` 成为唯一产品时间入口  
+2. `TransferDate` ≡ 品牌 `Instant`；`Ymd`/`Hm` 一等  
+3. `DomainDate = Date` 退役路径可执行；新字段禁止  
+4. 展示/表单走 Style；领域走 Clock/Calendar/Codec  
+5. lint 断供 date-fns 直连与组件私有 format  
+
+## 3. 非目标
+
+- 第一版多用户业务时区  
+- 恢复 PersistenceDate  
+- force-merge 真异语义  
+- 宣称 agent-host §20  
+- micro dual 狂欢  
+
+## 4. 波次与完成定义
+
+与详设 §9 对齐：
+
+| 波次 | 完成定义 | 状态 |
+|------|----------|------|
+| W0 | 包骨架 + 最小 Facade/Style/Clock/Codec/format.hm + 引擎；样例测试 | 待办 |
+| W1 | primitives brand Instant≡TransferDate；Codec 文档化 | 待办 |
+| W2 | app-vue format sole 上提；主路径改 import | 待办 |
+| W3 | ESLint 断供 date-fns（error + legacy） | 待办 |
+| W4 | 组件/React 私有 format 清零 | 待办 |
+| W5 | 高优先级 Ymd 字段（生日/全天） | 待办 |
+| W6 | 核心 VO DomainDate getter → Instant | 待办 |
+| W7 | 删 legacy / utils date 旧 API | 待办 |
+| W8 | Style ↔ presentation preference | 待办 |
+
+## 5. 质量门禁（每波）
+
+- 最近 `pnpm nx` test（time + 触及包）  
+- 相关 surface  
+- 触及治理/docs 时 `daily-use:governance-check`  
+- 不提交密钥与 Playwright 产物  
+- residual 记本 plan §7  
+
+## 6. 决策摘要（不可在实施中弱化）
+
+1. 质量优先于「少改几行」  
+2. Transfer ≡ Instant；DomainDate 长期删除  
+3. 日历日用 Ymd，不用午夜 Date  
+4. 真门面 + Style，禁止假 re-export  
+5. 双 shape 仅语义差，不换皮  
+
+## 7. Residual
+
+| ID | 日期 | 说明 | 结果 |
+|----|------|------|------|
+| T0 | 2026-07-26 | ADR-037 + 详设 + 本 plan 入库 | 文档 |
+
+## 8. 开跑提示（实施 agent）
+
+```text
+读 AGENT.md、ADR-037、docs/architecture/product-time-system.md、本 plan。
+按 W0→W8 推进；禁止削弱 DomainDate 退役与断供决策。
+每波小而可回滚的 commit；验证最近 nx target。
+不要把 dual 文件数当本 plan KPI。
+```

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -16,6 +16,7 @@ updated: 2026-07-26T00:00:00
 | 计划                                                                                                | 当前状态                                                                                                                                                           |
 | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [代码优雅化与后续实施地基](./2026-07-26-codebase-elegance-foundation.md) | **主目标**：Dual Registry + dual 清理 / 路径地图；**PR #189 已合 main**；E5b bootstrap 死域 follow-up；§3.1 |
+| [产品时间体系（ADR-037）](./2026-07-26-product-time-system.md) | **主实施**：`@dailyuse/time`、Transfer≡Instant、DomainDate 退役；详设见 architecture |
 | [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md) | **执行协议**：GOAL_PRIORITY 对齐 #189 merge 门槛；服务 elegance dual 清理 |
 | [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)                         | **实施中**（完成定义未宣称）：统一助手、右侧工作台、Workflow/Turn/Model；产品主能力线                                                                                                       |
 | [Auth + Account 收敛与安全闭环](./2026-07-17-auth-account-security-closure.md)                      | **实施中**：A–E 源码闭环；待 e2e 真跑与生产发信                                                                                                                    |


### PR DESCRIPTION
## Summary

Adopts **ADR-037 Product Time System** (quality-first, long-term):

- Canonical **Instant** (epoch ms); **TransferDate ≡ Instant**
- **Ymd / Hm** first-class; no midnight-Date calendar fake
- **DomainDate = Date** deprecated with retirement path
- **`@dailyuse/time`** facade + TimeStyle + Codec + Calendar + swappable engine
- Domain↔Transfer↔UI only via Codec; UI format only via facade
- Implementation plan W0–W8 + detailed design doc

## Docs

- `docs/architecture/adr/ADR-037-product-time-system.md`
- `docs/architecture/product-time-system.md`
- `docs/plan/active/2026-07-26-product-time-system.md`

## Test plan

- [x] `pnpm nx run daily-use:governance-check`
- [ ] Review ADR decisions (especially DomainDate exit + Transfer≡Instant)