### PR TITLE
fix(test): repair clean integration resolution

### DIFF
--- a/apps/api/src/__tests__/integration/task-goal-host-restart.integration.test.ts
+++ b/apps/api/src/__tests__/integration/task-goal-host-restart.integration.test.ts
@@ -89,10 +89,21 @@ describe('API host Task -> Goal restart recovery', () => {
     });
     const fixturePath = path.resolve(__dirname, 'fixtures/complete-task-and-exit.ts');
     const tsxPath = path.resolve(__dirname, '../../../../../node_modules/tsx/dist/cli.mjs');
+    const workspaceTsconfigPath = path.resolve(
+      __dirname,
+      '../../../../../tsconfig.workspace-src.json',
+    );
 
     const child = await execFileAsync(
       process.execPath,
-      [tsxPath, fixturePath, taskInstance.id, String(identityId)],
+      [
+        tsxPath,
+        '--tsconfig',
+        workspaceTsconfigPath,
+        fixturePath,
+        taskInstance.id,
+        String(identityId),
+      ],
       { env: process.env },
     );
     expect(child.stdout).toContain('TASK_COMMITTED');

--- a/apps/desktop/vitest.ipc.config.ts
+++ b/apps/desktop/vitest.ipc.config.ts
@@ -45,6 +45,14 @@ export default defineConfig({
         find: '@memoflow/account',
         replacement: resolve(__dirname, '../../packages/account/src/index.ts'),
       },
+      {
+        find: '@memoflow/powersync-schema',
+        replacement: resolve(__dirname, '../../packages/powersync-schema/src/index.ts'),
+      },
+      {
+        find: '@memoflow/data-portability/electron',
+        replacement: resolve(__dirname, '../../packages/data-portability/src/electron/index.ts'),
+      },
     ],
   },
 });

--- a/apps/desktop/vitest.main.config.ts
+++ b/apps/desktop/vitest.main.config.ts
@@ -68,6 +68,14 @@ export default defineConfig({
         find: '@memoflow/schedule-orchestration',
         replacement: resolve(__dirname, '../../packages/schedule-orchestration/src/index.ts'),
       },
+      {
+        find: '@memoflow/powersync-schema',
+        replacement: resolve(__dirname, '../../packages/powersync-schema/src/index.ts'),
+      },
+      {
+        find: '@memoflow/data-portability/electron',
+        replacement: resolve(__dirname, '../../packages/data-portability/src/electron/index.ts'),
+      },
     ],
   },
 });

--- a/packages/reminder/src/server/infrastructure/adapters/prisma/reminder-template-prisma.repository.integration.test.ts
+++ b/packages/reminder/src/server/infrastructure/adapters/prisma/reminder-template-prisma.repository.integration.test.ts
@@ -11,7 +11,7 @@ import {
   disconnectPrisma,
   getPrisma,
   seedAccount,
-} from '../../../__tests__/integration-helpers';
+} from '../../../../__tests__/integration-helpers';
 
 function createReminderTemplate(identityId: string, groupId: string) {
   const template = ReminderTemplate.create({
@@ -96,7 +96,9 @@ describe('ReminderTemplatePrismaRepository integration', () => {
       where: { id: String(template.id) },
       include: { history: true },
     });
-    const loaded = await repository.findByIdForIdentity(String(identityId), String(template.id), { includeHistory: true });
+    const loaded = await repository.findByIdForIdentity(String(identityId), String(template.id), {
+      includeHistory: true,
+    });
 
     expect(row).not.toBeNull();
     expect(row?.activeHours).toBeNull();

--- a/tsconfig.workspace-src.json
+++ b/tsconfig.workspace-src.json
@@ -14,6 +14,10 @@
       "@memoflow/patterns": [
         "packages/patterns/src/index.ts"
       ],
+      "@memoflow/patterns/*": [
+        "packages/patterns/src/*/index.ts",
+        "packages/patterns/src/*.ts"
+      ],
       "@memoflow/time": [
         "packages/time/src/index.ts"
       ],

--- a/vitest.workspace-helpers.ts
+++ b/vitest.workspace-helpers.ts
@@ -213,6 +213,14 @@ export const domainResolveAliases = [
     replacement: path.resolve(__dirname, './packages/time/src/index.ts'),
   },
   {
+    find: /^@memoflow\/schedule\/(.+)/,
+    replacement: path.resolve(__dirname, './packages/schedule/src/$1'),
+  },
+  {
+    find: '@memoflow/schedule',
+    replacement: path.resolve(__dirname, './packages/schedule/src/index.ts'),
+  },
+  {
     find: /^@memoflow\/task\/(.+)/,
     replacement: path.resolve(__dirname, './packages/task/src/$1/index.ts'),
   },


### PR DESCRIPTION
## Summary
- resolve @memoflow/schedule from source in shared domain integration suites
- correct the Reminder Prisma integration helper path

## Context
After #200 fixed the API smoke @memoflow/time resolution, release PR #196 advanced into integration tests and exposed these two clean-run defects.

## Validation
- Task integration: 5 files, 26 tests passed
- Reminder integration: 1 file, 2 tests passed
- Goal integration: 2 files, 3 tests passed
- API smoke: 2 files, 61 tests passed
- Prettier and git diff checks passed