### PR TITLE
fix(test): resolve time sources in domain suites

### DIFF
--- a/vitest.workspace-helpers.ts
+++ b/vitest.workspace-helpers.ts
@@ -205,6 +205,14 @@ export const domainResolveAliases = [
     replacement: path.resolve(contractsSrc, 'index.ts'),
   },
   {
+    find: /^@memoflow\/time\/(.+)/,
+    replacement: path.resolve(__dirname, './packages/time/src/$1'),
+  },
+  {
+    find: '@memoflow/time',
+    replacement: path.resolve(__dirname, './packages/time/src/index.ts'),
+  },
+  {
     find: /^@memoflow\/task\/(.+)/,
     replacement: path.resolve(__dirname, './packages/task/src/$1/index.ts'),
   },


### PR DESCRIPTION
## Summary
- resolve bare and deep @memoflow/time imports from source in shared domain Vitest suites
- keep API smoke and Task integration tests independent of untracked package build output

## Context
The corrected Boundary affected detection now runs api:test:smoke on clean CI runners. That exposed an existing source-resolution gap because @memoflow/time exports only dist files, which are absent before a package build.

## Validation
- node node_modules/vitest/vitest.mjs run --config apps/api/vitest.smoke.config.ts (2 files, 61 tests passed)
- Prettier check for vitest.workspace-helpers.ts
- git diff --check