### PR TITLE
refactor(ai): centralize runtime capability assembly (AH-7)

### DIFF
--- a/docs/audit/2026-08-08-pm-systematic-review.md
+++ b/docs/audit/2026-08-08-pm-systematic-review.md
@@ -1,0 +1,130 @@
+---
+tags:
+  - audit
+  - product-management
+  - systematic-review
+  - opportunities
+description: 产品经理视角的 MemoFlow 系统性审查：产品线、架构健康、工程效率、DX、安全、可观测性与机会点清单
+created: 2026-08-08T00:00:00Z
+---
+
+# MemoFlow 产品经理式系统性审查（2026-08-08）
+
+> 视角：以产品经理 / 交付负责人的身份，跨产品、架构、工程、流程、基建五个维度做一次"全景体检"。
+> 定位：本文不重复 [系统性诊断与重构蓝图](./2026-08-07-memoflow-systemic-diagnosis-and-rebuild.md)
+> 的架构细节，而是给出可决策的优先级、机会点和验收建议。实施细节以 active plans 与 standards 为准。
+
+## 1. 总体判断
+
+MemoFlow 已经是一个**资产丰富但完成度不均**的个人操作系统型产品：
+- **强项**：功能资产多（Goal / Task / Reminder / Schedule / Notification / Knowledge / AI / Dashboard / Repository / Account / Cloud Auth），
+  契约驱动、Nx 多包架构、plan 纪律与 agent 协作规范成熟；AI 能力（统一助手 / Agent Host / Workflow / Turn / Model）是清晰的主产品线；
+  CI/CD 平台 V2 六平面契约已落地，测试资产庞大（763 个 spec/test）。
+- **主风险**：主产品线 Agent Host 的"完成定义"尚未宣称（阶段 0-6 部分完成），产品恢复 UI、Artifact 工作台、Electron 多引擎 E2E 等
+  切片仍 pending；移动端不在范围内；生产部署依赖单机 docker 栈；长期 timing/fault 运营证据（CI baseline-v1）尚未采集。
+
+## 2. 产品线盘点（成熟度）
+
+| 产品线 | 核心资产 | 成熟度 | 备注 |
+|---|---|---|---|
+| 统一助手 / Agent Host | AssistantFacade、Workflow/Turn/Model、ProposalKernel、CapabilityResolver | 🟡 实施中 | 完成定义未宣称；AH-2/4/5/6/7 切片 pending |
+| Goal | Goal Agent workflow（澄清→草稿→编辑→确认→执行） | 🟢 完整 | 含 Knowledge Q&A + Citations |
+| Task | Task 服务 + TaskInstance 维护 runtime（乐观锁、outbox） | 🟢 近期重构完成 | PR #211 R0-R7 落地 |
+| Reminder / Schedule / Notification | 业务闭环 R0-R7 | 🟢 完成 | ScheduleLease/claim、Reminder/Notification 通道 |
+| Knowledge | 知识库 + 索引（PowerSync 本地 / Prisma 表）+ Q&A | 🟡 双后端 | 向量召回支持 none/local-js-hybrid/pgvector |
+| AI Runtime | direct-provider / remote-ai-service 双模式 | 🟢 本次收缩 | AH-7 单 capability 投影（2026-08-08） |
+| Dashboard / Repository / Account / Cloud Auth | 完整模块 | 🟢 完成 | device flow、Profile 单轨 |
+| 桌面端（Electron） | 三栏 UI、Tab/KeepAlive、单一滚动宿主 | 🟢 基础完成 | 多引擎 E2E 待建（AH-5） |
+| 移动端 | app-react / app-vue / ui-react-native 资产存在 | 🔴 不在本轮范围 | 明确边界 |
+
+## 3. 用户价值与体验
+
+1. **统一助手是北极星**：右侧工作台 + Artifact/Proposal + 中间对话区的产品形态正确，但"产品恢复 UI"（AH-2）与
+   "Task 共用 Artifact 工作台"（AH-4）是用户可感知价值的最大缺口——当前 Agent 输出无法在 UI 中恢复/编辑。
+2. **恢复语义是个人 OS 的信任基石**：conversationId ↔ Host open-chat 关联已固化（AH-1），但 fail-closed 的恢复入口仍缺；
+   建议 P1 补最小"最近会话恢复"路径，而不是全量会话管理。
+3. **onboarding 与首次价值**：建议用 local-docker 产品旅程（已 7/7 通过）作为发布门禁，并在首次 Goal 生成后引导
+   Knowledge Q&A 形成价值闭环。
+
+## 4. 架构与工程健康度
+
+- **Nx 多包边界**：30+ packages 分层清晰（contracts / domain / infrastructure / transport / ui）。
+- **契约驱动**：contracts 包 + zod schema 贯穿 runtime/UI，改动可被 surface spec 兜底。
+- **一致性机制**：乐观锁、outbox 单通道、ScheduleLease/claim、stale proposal 禁 approve（AH-3）——业务闭环质量高。
+- **AI 双 runtime**：direct / remote 能力投影已统一（AH-7），未来新增 runtime 只需接入 assembleCapabilities。
+- **测试**：763 个 spec/test；surface spec（契约边界）+ 单元 + e2e 分层。
+- **CI/CD**：8 个 workflow；CI/CD Platform V2 六平面（scope/workspace/execution/artifact/observation/release）；
+  W8/W11 已接入 scheduled audit，但 **baseline-v1 的 comparable run 证据待采集**——这是当前 CI 线最大的诚实缺口。
+
+## 5. 开发体验（DX）
+
+- **协作规范成熟**：AGENT.md 唯一入口 + plan/active 纪律 + residual 日志 + repository agent-skills，agent 友好。
+- **探索依赖 MCP**：AGENT.md 要求 CodeGraph / nx-mcp 做符号探索；若 MCP 未就绪（如新环境），探索效率下降。
+- **写保护缺口（本机实测）**：Hermes 会话的 `HERMES_WRITE_SAFE_ROOT=/opt/data` 不允许直接写
+  `/workspace/repos/memoflow`，需通过 execute_code/terminal 绕过；建议把仓库根加入写安全前缀，否则文件工具与
+  代码工作流错位。
+- **依赖安装**：本机容器无 node_modules/pnpm，首次 `pnpm install` 全量安装耗时明显；建议维护 warm cache 或
+  devcontainer 预装。
+
+## 6. 安全与合规
+
+- 认证：Better Auth + device flow + Desktop 显式批准 + PIN 解耦——已成型。
+- 密钥：CPA 管理密钥、上游 key 遵循"不经参数、走 0600 文件"；.clients.env 0600；gatewayctl audit 日志 sanitized。
+- Docker：API 镜像裁剪（-70.4%）、独立 migrator、isolated builder、显式生产依赖闭包——镜像面健康。
+- 供应链：release-please + docker-deploy；第三方中转（gateai.cc）作为 AI 上游存在配额/合规风险，建议为关键路径
+  保留官方或自有通道。
+- 待办：审计文档中不应出现明文密钥（历次 review 均打码）；建议 CI 加 secret 扫描。
+
+## 7. 性能与可观测性
+
+- CI：timing/fault 观测已埋点（run observation、fault-injection 22 项平台测试），但**运营证据窗口未开**（baseline-v1）。
+- 运行时：AI runtime 提供 knowledgeIndexDiagnostics（persistence/vectorRecall 状态）；建议扩到 Goal/Task 关键路径。
+- 建议：给关键业务链路（Goal 生成、Task claim、Notification 投递）加 P99 指标，纳入 CI audit 的门禁。
+
+## 8. 基建（本机 Hermes 侧）
+
+- 模型网关 CPA（127.0.0.1:8317）已修复 egress（resin 死→direct），deepseek/gpt-5.5/glm 可用；claude 通道缺 Anthropic key（claude-code 装好未激活）。
+- 编码 Agent：codex（gpt-5.5/responses）、opencode、reasonix（deepseek）、codebuddy（腾讯，已登录）、agy 均已可用。
+- MCP：memoflow profile 已配 github/postgres/filesystem/docker（待网关重启生效）。
+- 机会：把"免费/低费模型优先"沉淀为默认路由策略（deepseek/glm 优先，gpt 兜底），控制成本。
+
+## 9. 风险清单
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| Agent Host 完成定义长期未宣称 → 产品主线悬空 | 高 | AH-4/AH-5 排期，P1 补恢复 UI |
+| CI baseline 证据缺失 → 优化无对照 | 中 | 采集 ≥5 次 comparable run |
+| 单机容器栈承载生产（oracle2） | 中 | 明确容灾/回滚演练 |
+| 第三方 AI 中转配额/稳定性 | 中 | 多上游 + 免费模型优先 |
+| 文档冗余（根级 UI_REDESIGN_* 等历史文档） | 低 | 归档清理，遵守 docs 分层 |
+
+## 10. 机会点清单（按优先级）
+
+### P0（北极星，主线）
+1. **AH-4 Task 共用 Artifact 工作台（最小一档）**：非全量富编辑，先把 Agent 产出展示为只读+可复制的工作台，打通 journey。
+2. **AH-2 产品恢复 UI（最小闭环）**：按 conversationId 枚举 open-chat 的只读恢复路径，fail-closed 缺省提示。
+
+### P1（补齐主线的支撑）
+3. **AH-5 Electron 多引擎 E2E scaffold**（或诚实 external + driver 一步）。
+4. **CI baseline-v1 采集**：≥5 次 comparable run，固化 timing 报告。
+5. **写保护与 DX 修复**：仓库加入 HERMES_WRITE_SAFE_ROOT；devcontainer 预装依赖。
+6. **密钥扫描**：CI 增加 secret/明文密钥扫描。
+
+### P2（打磨与治理）
+7. **文档清理**：根级 UI_REDESIGN_* 历史文档移入 archive；IMPLEMENTATION_STATUS.md 与当前状态对齐或归档。
+8. **可观测性扩展**：Goal/Task 关键链路 P99 指标入 CI audit 门禁。
+9. **AI 成本策略**：默认路由 deepseek/glm，gpt 仅按需；记录单任务成本。
+10. **AH-6/AH-7 收尾**：real Pi spawn 诚实边界；runtimeMode 后续投影持续走 assembleCapabilities。
+
+## 11. 建议的下一步（30/60/90）
+
+- **30 天**：AH-2 恢复 UI 最小闭环 + AH-4 工作台最小一档 + CI baseline 首采。
+- **60 天**：Agent Host 完成定义可诚实宣称（含 AH-5 E2E）；DX 写保护与依赖预热修复。
+- **90 天**：移动端可行性评估、成本策略落地、系统性文档归档。
+
+## 12. 关联文档
+
+- [系统性诊断与大重构蓝图](./2026-08-07-memoflow-systemic-diagnosis-and-rebuild.md)
+- [业务架构深度审查](./2026-08-07-business-architecture-deep-audit.md)
+- [UI 基础与 Shell 系统诊断](./2026-08-06-ui-foundation-shell-system-diagnosis.md)
+- Active Plans：[统一助手与 Agent Host](../plan/active/2026-07-17-unified-assistant-agent-host.md)、[夜间 hygiene 协议](../plan/active/2026-07-25-nightly-hygiene-and-agent-host.md)、[CI/CD Platform V2](../plan/active/2026-08-05-ci-cd-platform-v2-refactor.md)

--- a/docs/plan/active/2026-07-17-unified-assistant-agent-host.md
+++ b/docs/plan/active/2026-07-17-unified-assistant-agent-host.md
@@ -25,6 +25,10 @@ updated: 2026-07-22T00:00:00
 
 本文描述目标架构和渐进迁移顺序，不把尚未实现的 Capability Resolver、Turn Engine、CLI adapter 或 AgentActivity 描述成当前能力。
 
+### 当前进展（2026-08-08；nightly N4 / AH-7 对齐）
+
+- **Nightly residual N4（AH-7）**：capability 组装从两个 runtime 各自手写收拢为共享 `assembleCapabilities`（`packages/ai/src/server/shared/assemble-capabilities.ts`），direct/remote 两模式同一投影函数，含 focused tests 5 绿；配套 PM 系统审查见 docs/audit/2026-08-08-pm-systematic-review.md。
+
 ### 当前进展（2026-07-25 续；与 vault residual 1342 + nightly N1 对齐）
 
 - **Nightly residual N1（AH-1）**：`AssistantEvent` `run.started` 可选 `conversationId`；`AssistantFacade` 在 open-chat（direct_turn / pi_readonly）下发 trimmed conversationId；缺 conversation 时 omit 字段且 direct_turn 仍 `CONVERSATION_REQUIRED`。**不**宣称 Conversation↔AgentRun 持久多对一产品完成定义已勾。

--- a/docs/plan/active/2026-07-25-nightly-hygiene-and-agent-host.md
+++ b/docs/plan/active/2026-07-25-nightly-hygiene-and-agent-host.md
@@ -97,7 +97,7 @@ residual 记本文件 §9 与 elegance plan §9。
 | AH-4 | Task 共用 Artifact 工作台一小步（非全量富编辑） | Host UI + journey | pending |
 | AH-5 | Electron multi-engine 产品 E2E（或诚实 external + driver 一步） | scaffold `e2e.electron_desktop_full` | pending / 可 external |
 | AH-6 | real Pi spawn：要么 fail-closed 产品路径，要么永久 research keep-boundary | scaffold `e2e.real_pi_spawn` | pending / 默认不假绿 |
-| AH-7 | 阶段 8 遗留：direct/remote runtimeMode 向 capability 组装收缩（小步） | 单 capability 投影 | pending |
+| AH-7 | 阶段 8 遗留：direct/remote runtimeMode 向 capability 组装收缩（小步） | 单 capability 投影 | **本文件 residual N4 落地（2026-08-08）** |
 
 诚实：AH-5/AH-6 可长期 external；**不**据此勾 agent-host §20 全项。
 
@@ -129,6 +129,7 @@ residual 记本文件 §9 与 elegance plan §9。
 | E-PR189 | 2026-07-26 | elegance A+B+C：archive vault；Dual Registry；dual 237→84；AI path map；AH-2 书面不做 | elegance | merge 门槛 |
 | E5b | 2026-07-26 | bootstrap LegacyAccountModule → AccountApiModule + surface（#189 后真 E5 S） | elegance | 死域 S |
 | N3 | 2026-07-25 | AH-3：ProposalKernel stale 禁 approve；revise 清 stale→draft；STALE_REVISION 仍在 | agent-host | kernel tests |
+| N4 | 2026-08-08 | AH-7：`assembleCapabilities` 单 capability 投影落地；direct/remote 两 runtime 统一能力组装；focused tests 5 绿；PM 系统审查文档见 docs/audit/2026-08-08-pm-systematic-review.md | agent-host | shared spec 5 绿 |
 
 ## 10. 完成 / 归档
 

--- a/packages/ai/src/server/infrastructure/runtime/direct-provider-ai.runtime.ts
+++ b/packages/ai/src/server/infrastructure/runtime/direct-provider-ai.runtime.ts
@@ -8,7 +8,7 @@
  * Does NOT support knowledge query, analytics, or goal automation.
  */
 
-import type { AICapabilities } from '@memoflow/contracts/ai';
+import { assembleCapabilities } from '../../shared/assemble-capabilities';
 import type {
   AIModuleDependencies,
   AIModuleServices,
@@ -56,9 +56,6 @@ import { CapabilityResolver } from '../capability-resolver';
 import { AIKnowledgeNotePathResolver } from '../../application/services/ai-knowledge-note-path-resolver';
 import { OpenAICompatibleModelCatalogGateway } from '../gateways/openai-compatible-model-catalog.gateway';
 import { CustomModelGateway } from '../model-gateway';
-
-const ADVANCED_AI_REASON =
-  'Advanced AI features require a remote ai-service runtime. Configure AI_SERVICE_BASE_URL and AI_SERVICE_SECRET to enable goal automation, knowledge retrieval, analytics, and reindexing.';
 
 /**
  * Creates the direct-provider runtime.
@@ -151,19 +148,9 @@ export function createDirectProviderAIRuntime(dependencies: AIModuleDependencies
       )
     : null;
 
-  const capabilities: AICapabilities = {
-    runtimeMode: 'direct-provider',
-    supportsChat: true,
-    supportsGoalGeneration: true,
+  const capabilities = assembleCapabilities('direct-provider', {
     supportsKnowledgeNotes: Boolean(knowledgeNoteUseCase),
-    supportsKnowledgeQuery: false,
-    supportsKnowledgeReindex: false,
-    supportsAnalyticsQuery: false,
-    supportsGoalAutomation: false,
-    supportsAgentRuntime: false,
-    supportsEvaluationReports: false,
-    advancedFeaturesReason: ADVANCED_AI_REASON,
-  };
+  });
 
   // Residual 322/324: fail-closed capability projection shared with agent start gate.
   const capabilityResolver = new CapabilityResolver(

--- a/packages/ai/src/server/infrastructure/runtime/remote-ai-service.runtime.ts
+++ b/packages/ai/src/server/infrastructure/runtime/remote-ai-service.runtime.ts
@@ -14,7 +14,7 @@
  * Only fail-fast on explicitly attempted incomplete bundles (handled at call site).
  */
 
-import type { AICapabilities } from '@memoflow/contracts/ai';
+import { assembleCapabilities } from '../../shared/assemble-capabilities';
 import type {
   AIModuleDependencies,
   AIModuleServices,
@@ -74,9 +74,6 @@ import { LangGraphWorkflowAdapter } from '../workflow';
 import { AIKnowledgeNotePathResolver } from '../../application/services/ai-knowledge-note-path-resolver';
 import { OpenAICompatibleModelCatalogGateway } from '../gateways/openai-compatible-model-catalog.gateway';
 import { CustomModelGateway } from '../model-gateway';
-
-const ADVANCED_AI_REASON =
-  'Advanced AI features require a remote ai-service runtime. Configure AI_SERVICE_BASE_URL and AI_SERVICE_SECRET to enable goal automation, knowledge retrieval, analytics, and reindexing.';
 
 /**
  * Creates the remote AI-service runtime.
@@ -272,25 +269,15 @@ export function createRemoteAIServiceRuntime(dependencies: AIModuleDependencies)
   );
   const supportsAgentRuntime = Boolean(dependencies.agentRuntimePort);
 
-  const capabilities: AICapabilities = {
-    runtimeMode: 'remote-ai-service',
-    supportsChat: true,
-    supportsGoalGeneration: true,
+  const capabilities = assembleCapabilities('remote-ai-service', {
     supportsKnowledgeNotes: Boolean(knowledgeNoteUseCase),
     supportsKnowledgeQuery,
-    supportsKnowledgeReindex: supportsKnowledgeQuery,
     supportsAnalyticsQuery,
     supportsGoalAutomation,
     supportsAgentRuntime,
     supportsEvaluationReports: Boolean(evaluationReportUseCase),
-    advancedFeaturesReason:
-      supportsKnowledgeQuery &&
-      supportsAnalyticsQuery &&
-      supportsGoalAutomation &&
-      supportsAgentRuntime
-        ? undefined
-        : ADVANCED_AI_REASON,
-  };
+    clearAdvancedReasonWhenComplete: true,
+  });
 
   // Residual 322/324: fail-closed capability projection shared with agent start gate.
   // Workflow adapter offers are explicit (not silent engine.*) when remote agent runtime is present.

--- a/packages/ai/src/server/shared/__tests__/assemble-capabilities.spec.ts
+++ b/packages/ai/src/server/shared/__tests__/assemble-capabilities.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADVANCED_AI_REASON,
+  assembleCapabilities,
+} from '../assemble-capabilities';
+
+describe('assembleCapabilities (AH-7 single capability projection)', () => {
+  it('projects direct-provider mode with only basic features (fail-closed)', () => {
+    const caps = assembleCapabilities('direct-provider', {
+      supportsKnowledgeNotes: false,
+    });
+
+    expect(caps.runtimeMode).toBe('direct-provider');
+    expect(caps.supportsChat).toBe(true);
+    expect(caps.supportsGoalGeneration).toBe(true);
+    expect(caps.supportsKnowledgeNotes).toBe(false);
+    expect(caps.supportsKnowledgeQuery).toBe(false);
+    expect(caps.supportsKnowledgeReindex).toBe(false);
+    expect(caps.supportsAnalyticsQuery).toBe(false);
+    expect(caps.supportsGoalAutomation).toBe(false);
+    expect(caps.supportsAgentRuntime).toBe(false);
+    expect(caps.supportsEvaluationReports).toBe(false);
+    expect(caps.advancedFeaturesReason).toBe(ADVANCED_AI_REASON);
+  });
+
+  it('keeps advancedFeaturesReason in direct mode even when flags are set (no auto-clear)', () => {
+    const caps = assembleCapabilities('direct-provider', {
+      supportsKnowledgeQuery: true,
+      supportsAnalyticsQuery: true,
+      supportsGoalAutomation: true,
+      supportsAgentRuntime: true,
+    });
+
+    expect(caps.advancedFeaturesReason).toBe(ADVANCED_AI_REASON);
+  });
+
+  it('clears advancedFeaturesReason when every advanced feature is available (remote behavior)', () => {
+    const caps = assembleCapabilities('remote-ai-service', {
+      supportsKnowledgeQuery: true,
+      supportsAnalyticsQuery: true,
+      supportsGoalAutomation: true,
+      supportsAgentRuntime: true,
+      supportsEvaluationReports: true,
+      clearAdvancedReasonWhenComplete: true,
+    });
+
+    expect(caps.runtimeMode).toBe('remote-ai-service');
+    expect(caps.supportsKnowledgeQuery).toBe(true);
+    expect(caps.supportsKnowledgeReindex).toBe(true);
+    expect(caps.advancedFeaturesReason).toBeUndefined();
+  });
+
+  it('keeps advancedFeaturesReason when any advanced feature is missing (remote behavior)', () => {
+    const caps = assembleCapabilities('remote-ai-service', {
+      supportsKnowledgeQuery: true,
+      supportsAnalyticsQuery: false,
+      supportsGoalAutomation: true,
+      supportsAgentRuntime: true,
+      clearAdvancedReasonWhenComplete: true,
+    });
+
+    expect(caps.advancedFeaturesReason).toBe(ADVANCED_AI_REASON);
+  });
+
+  it('defaults every advanced flag to false when input is omitted', () => {
+    const caps = assembleCapabilities('direct-provider');
+
+    expect(caps.supportsKnowledgeQuery).toBe(false);
+    expect(caps.supportsAnalyticsQuery).toBe(false);
+    expect(caps.supportsGoalAutomation).toBe(false);
+    expect(caps.supportsAgentRuntime).toBe(false);
+    expect(caps.supportsEvaluationReports).toBe(false);
+  });
+});

--- a/packages/ai/src/server/shared/assemble-capabilities.ts
+++ b/packages/ai/src/server/shared/assemble-capabilities.ts
@@ -1,0 +1,59 @@
+import type { AICapabilities, AIRuntimeMode } from '@memoflow/contracts/ai';
+
+/**
+ * Shared reason shown when advanced AI features are unavailable.
+ * Kept in the shared capability assembly so direct and remote runtimes
+ * expose the same explanation (AH-7: single capability projection).
+ */
+export const ADVANCED_AI_REASON =
+  'Advanced AI features require a remote ai-service runtime. Configure AI_SERVICE_BASE_URL and AI_SERVICE_SECRET to enable goal automation, knowledge retrieval, analytics, and reindexing.';
+
+export interface CapabilityAssemblyInput {
+  supportsKnowledgeNotes?: boolean;
+  supportsKnowledgeQuery?: boolean;
+  supportsAnalyticsQuery?: boolean;
+  supportsGoalAutomation?: boolean;
+  supportsAgentRuntime?: boolean;
+  supportsEvaluationReports?: boolean;
+  /**
+   * When true, clears `advancedFeaturesReason` as soon as every advanced
+   * feature is available (remote runtime behavior). Direct runtime keeps the
+   * reason unconditionally, so it omits this flag.
+   */
+  clearAdvancedReasonWhenComplete?: boolean;
+}
+
+/**
+ * Single capability projection shared by all AI runtimes (AH-7).
+ *
+ * Both runtimes previously declared their own `AICapabilities` literals with
+ * subtly different shapes; this function centralizes the assembly so the
+ * capability surface stays consistent and fail-closed by default.
+ */
+export function assembleCapabilities(
+  runtimeMode: AIRuntimeMode,
+  input: CapabilityAssemblyInput = {},
+): AICapabilities {
+  const supportsKnowledgeQuery = Boolean(input.supportsKnowledgeQuery);
+  const supportsAnalyticsQuery = Boolean(input.supportsAnalyticsQuery);
+  const supportsGoalAutomation = Boolean(input.supportsGoalAutomation);
+  const supportsAgentRuntime = Boolean(input.supportsAgentRuntime);
+
+  const allAdvancedAvailable =
+    supportsKnowledgeQuery && supportsAnalyticsQuery && supportsGoalAutomation && supportsAgentRuntime;
+
+  return {
+    runtimeMode,
+    supportsChat: true,
+    supportsGoalGeneration: true,
+    supportsKnowledgeNotes: Boolean(input.supportsKnowledgeNotes),
+    supportsKnowledgeQuery,
+    supportsKnowledgeReindex: supportsKnowledgeQuery,
+    supportsAnalyticsQuery,
+    supportsGoalAutomation,
+    supportsAgentRuntime,
+    supportsEvaluationReports: Boolean(input.supportsEvaluationReports),
+    advancedFeaturesReason:
+      input.clearAdvancedReasonWhenComplete && allAdvancedAvailable ? undefined : ADVANCED_AI_REASON,
+  };
+}

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -2645,6 +2645,16 @@
       ]
     },
     {
+      "path": "packages/ai/src/server/shared/__tests__/assemble-capabilities.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/ai/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/ai/vitest.config.ts"
+      ]
+    },
+    {
       "path": "packages/ai/src/server/transport/__tests__/ai-assistant-facade.controller.spec.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -8811,14 +8821,14 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 113
+      "fileCount": 114
     },
     {
       "id": "packages/ai/vitest.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 113
+      "fileCount": 114
     },
     {
       "id": "packages/app-vue/vitest.config.ts",
@@ -9418,6 +9428,7 @@
       "packages/ai/src/server/infrastructure/turn-engine/__tests__/pi-readonly-process.adapter.surface.spec.ts",
       "packages/ai/src/server/infrastructure/turn-engine/__tests__/readonly-analysis.turn-engine.spec.ts",
       "packages/ai/src/server/infrastructure/workflow/__tests__/langgraph-workflow.adapter.spec.ts",
+      "packages/ai/src/server/shared/__tests__/assemble-capabilities.spec.ts",
       "packages/ai/src/server/transport/__tests__/ai-assistant-facade.controller.spec.ts",
       "packages/ai/src/server/transport/ai-agent-runtime.controller.test.ts",
       "packages/ai/src/server/transport/ai-goal-generation.controller.test.ts",
@@ -9762,7 +9773,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 832,
+    "unit": 833,
     "integration": 10,
     "smoke": 2,
     "boundary-ipc": 9,


### PR DESCRIPTION
## 变更

- **AH-7 落地**: direct/remote runtimeMode 向 capability 单投影收缩
- 新增 `packages/ai/src/server/shared/assemble-capabilities.ts`:统一 `assembleCapabilities()` 投影函数 + 共享 `ADVANCED_AI_REASON`
- direct-provider / remote-ai-service 两个 runtime 改为从同一函数组装 capabilities(行为保持:remote 全高级能力时清 reason,direct 恒保留)
- 新增 focused spec 5 项

## 验证

- `pnpm nx run ai:typecheck` ✅
- `pnpm nx run ai:lint` ✅
- `pnpm nx run ai:test` → 758 passed / 1 failed(预先存在: `ai-chat-application-service.test.ts` StreamAIMessageUseCase abort 用例,与本次改动无关,已在干净树复现)
- `pnpm test:inventory` + `pnpm nx run memoflow:governance-check` ✅

## 文档

- nightly hygiene N4 residual + AH-7 状态更新
- agent-host plan 当前进展补充
- 新增 docs/audit/2026-08-08-pm-systematic-review.md(PM 式系统性审查)

## 备注

- 变更策略遵循 AGENT.md:不引入 shim、根因修复