### PR TITLE
ci: shorten affected feedback loops

### DIFF
--- a/.github/actions/setup-nx-affected-job/action.yml
+++ b/.github/actions/setup-nx-affected-job/action.yml
@@ -41,10 +41,15 @@ runs:
         corepack enable
         pnpm --version
 
+    - name: Resolve pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
     - name: Cache pnpm store
       uses: actions/cache@v5
       with:
-        path: ~/.local/share/pnpm/store/v3
+        path: ${{ steps.pnpm-store.outputs.path }}
         key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: pnpm-store-${{ runner.os }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,80 @@ jobs:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx affected -t build --parallel=3 --exclude='contracts,utils,ui-core,assets,sync-client' --outputStyle=static
 
-  boundary-tests:
-    name: Boundary Tests
+  detect-ci-scope:
+    name: Detect CI Scope
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
+
+    outputs:
+      has_smoke: ${{ steps.detect.outputs.has_smoke }}
+      has_integration: ${{ steps.detect.outputs.has_integration }}
+      has_ipc: ${{ steps.detect.outputs.has_ipc }}
+      has_main: ${{ steps.detect.outputs.has_main }}
+      has_web_flow: ${{ steps.detect.outputs.has_web_flow }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare workspace
+        uses: ./.github/actions/setup-nx-affected-job
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          setup-python: 'false'
+          setup-uv: 'false'
+
+      - name: Detect affected CI scopes
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          detect_target() {
+            local target_name="$1"
+            local output_name="$2"
+            local projects
+            projects="$(pnpm exec nx show projects --affected --with-target="$target_name")"
+
+            if [ -n "$projects" ]; then
+              printf -v "$output_name" '%s' true
+              printf 'Affected projects with %s:\n%s\n' "$target_name" "$projects"
+            fi
+          }
+
+          has_smoke=false
+          has_integration=false
+          has_ipc=false
+          has_main=false
+          has_web_flow=false
+
+          detect_target "test:smoke" has_smoke
+          detect_target "test:integration" has_integration
+          detect_target "test:ipc" has_ipc
+          detect_target "test:main" has_main
+
+          affected_projects="$(pnpm exec nx show projects --affected)"
+          if grep -Eq '^(web|api|ai-service)$' <<< "$affected_projects"; then
+            has_web_flow=true
+            echo "Web Flow affected through one or more of: web, api, ai-service"
+          else
+            echo "Web Flow is not affected."
+          fi
+
+          echo "has_smoke=$has_smoke" >> "$GITHUB_OUTPUT"
+          echo "has_integration=$has_integration" >> "$GITHUB_OUTPUT"
+          echo "has_ipc=$has_ipc" >> "$GITHUB_OUTPUT"
+          echo "has_main=$has_main" >> "$GITHUB_OUTPUT"
+          echo "has_web_flow=$has_web_flow" >> "$GITHUB_OUTPUT"
+
+  boundary-smoke:
+    name: Boundary Smoke
+    needs: detect-ci-scope
+    if: needs.detect-ci-scope.outputs.has_smoke == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       DATABASE_URL: postgresql://test_user:test_pass@127.0.0.1:5433/memoflow_test
@@ -94,117 +164,188 @@ jobs:
           setup-python: 'false'
           setup-uv: 'false'
 
-      - name: Detect affected boundary targets
-        id: detect-boundary
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          detect_target() {
-            local target_name="$1"
-            local output_name="$2"
-            local projects=()
-
-            while IFS= read -r project; do
-              [ -n "$project" ] && projects+=("$project")
-            done < <(pnpm exec nx show projects --affected --with-target="$target_name")
-
-            if [ "${#projects[@]}" -gt 0 ]; then
-              printf -v "$output_name" '%s' true
-              has_any=true
-              printf 'Affected projects with %s: %s\n' "$target_name" "${projects[*]}"
-            fi
-          }
-
-          has_any=false
-          has_smoke=false
-          has_integration=false
-          has_ipc=false
-          has_main=false
-
-          detect_target "test:smoke" has_smoke
-          detect_target "test:integration" has_integration
-          detect_target "test:ipc" has_ipc
-          detect_target "test:main" has_main
-
-          echo "has_any=$has_any" >> "$GITHUB_OUTPUT"
-          echo "has_smoke=$has_smoke" >> "$GITHUB_OUTPUT"
-          echo "has_integration=$has_integration" >> "$GITHUB_OUTPUT"
-          echo "has_ipc=$has_ipc" >> "$GITHUB_OUTPUT"
-          echo "has_main=$has_main" >> "$GITHUB_OUTPUT"
-
-      - name: No boundary targets affected
-        if: steps.detect-boundary.outputs.has_any != 'true'
-        run: echo "No boundary targets affected; skipping boundary test execution."
-
       - name: Run affected smoke tests
-        if: steps.detect-boundary.outputs.has_smoke == 'true'
         env:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx affected -t test:smoke --parallel=2 --outputStyle=static
 
-      - name: Start integration database
-        if: steps.detect-boundary.outputs.has_integration == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
+  boundary-integration:
+    name: Boundary Integration
+    needs: detect-ci-scope
+    if: needs.detect-ci-scope.outputs.has_integration == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
 
-          docker run -d \
-            --name ci-postgres \
-            -e POSTGRES_USER=test_user \
-            -e POSTGRES_PASSWORD=test_pass \
-            -e POSTGRES_DB=memoflow_test \
-            -p 5433:5432 \
-            --health-cmd "pg_isready -U test_user -d memoflow_test" \
-            --health-interval 5s \
-            --health-timeout 5s \
-            --health-retries 10 \
-            pgvector/pgvector:0.8.5-pg18
+    env:
+      DATABASE_URL: postgresql://test_user:test_pass@127.0.0.1:5433/memoflow_test
+      JWT_SECRET: test-jwt-secret-not-for-production-use
+      TZ: UTC
 
-          for _ in $(seq 1 30); do
-            status="$(docker inspect --format='{{.State.Health.Status}}' ci-postgres)"
-            if [ "$status" = "healthy" ]; then
-              echo "Postgres is healthy."
-              exit 0
-            fi
-            sleep 2
-          done
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.5-pg18
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+          POSTGRES_DB: memoflow_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U test_user -d memoflow_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
-          echo "Postgres failed to become healthy in time."
-          docker logs ci-postgres
-          exit 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare workspace
+        uses: ./.github/actions/setup-nx-affected-job
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          setup-python: 'false'
+          setup-uv: 'false'
 
       - name: Push Prisma schema to test database
-        if: steps.detect-boundary.outputs.has_integration == 'true'
         env:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx run database:prisma-push
 
       - name: Run affected integration tests
-        if: steps.detect-boundary.outputs.has_integration == 'true'
         env:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx affected -t test:integration --parallel=1 --outputStyle=static
 
+  boundary-ipc:
+    name: Boundary IPC
+    needs: detect-ci-scope
+    if: needs.detect-ci-scope.outputs.has_ipc == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      JWT_SECRET: test-jwt-secret-not-for-production-use
+      TZ: UTC
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare workspace
+        uses: ./.github/actions/setup-nx-affected-job
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          setup-python: 'false'
+          setup-uv: 'false'
+
       - name: Run affected IPC tests
-        if: steps.detect-boundary.outputs.has_ipc == 'true'
         env:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx affected -t test:ipc --parallel=1 --outputStyle=static
 
+  boundary-main:
+    name: Boundary Main Process
+    needs: detect-ci-scope
+    if: needs.detect-ci-scope.outputs.has_main == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      JWT_SECRET: test-jwt-secret-not-for-production-use
+      TZ: UTC
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare workspace
+        uses: ./.github/actions/setup-nx-affected-job
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          setup-python: 'false'
+          setup-uv: 'false'
+
       - name: Run affected main-process tests
-        if: steps.detect-boundary.outputs.has_main == 'true'
         env:
           NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
         run: pnpm exec nx affected -t test:main --parallel=1 --outputStyle=static
 
-      - name: Stop integration database
-        if: always() && steps.detect-boundary.outputs.has_integration == 'true'
+  boundary-tests:
+    name: Boundary Tests
+    if: always()
+    needs:
+      - detect-ci-scope
+      - boundary-smoke
+      - boundary-integration
+      - boundary-ipc
+      - boundary-main
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify affected boundary jobs passed
+        env:
+          DETECT_RESULT: ${{ needs.detect-ci-scope.result }}
+          SMOKE_ENABLED: ${{ needs.detect-ci-scope.outputs.has_smoke }}
+          SMOKE_RESULT: ${{ needs.boundary-smoke.result }}
+          INTEGRATION_ENABLED: ${{ needs.detect-ci-scope.outputs.has_integration }}
+          INTEGRATION_RESULT: ${{ needs.boundary-integration.result }}
+          IPC_ENABLED: ${{ needs.detect-ci-scope.outputs.has_ipc }}
+          IPC_RESULT: ${{ needs.boundary-ipc.result }}
+          MAIN_ENABLED: ${{ needs.detect-ci-scope.outputs.has_main }}
+          MAIN_RESULT: ${{ needs.boundary-main.result }}
         shell: bash
-        run: docker rm -f ci-postgres || true
+        run: |
+          set -euo pipefail
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "CI scope detection did not pass: $DETECT_RESULT"
+            exit 1
+          fi
+
+          failures=0
+          verify_boundary() {
+            local label="$1"
+            local enabled="$2"
+            local result="$3"
+
+            if [ "$enabled" = "true" ]; then
+              if [ "$result" != "success" ]; then
+                echo "$label was affected but did not pass: $result"
+                failures=$((failures + 1))
+              else
+                echo "$label passed."
+              fi
+            elif [ "$result" = "skipped" ]; then
+              echo "$label was not affected; skipped."
+            else
+              echo "$label was not affected but returned an unexpected result: $result"
+              failures=$((failures + 1))
+            fi
+          }
+
+          verify_boundary "Smoke" "$SMOKE_ENABLED" "$SMOKE_RESULT"
+          verify_boundary "Integration" "$INTEGRATION_ENABLED" "$INTEGRATION_RESULT"
+          verify_boundary "IPC" "$IPC_ENABLED" "$IPC_RESULT"
+          verify_boundary "Main process" "$MAIN_ENABLED" "$MAIN_RESULT"
+
+          if [ "$failures" -gt 0 ]; then
+            exit 1
+          fi
+
+          echo "All affected Boundary jobs passed."
 
   web-flow-shard:
     name: Web Flow Shard (${{ matrix.shard }})
+    needs: detect-ci-scope
+    if: needs.detect-ci-scope.outputs.has_web_flow == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -272,16 +413,35 @@ jobs:
   web-flow:
     name: Web Flow Oracle
     if: always()
-    needs: web-flow-shard
+    needs:
+      - detect-ci-scope
+      - web-flow-shard
     runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
       - name: Verify every web flow shard passed
         env:
+          DETECT_RESULT: ${{ needs.detect-ci-scope.result }}
+          WEB_FLOW_ENABLED: ${{ needs.detect-ci-scope.outputs.has_web_flow }}
           WEB_FLOW_SHARDS_RESULT: ${{ needs.web-flow-shard.result }}
         shell: bash
         run: |
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "CI scope detection did not pass: $DETECT_RESULT"
+            exit 1
+          fi
+
+          if [ "$WEB_FLOW_ENABLED" != "true" ]; then
+            if [ "$WEB_FLOW_SHARDS_RESULT" != "skipped" ]; then
+              echo "Web Flow was not affected but returned an unexpected result: $WEB_FLOW_SHARDS_RESULT"
+              exit 1
+            fi
+
+            echo "Web Flow was not affected; shards skipped."
+            exit 0
+          fi
+
           if [ "$WEB_FLOW_SHARDS_RESULT" != "success" ]; then
             echo "One or more Web Flow shards did not pass: $WEB_FLOW_SHARDS_RESULT"
             exit 1

--- a/docs/plan/active/2026-08-04-ci-feedback-loop-phase-two.md
+++ b/docs/plan/active/2026-08-04-ci-feedback-loop-phase-two.md
@@ -1,0 +1,65 @@
+---
+tags:
+  - plan
+  - ci
+  - developer-experience
+description: 缩短 CI 反馈回路并让边界测试一次暴露全部失败
+created: 2026-08-04T00:00:00+08:00
+updated: 2026-08-04T01:10:00+08:00
+---
+
+# CI Feedback Loop Phase Two
+
+## 背景
+
+前一轮修复已经降低单次 CI 时长，但串行 Boundary Tests 会在第一个失败处停止，导致同一 PR 需要多轮推送才能发现全部问题。Web Flow 四个分片对不相关变更也会完整安装、构建和执行；pnpm store 缓存路径还固定在旧版默认目录，无法保证实际命中。
+
+本轮只处理低风险、可独立验证的反馈回路问题。release-please 调度、Nx `sharedGlobals`、remote cache 和跨 job 构建制品留给后续单独设计，避免把发布与缓存信任边界混入本次改动。
+
+## 目标
+
+1. composite action 从当前 pnpm 实际配置解析 store 路径，消除版本和 runner 布局假设。
+2. 统一检测 affected 范围，并行执行 smoke、integration、IPC、main-process 四类 Boundary 测试。
+3. 保留 `Boundary Tests` 和 `Web Flow Oracle` 两个稳定的 required check 名称，由 Oracle 聚合跳过、成功、失败和取消状态。
+4. 仅当 `web`、`api` 或 `ai-service` 受影响时执行 Web Flow 分片。
+5. 提供跨平台本地 clean-room Boundary 入口，在临时 Git worktree 中安装和执行，不依赖当前工作区残留的构建产物，并一次汇总全部失败。
+
+## 实施
+
+### Phase A：检测与缓存
+
+- 在 `setup-nx-affected-job` 中运行 `pnpm store path --silent`，将输出交给 `actions/cache`。
+- 新建 CI affected detector，一次计算四类 Boundary target 和 Web Flow 应用影响范围，作为后续 jobs 的唯一条件来源。
+
+### Phase B：并行 Boundary 与 Web gate
+
+- 将四类 Boundary 测试拆成独立 jobs；integration job 独占 PostgreSQL service 并初始化 schema。
+- 新增 `Boundary Tests` Oracle；检测失败或任何已触发子 job 非成功时失败，全部未受影响时成功。
+- Web Flow matrix 依赖 detector；`Web Flow Oracle` 区分“未受影响而跳过”和“应执行但未成功”。
+
+### Phase C：本地 clean-room 入口
+
+- 新增 `tools/ci/run-clean-boundary.mjs` 与根脚本 `ci:boundary:clean`。
+- 默认从当前 `HEAD` 生成临时源码快照（不包含未跟踪产物或当前工作区改动），复用 pnpm store，安装依赖后依次运行四类 Boundary target。
+- integration 阶段使用独立容器和端口；所有阶段继续执行并在结尾统一报告失败。
+- 无论成功或失败都清理容器和临时源码目录；不得修改当前工作区文件或删除当前工作区产物。
+
+## 验收
+
+- [x] Phase A：动态 pnpm store cache 已接入 composite action。
+- [x] Phase B：Boundary jobs 已拆分并行，Web Flow 已接入 affected gate，两个 Oracle 名称保持不变。
+- [x] Phase C：本地 clean-room runner、根脚本和 dry-run 已完成。
+- workflow 和 composite action 可被 YAML 解析，格式检查通过。
+- `pnpm test:targets:check` 与治理检查通过。
+- clean-room runner 的参数检查和 dry-run 通过；完整运行已进入临时快照安装阶段，但本机外层执行器在 Windows 长时子进程上中止，四类测试尚未取得完整结果。
+- `git diff --check` 通过。
+- PR 中两个 required Oracle check 保持原名称；从真实 Actions 结果确认无关变更会跳过 Web Flow，Boundary 失败可在同一轮并行暴露。
+
+本地验证结果：`actionlint`、Prettier、`pnpm test:targets:check`、Node 语法检查、clean-room `--help/--dry-run` 和 `git diff --check` 均通过。完整 clean-room 安装已在独立快照中成功复现；完整四阶段测试以及 CI timing 需要在具备 Docker、网络和不被外层超时中止的环境中运行。
+
+## 非目标与后续
+
+- 不在本轮改变 release-please 的触发语义。
+- 不在本轮缩小 Nx 全局输入；需要先建立配置文件到项目的明确影响契约。
+- 不在本轮引入 Nx Cloud 或自建 remote cache；需要先确定凭据、数据保留和缓存污染处理策略。
+- 不在本轮共享 API build artifact；Web Flow 分片的制品边界与下载收益应根据本轮真实 timing 再决定。

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -4,7 +4,7 @@ tags:
   - active
 description: 进行中的计划目录与当前状态
 created: 2026-04-26T00:00:00
-updated: 2026-08-04T00:00:00+08:00
+updated: 2026-08-04T21:10:00+08:00
 ---
 
 # Active Plans
@@ -13,11 +13,10 @@ updated: 2026-08-04T00:00:00+08:00
 
 ## 当前计划
 
-| 计划                                                                                 | 当前状态                                                                               |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| [CI Feedback Loop Phase Two](./2026-08-04-ci-feedback-loop-phase-two.md)             | **实施中**：动态 pnpm 缓存、Boundary 并行聚合、Web affected gate、本地 clean-room 入口 |
-| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)          | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称            |
-| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md) | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式                 |
+| 计划                                                                                 | 当前状态                                                                    |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)          | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称 |
+| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md) | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式      |
 
 ## 本轮已归档（2026-08-03）
 

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -4,7 +4,7 @@ tags:
   - active
 description: 进行中的计划目录与当前状态
 created: 2026-04-26T00:00:00
-updated: 2026-08-03T23:15:00+08:00
+updated: 2026-08-04T00:00:00+08:00
 ---
 
 # Active Plans
@@ -13,36 +13,37 @@ updated: 2026-08-03T23:15:00+08:00
 
 ## 当前计划
 
-| 计划                                                                                           | 当前状态                                                                                   |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)                    | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称                |
-| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md)           | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式                     |
+| 计划                                                                                 | 当前状态                                                                               |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [CI Feedback Loop Phase Two](./2026-08-04-ci-feedback-loop-phase-two.md)             | **实施中**：动态 pnpm 缓存、Boundary 并行聚合、Web affected gate、本地 clean-room 入口 |
+| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)          | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称            |
+| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md) | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式                 |
 
 ## 本轮已归档（2026-08-03）
 
-| 计划                                                                                                              | 结果                                                                                                                   |
-| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| [Desktop Cloud Connection Boundary Refactor](../archive/2026-08-03-desktop-cloud-connection-boundary-refactor.md) | Profile Access、Cloud Connection Dialog 与可选 PIN 解耦完成；Desktop E2E 2/2 与全仓 validation 通过 |
+| 计划                                                                                                              | 结果                                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [Desktop Cloud Connection Boundary Refactor](../archive/2026-08-03-desktop-cloud-connection-boundary-refactor.md) | Profile Access、Cloud Connection Dialog 与可选 PIN 解耦完成；Desktop E2E 2/2 与全仓 validation 通过                       |
 | [Desktop GitHub Device Authorization](../archive/2026-08-03-desktop-github-device-authorization.md)               | Better Auth device flow、Web 显式批准、Desktop main 协调器、guest 原地 adoption 与离线重开完成；prod-like validation 通过 |
-| [Desktop Profile 与云端认证一次性重写](../archive/2026-08-02-desktop-profile-and-cloud-auth-rewrite.md)           | Better Auth + Profile/Unlock 单轨完成；旧认证内核删除；Desktop E2E 与全仓 prod-like validation 通过                   |
-| [Reka UI、Goal 一致性与桌面工作区长期重构](../archive/2026-08-01-reka-goal-consistency-and-workspace-refactor.md) | W0–W10 完成；Docker 旅程 7/7、Electron 布局矩阵、原子写入/可靠贡献/单导航与无障碍门槛通过                              |
-| [三轮 Docker 构建优化](../archive/2026-07-31-three-round-docker-build-optimization.md)                            | 三轮完成；API 镜像减少 30.9%，独立 migrator、isolated builder、显式生产依赖边界与 BuildKit cache 均通过 prod-like 验证 |
-| [API Runtime 镜像裁剪](../archive/2026-07-31-api-runtime-image-pruning.md)                                        | runtime 使用生产依赖闭包；镜像减少约 70.4%；六服务 healthy，启动链与治理检查通过                                       |
-| [最新 main 本机 Docker 产品复审](../archive/2026-07-31-latest-local-docker-product-review.md)                     | 六服务 healthy；部署阻塞已修；非 AI 与 AI 桌面复审 findings 见 `docs/audit/2026-07-31-local-docker-product-review.md`  |
-| [本机 Docker 核心产品审查与优化](../archive/2026-07-29-local-docker-core-product-optimization.md)                 | Phase A–E 与第 10 节全通过；Docker PM journey 7/7、Electron 壳层 8/8、最终 validation pass                             |
-| [MemoFlow 产品身份迁移](../archive/2026-07-29-memoflow-identity-migration.md)                                     | 仓库、源码、部署与文档标识统一；identity audit 已纳入治理门禁                                                          |
-| [事务邮件通用 SMTP](../archive/2026-07-28-transactional-email-smtp.md)                                            | Phase A–D 实施完成；默认 console；指南见 `docs/guides/development/transactional-email-smtp.md`                         |
-| [Docker Web PM 旅程 findings](../archive/2026-07-27-docker-web-pm-journey-findings.md)                            | 旅程记录；i18n/熔断/取码/SMTP 修复已入代码                                                                             |
-| [Import Path Elegance](../archive/2026-07-27-import-path-elegance.md)                                             | 包内 `@/` → 相对路径完成；政策 `import-path-policy.md`                                                                 |
-| [产品时间体系 ADR-037](../archive/2026-07-26-product-time-system.md)                                              | W0–W8 + P1–P11 完成（#191/#192）                                                                                       |
-| [产品时间 Goal 提示词](../archive/2026-07-26-product-time-system-goal-prompt.md)                                  | 随时间 plan 归档                                                                                                       |
-| [代码优雅化地基](../archive/2026-07-26-codebase-elegance-foundation.md)                                           | E1–E7；#189/#190 已合                                                                                                  |
-| [Auth + Account 安全闭环](../archive/2026-07-17-auth-account-security-closure.md)                                 | A–E 源码闭环；投递见 SMTP archive                                                                                      |
-| [Web 登录页优化](../archive/2026-07-15-web-auth-page-optimization.md)                                             | 主项已落地；残余法律文案/e2e                                                                                           |
-| [Web 核心产品审查](../archive/2026-07-15-web-core-product-review.md)                                              | 审查历史材料                                                                                                           |
-| [Web 产品设计复审](../archive/2026-07-16-web-product-design-review.md)                                            | 审查历史材料                                                                                                           |
-| [Obsidian Vault 与 GitHub 知识仓库](../archive/2026-07-16-obsidian-vault-repository-optimization.md)              | §13.2 **15/15**；合 main **#188**                                                                                      |
-| [Windows vault-repo residual handoff](../archive/2026-07-25-windows-vault-repo-residual-handoff.md)               | Windows 收尾完成；历史 handoff                                                                                         |
+| [Desktop Profile 与云端认证一次性重写](../archive/2026-08-02-desktop-profile-and-cloud-auth-rewrite.md)           | Better Auth + Profile/Unlock 单轨完成；旧认证内核删除；Desktop E2E 与全仓 prod-like validation 通过                       |
+| [Reka UI、Goal 一致性与桌面工作区长期重构](../archive/2026-08-01-reka-goal-consistency-and-workspace-refactor.md) | W0–W10 完成；Docker 旅程 7/7、Electron 布局矩阵、原子写入/可靠贡献/单导航与无障碍门槛通过                                 |
+| [三轮 Docker 构建优化](../archive/2026-07-31-three-round-docker-build-optimization.md)                            | 三轮完成；API 镜像减少 30.9%，独立 migrator、isolated builder、显式生产依赖边界与 BuildKit cache 均通过 prod-like 验证    |
+| [API Runtime 镜像裁剪](../archive/2026-07-31-api-runtime-image-pruning.md)                                        | runtime 使用生产依赖闭包；镜像减少约 70.4%；六服务 healthy，启动链与治理检查通过                                          |
+| [最新 main 本机 Docker 产品复审](../archive/2026-07-31-latest-local-docker-product-review.md)                     | 六服务 healthy；部署阻塞已修；非 AI 与 AI 桌面复审 findings 见 `docs/audit/2026-07-31-local-docker-product-review.md`     |
+| [本机 Docker 核心产品审查与优化](../archive/2026-07-29-local-docker-core-product-optimization.md)                 | Phase A–E 与第 10 节全通过；Docker PM journey 7/7、Electron 壳层 8/8、最终 validation pass                                |
+| [MemoFlow 产品身份迁移](../archive/2026-07-29-memoflow-identity-migration.md)                                     | 仓库、源码、部署与文档标识统一；identity audit 已纳入治理门禁                                                             |
+| [事务邮件通用 SMTP](../archive/2026-07-28-transactional-email-smtp.md)                                            | Phase A–D 实施完成；默认 console；指南见 `docs/guides/development/transactional-email-smtp.md`                            |
+| [Docker Web PM 旅程 findings](../archive/2026-07-27-docker-web-pm-journey-findings.md)                            | 旅程记录；i18n/熔断/取码/SMTP 修复已入代码                                                                                |
+| [Import Path Elegance](../archive/2026-07-27-import-path-elegance.md)                                             | 包内 `@/` → 相对路径完成；政策 `import-path-policy.md`                                                                    |
+| [产品时间体系 ADR-037](../archive/2026-07-26-product-time-system.md)                                              | W0–W8 + P1–P11 完成（#191/#192）                                                                                          |
+| [产品时间 Goal 提示词](../archive/2026-07-26-product-time-system-goal-prompt.md)                                  | 随时间 plan 归档                                                                                                          |
+| [代码优雅化地基](../archive/2026-07-26-codebase-elegance-foundation.md)                                           | E1–E7；#189/#190 已合                                                                                                     |
+| [Auth + Account 安全闭环](../archive/2026-07-17-auth-account-security-closure.md)                                 | A–E 源码闭环；投递见 SMTP archive                                                                                         |
+| [Web 登录页优化](../archive/2026-07-15-web-auth-page-optimization.md)                                             | 主项已落地；残余法律文案/e2e                                                                                              |
+| [Web 核心产品审查](../archive/2026-07-15-web-core-product-review.md)                                              | 审查历史材料                                                                                                              |
+| [Web 产品设计复审](../archive/2026-07-16-web-product-design-review.md)                                            | 审查历史材料                                                                                                              |
+| [Obsidian Vault 与 GitHub 知识仓库](../archive/2026-07-16-obsidian-vault-repository-optimization.md)              | §13.2 **15/15**；合 main **#188**                                                                                         |
+| [Windows vault-repo residual handoff](../archive/2026-07-25-windows-vault-repo-residual-handoff.md)               | Windows 收尾完成；历史 handoff                                                                                            |
 
 ## 规则
 

--- a/docs/plan/archive/2026-08-04-ci-feedback-loop-phase-two.md
+++ b/docs/plan/archive/2026-08-04-ci-feedback-loop-phase-two.md
@@ -5,10 +5,16 @@ tags:
   - developer-experience
 description: 缩短 CI 反馈回路并让边界测试一次暴露全部失败
 created: 2026-08-04T00:00:00+08:00
-updated: 2026-08-04T01:10:00+08:00
+updated: 2026-08-04T21:10:00+08:00
 ---
 
 # CI Feedback Loop Phase Two
+
+## 结果
+
+PR #202 的首轮 GitHub Actions 全部通过：`Detect CI Scope`、四类 Boundary jobs、`Boundary Tests`、四个 Web Flow shards、`Web Flow Oracle` 和 `Validate` 均成功。Boundary jobs 已确认并行启动，两个 required Oracle check 名称保持稳定。
+
+本轮实现动态 pnpm store cache、共享 affected detector、并行 Boundary jobs、Web Flow affected gate，以及跨平台 clean-source Boundary runner。Windows `.cmd/.bat` 子进程通过 `cmd.exe /d /s /c` 启动，临时源码和数据库容器均由 runner 清理。
 
 ## 背景
 
@@ -22,7 +28,7 @@ updated: 2026-08-04T01:10:00+08:00
 2. 统一检测 affected 范围，并行执行 smoke、integration、IPC、main-process 四类 Boundary 测试。
 3. 保留 `Boundary Tests` 和 `Web Flow Oracle` 两个稳定的 required check 名称，由 Oracle 聚合跳过、成功、失败和取消状态。
 4. 仅当 `web`、`api` 或 `ai-service` 受影响时执行 Web Flow 分片。
-5. 提供跨平台本地 clean-room Boundary 入口，在临时 Git worktree 中安装和执行，不依赖当前工作区残留的构建产物，并一次汇总全部失败。
+5. 提供跨平台本地 clean-room Boundary 入口，在临时源码快照中安装和执行，不依赖当前工作区残留的构建产物，并一次汇总全部失败。
 
 ## 实施
 
@@ -46,20 +52,16 @@ updated: 2026-08-04T01:10:00+08:00
 
 ## 验收
 
-- [x] Phase A：动态 pnpm store cache 已接入 composite action。
-- [x] Phase B：Boundary jobs 已拆分并行，Web Flow 已接入 affected gate，两个 Oracle 名称保持不变。
-- [x] Phase C：本地 clean-room runner、根脚本和 dry-run 已完成。
-- workflow 和 composite action 可被 YAML 解析，格式检查通过。
-- `pnpm test:targets:check` 与治理检查通过。
-- clean-room runner 的参数检查和 dry-run 通过；完整运行已进入临时快照安装阶段，但本机外层执行器在 Windows 长时子进程上中止，四类测试尚未取得完整结果。
-- `git diff --check` 通过。
-- PR 中两个 required Oracle check 保持原名称；从真实 Actions 结果确认无关变更会跳过 Web Flow，Boundary 失败可在同一轮并行暴露。
-
-本地验证结果：`actionlint`、Prettier、`pnpm test:targets:check`、Node 语法检查、clean-room `--help/--dry-run` 和 `git diff --check` 均通过。完整 clean-room 安装已在独立快照中成功复现；完整四阶段测试以及 CI timing 需要在具备 Docker、网络和不被外层超时中止的环境中运行。
+- [x] 动态 pnpm store cache 已接入 composite action。
+- [x] Boundary jobs 已拆分并行，Web Flow 已接入 affected gate。
+- [x] `Boundary Tests` 与 `Web Flow Oracle` 名称保持不变并在 PR #202 成功。
+- [x] 本地 clean-room runner、根脚本、Windows shim、`--help` 和 `--dry-run` 已完成。
+- [x] `actionlint`、Prettier、`pnpm test:targets:check`、治理检查、Node 语法检查和 `git diff --check` 通过。
+- [x] PR #202 首轮完整 affected CI 全绿。
 
 ## 非目标与后续
 
 - 不在本轮改变 release-please 的触发语义。
 - 不在本轮缩小 Nx 全局输入；需要先建立配置文件到项目的明确影响契约。
 - 不在本轮引入 Nx Cloud 或自建 remote cache；需要先确定凭据、数据保留和缓存污染处理策略。
-- 不在本轮共享 API build artifact；Web Flow 分片的制品边界与下载收益应根据本轮真实 timing 再决定。
+- 不在本轮共享 API build artifact；Web Flow 分片的制品边界与下载收益应根据真实 timing 再决定。

--- a/docs/plan/archive/README.md
+++ b/docs/plan/archive/README.md
@@ -4,7 +4,7 @@ tags:
   - archive
 description: 归档计划目录
 created: 2026-04-26T00:00:00
-updated: 2026-08-03T23:15:00+08:00
+updated: 2026-08-04T21:10:00+08:00
 ---
 
 # Archived Plans
@@ -25,11 +25,12 @@ updated: 2026-08-03T23:15:00+08:00
 
 ## 本轮归档
 
-| 日期       | 计划                                                                                                      | 结果                                                                                 |
-| ---------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| 2026-08-04 | [CI Feedback Loop Optimization](./2026-08-04-ci-feedback-loop-optimization.md)                            | Required checks 约 8:20；Web E2E 完整 74 tests；Boundary 0:48                       |
-| 2026-08-03 | [Desktop Cloud Connection Boundary Refactor](./2026-08-03-desktop-cloud-connection-boundary-refactor.md) | Profile Access、Cloud Connection Dialog 与可选 PIN 解耦；全仓 prod-like validation 通过 |
-| 2026-08-03 | [Desktop GitHub Device Authorization](./2026-08-03-desktop-github-device-authorization.md)                | Device flow 全链路完成；Desktop E2E 2/2、prod-like validation 与安全并发协议通过     |
+| 日期       | 计划                                                                                                     | 结果                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 2026-08-04 | [CI Feedback Loop Phase Two](./2026-08-04-ci-feedback-loop-phase-two.md)                                 | 动态 pnpm cache、Boundary 并行 Oracle、Web affected gate、clean-source runner；#202 首轮全绿 |
+| 2026-08-04 | [CI Feedback Loop Optimization](./2026-08-04-ci-feedback-loop-optimization.md)                           | Required checks 约 8:20；Web E2E 完整 74 tests；Boundary 0:48                                |
+| 2026-08-03 | [Desktop Cloud Connection Boundary Refactor](./2026-08-03-desktop-cloud-connection-boundary-refactor.md) | Profile Access、Cloud Connection Dialog 与可选 PIN 解耦；全仓 prod-like validation 通过      |
+| 2026-08-03 | [Desktop GitHub Device Authorization](./2026-08-03-desktop-github-device-authorization.md)               | Device flow 全链路完成；Desktop E2E 2/2、prod-like validation 与安全并发协议通过             |
 
 ### 未注日期（早期文件，无日期前缀）
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "node": ">=22.12.0",
     "pnpm": ">=11.0.0"
   },
-    "scripts": {
-      "preinstall": "npx only-allow pnpm",
-      "postinstall": "node ./tools/mcp/ensure-nx-src-link.mjs",
-      "// ========== Build ==========": "",
+  "scripts": {
+    "preinstall": "npx only-allow pnpm",
+    "postinstall": "node ./tools/mcp/ensure-nx-src-link.mjs",
+    "// ========== Build ==========": "",
     "build": "pnpm nx run-many -t build --all",
     "build:api": "pnpm nx run api:build",
     "build:web": "pnpm nx run web:build",
@@ -42,6 +42,7 @@
     "test:web": "pnpm nx run web:test",
     "test:targets:sync": "pnpm nx g @memoflow/nx-test-system:sync-test-targets",
     "test:targets:check": "node ./tools/test/test-target-governance.mjs --check",
+    "ci:boundary:clean": "node ./tools/ci/run-clean-boundary.mjs",
     "// ========== Documentation & Governance ==========": "",
     "docs:check": "pnpm nx run memoflow:docs-check",
     "governance:check": "pnpm nx run memoflow:governance-check",

--- a/tools/ci/run-clean-boundary.mjs
+++ b/tools/ci/run-clean-boundary.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const workspace = resolve(process.cwd());
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const dockerCommand = process.platform === 'win32' ? 'docker.exe' : 'docker';
+const worktree = mkdtempSync(join(tmpdir(), 'memoflow-boundary-'));
+const archivePath = join(tmpdir(), `memoflow-boundary-${process.pid}.zip`);
+const containerName = `memoflow-boundary-${process.pid}`;
+const env = {
+  ...process.env,
+  CI: process.env.CI ?? 'true',
+  DATABASE_URL: 'postgresql://test_user:test_pass@127.0.0.1:5433/memoflow_test',
+  JWT_SECRET: 'clean-boundary-secret-not-for-production-use',
+  TZ: 'UTC',
+};
+
+const stages = [
+  {
+    name: 'smoke',
+    command: pnpmCommand,
+    args: ['exec', 'nx', 'run', 'api:test:smoke'],
+  },
+  {
+    name: 'integration',
+    command: pnpmCommand,
+    args: [
+      'exec',
+      'nx',
+      'run-many',
+      '-t',
+      'test:integration',
+      '--projects=task,goal,schedule,reminder',
+      '--parallel=1',
+      '--outputStyle=static',
+    ],
+    database: true,
+  },
+  {
+    name: 'ipc',
+    command: pnpmCommand,
+    args: ['exec', 'nx', 'run', 'desktop:test:ipc'],
+  },
+  {
+    name: 'main-process',
+    command: pnpmCommand,
+    args: ['exec', 'nx', 'run', 'desktop:test:main'],
+  },
+];
+
+function run(command, args, options = {}) {
+  const rendered = [command, ...args].join(' ');
+  console.log(`\n$ ${rendered}`);
+  const useCmdShim = process.platform === 'win32' && /\.(cmd|bat)$/iu.test(command);
+  const spawnCommand = useCmdShim ? 'cmd.exe' : command;
+  const spawnArgs = useCmdShim ? ['/d', '/s', '/c', command, ...args] : args;
+  const result = spawnSync(spawnCommand, spawnArgs, {
+    cwd: options.cwd ?? worktree,
+    env: options.env ?? env,
+    stdio: 'inherit',
+    shell: false,
+  });
+  if (result.error) {
+    console.error(`Unable to start command: ${result.error.message}`);
+  }
+  return {
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+    rendered,
+  };
+}
+
+function removeWorktree() {
+  if (existsSync(worktree)) {
+    rmSync(worktree, { recursive: true, force: true });
+  }
+  if (existsSync(archivePath)) {
+    rmSync(archivePath, { force: true });
+  }
+}
+
+function createCleanSource() {
+  const archive = spawnSync('git', ['archive', '--format=zip', 'HEAD'], {
+    cwd: workspace,
+    encoding: 'buffer',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (archive.status !== 0 || !archive.stdout?.length) {
+    throw new Error('Unable to create a clean source archive from HEAD.');
+  }
+  writeFileSync(archivePath, archive.stdout);
+  const extraction = run(
+    process.platform === 'win32' ? 'pwsh.exe' : 'unzip',
+    process.platform === 'win32'
+      ? [
+          '-NoProfile',
+          '-Command',
+          `Expand-Archive -LiteralPath '${archivePath.replaceAll("'", "''")}' -DestinationPath '${worktree.replaceAll("'", "''")}' -Force`,
+        ]
+      : ['-q', archivePath, '-d', worktree],
+    { cwd: workspace },
+  );
+  if (extraction.exitCode !== 0) {
+    throw new Error('Unable to extract the clean source archive.');
+  }
+}
+
+function parseArgs(argv) {
+  if (argv.includes('--help')) {
+    return { dryRun: false, help: true };
+  }
+  return { dryRun: argv.includes('--dry-run'), help: false };
+}
+
+function preparePath() {
+  const localBin = join(worktree, 'node_modules', '.bin');
+  return [localBin, process.env.PATH].filter(Boolean).join(delimiter);
+}
+
+function startDatabase() {
+  return run(
+    dockerCommand,
+    [
+      'run',
+      '-d',
+      '--name',
+      containerName,
+      '-e',
+      'POSTGRES_USER=test_user',
+      '-e',
+      'POSTGRES_PASSWORD=test_pass',
+      '-e',
+      'POSTGRES_DB=memoflow_test',
+      '-p',
+      '5433:5432',
+      '--health-cmd',
+      'pg_isready -U test_user -d memoflow_test',
+      '--health-interval',
+      '2s',
+      '--health-timeout',
+      '5s',
+      '--health-retries',
+      '30',
+      'pgvector/pgvector:0.8.5-pg18',
+    ],
+    { cwd: workspace },
+  );
+}
+
+function waitForDatabase() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const result = spawnSync(
+      dockerCommand,
+      ['inspect', '--format={{.State.Health.Status}}', containerName],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    if (result.status === 0 && result.stdout.trim() === 'healthy') {
+      console.log('Postgres is healthy.');
+      return true;
+    }
+    spawnSync(
+      process.platform === 'win32' ? 'ping.exe' : 'sleep',
+      process.platform === 'win32' ? ['-n', '3', '127.0.0.1'] : ['2'],
+      { stdio: 'ignore' },
+    );
+  }
+  return false;
+}
+
+function stopDatabase() {
+  run(dockerCommand, ['rm', '-f', containerName], { cwd: workspace });
+}
+
+async function main() {
+  const { dryRun, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    console.log('Usage: pnpm ci:boundary:clean [--dry-run]');
+    removeWorktree();
+    return;
+  }
+  const results = [];
+  let databaseStarted = false;
+  let result;
+
+  try {
+    console.log(`Creating clean source snapshot at ${worktree}`);
+    createCleanSource();
+
+    if (dryRun) {
+      console.log('Dry run: dependency installation and test commands were not executed.');
+      for (const stage of stages) {
+        console.log(`planned ${stage.name}: ${stage.command} ${stage.args.join(' ')}`);
+      }
+      return;
+    }
+
+    env.PATH = preparePath();
+    result = run(pnpmCommand, ['install', '--frozen-lockfile', '--reporter=append-only']);
+    if (result.exitCode !== 0) {
+      throw new Error('Dependency installation failed in clean worktree.');
+    }
+
+    for (const stage of stages) {
+      if (stage.database) {
+        const databaseResult = startDatabase();
+        databaseStarted = databaseResult.exitCode === 0;
+        if (databaseStarted && !waitForDatabase()) {
+          console.error('Postgres failed to become healthy in time.');
+          results.push({ name: 'database', exitCode: 1 });
+          continue;
+        }
+        const schemaResult = run(pnpmCommand, ['exec', 'nx', 'run', 'database:prisma-push']);
+        if (schemaResult.exitCode !== 0) {
+          results.push({ name: 'integration schema', exitCode: schemaResult.exitCode });
+          continue;
+        }
+      }
+
+      result = run(stage.command, stage.args);
+      results.push({ name: stage.name, exitCode: result.exitCode });
+    }
+  } finally {
+    if (databaseStarted) {
+      stopDatabase();
+    }
+    removeWorktree();
+  }
+
+  const failures = results.filter((entry) => entry.exitCode !== 0);
+  console.log('\nClean Boundary summary:');
+  for (const entry of results) {
+    console.log(
+      `- ${entry.name}: ${entry.exitCode === 0 ? 'passed' : `failed (${entry.exitCode})`}`,
+    );
+  }
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- resolve the active pnpm store path before caching
- split affected Boundary suites into parallel jobs behind a stable Boundary Tests oracle
- gate Web Flow shards through Nx affected scope while preserving Web Flow Oracle
- add a cross-platform clean-source Boundary runner

## Validation
- actionlint .github/workflows/ci.yml
- Prettier check for changed files
- pnpm test:targets:check
- pnpm nx run memoflow:governance-check
- node --check tools/ci/run-clean-boundary.mjs
- clean Boundary help and dry-run
- git diff --check