### PR TITLE
Use generic Release Please token secret

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `DAILYUSE_WORKFLOW` (this secret name is not important).
-          token: ${{ secrets.DAILYUSE_WORKFLOW }}
+          # Prefer a PAT so release-created pull requests can trigger follow-up
+          # workflows; fall back to the job token when no PAT is configured.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           # use manifest mode for a single product release and keep the
           # desktop package version aligned with the root release version
           config-file: release-please-config.json


### PR DESCRIPTION
## What changed

- Replace the deleted `DAILYUSE_WORKFLOW` secret reference with `RELEASE_PLEASE_TOKEN`.
- Fall back to `github.token` when the PAT is unavailable.

## Why

The generic `RELEASE_PLEASE_TOKEN` secret has been created and the legacy secret has been removed. Until this workflow reference is updated on `main`, Release Please runs cannot authenticate with the configured PAT.

This minimal PR is intentionally split from the broader MemoFlow identity migration so it can be reviewed and merged first.

## Validation

- `git diff --check`
- Verified the workflow diff contains only the token reference and explanatory comment change.