### PR TITLE
refactor: fix P0 layering inversions per reference-architecture review (ardanlabs/service + usememos/memos)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -158,7 +158,7 @@ async function bootstrap(): Promise<void> {
       },
     ],
   });
-  const reminderApiModule = composeReminder({
+  const reminderComposed = composeReminder({
     db: prisma,
     closureChecker: accountActiveChecker,
   });
@@ -189,13 +189,13 @@ async function bootstrap(): Promise<void> {
       scheduleTaskRepository: scheduleRepositorySet.scheduleTaskRepository,
     },
     reminderProjection: {
-      source: reminderApiModule.scheduleProjectionSource,
+      source: reminderComposed.scheduleProjectionSource,
       scheduleTaskRepository: scheduleRepositorySet.scheduleTaskRepository,
     },
     execution: {
       taskSource: createTaskPrismaScheduleExecutionSource(prisma),
       goalSource: createGoalPrismaScheduleExecutionSource(prisma),
-      reminderSource: reminderApiModule.scheduleExecutionSource,
+      reminderSource: reminderComposed.scheduleExecutionSource,
       notificationPort: notificationApiModule.scheduleNotificationPort,
     },
   });
@@ -203,33 +203,36 @@ async function bootstrap(): Promise<void> {
     repositories: scheduleRepositorySet,
     sourceExecutor: scheduleOrchestrationModule.sourceExecutor,
   });
-  const taskApiModule = composeTask({
+  const taskComposed = composeTask({
     db: prisma,
     runtimeContributions: scheduleOrchestrationModule.projectionRuntime,
     goalProgressHandler: createGoalTaskProgressPrismaHandler(prisma),
+  });
+  const goalComposed = composeGoal({
+    db: prisma,
+    taskBindingReadPort: new PrismaTaskBindingReadPort(prisma),
   });
   const aiApiModule = composeAI({
     db: prisma,
     repositoryApiPort: repositoryApiModule.getApplicationPort(),
     repositoryStorageBaseDir,
+    goalApplicationPort: goalComposed.applicationPort,
+    taskApplicationPort: taskComposed.applicationPort,
+    reminderApplicationPort: reminderComposed.applicationPort,
   });
   const governanceApiModule = composeGovernance({ db: prisma });
-  const goalApiModule = composeGoal({
-    db: prisma,
-    taskBindingReadPort: new PrismaTaskBindingReadPort(prisma),
-  });
   const app = await bootstrapper
     // === 核心：白名单注册 ===
     .register(governanceApiModule) // ✅ 治理模块 (runtime composer)
     .register(accountApiModule) // ✅ 账户模块 (runtime composer)
     .register(notificationApiModule.module) // ✅ 通知模块 (runtime composer)
-    .register(reminderApiModule.module) // ✅ 提醒模块 (runtime composer)
+    .register(reminderComposed.module) // ✅ 提醒模块 (runtime composer)
     .register(repositoryApiModule) // ✅ 仓库模块 (runtime composer)
     .register(scheduleApiModule.module) // ✅ 日程模块 (runtime composer)
     .register(settingApiModule) // ✅ 设置模块 (runtime composer)
-    .register(taskApiModule) // ✅ 任务模块
+    .register(taskComposed.module) // ✅ 任务模块
     .register(aiApiModule) // ✅ AI 模块 (runtime composer)
-    .register(goalApiModule) // ✅ 目标模块
+    .register(goalComposed.module) // ✅ 目标模块
     .register(dataPortabilityApiModule.module) // ✅ 数据导入导出模块 (runtime composer)
     .register(PowerSyncApiModule) // ✅ PowerSync 同步模块
     .register(DashboardApiModule) // ✅ 仪表盘聚合模块

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -31,7 +31,7 @@ import { ensurePowerSyncPublication } from './shared/infrastructure/database/ens
 import { composeGovernance } from './runtime/compose-governance';
 import { composeAccount } from './runtime/compose-account';
 import { composeNotification } from './runtime/compose-notification';
-import { composeReminder } from './runtime/compose-reminder';
+import { composeReminder, createExecutorClosureChecker } from './runtime/compose-reminder';
 import { composeRepository } from './runtime/compose-repository';
 import { composeSchedule } from './runtime/compose-schedule';
 import { composeSetting } from './runtime/compose-setting';
@@ -118,6 +118,14 @@ async function bootstrap(): Promise<void> {
   const closureRepo = new PrismaAccountClosureOperationRepository(prisma);
   const accountActiveChecker = async (identityId: string) =>
     (await closureRepo.findActiveByIdentityId(identityId)) !== null;
+  // Executor-visible closure predicate frozen from merge-base: block when the
+  // account is missing / Deactivated / Closed, or an active closure operation
+  // exists in requested|revoking|closing. The AI executor MUST see this
+  // predicate, not the shared account-active checker.
+  // 从 merge-base 冻结的 executor 可见闭户谓词：账户缺失 / Deactivated / Closed
+  // 或存在 requested|revoking|closing 阶段的有效闭户操作时阻断。AI executor
+  // 必须看到该谓词，而不是共享的账户激活检查器。
+  const executorClosureChecker = createExecutorClosureChecker(prisma);
   const cloudAuth = createCloudAuth({
     database: prisma,
     secret: jwtConfig.secret,
@@ -161,6 +169,7 @@ async function bootstrap(): Promise<void> {
   const reminderComposed = composeReminder({
     db: prisma,
     closureChecker: accountActiveChecker,
+    executorClosureChecker,
   });
   const repositoryApiModule = composeRepository({
     db: prisma,
@@ -218,7 +227,7 @@ async function bootstrap(): Promise<void> {
     repositoryStorageBaseDir,
     goalApplicationPort: goalComposed.applicationPort,
     taskApplicationPort: taskComposed.applicationPort,
-    reminderApplicationPort: reminderComposed.applicationPort,
+    reminderApplicationPort: reminderComposed.executorReminderPort,
   });
   const governanceApiModule = composeGovernance({ db: prisma });
   const app = await bootstrapper

--- a/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts
+++ b/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ok } from '@memoflow/contracts/result';
+import { error, ok } from '@memoflow/contracts/result';
 import type {
   GoalAutomationExecutionInput,
   IAnalyticsReadPort,
@@ -253,5 +253,21 @@ describe('BackendAutomationToolExecutorAdapter', () => {
       },
     ]);
     expect(mocks.createGoal).not.toHaveBeenCalled();
+  });
+
+  it('marks create_reminder as failed when the reminder port blocks on closure (merge-base receipt semantics)', async () => {
+    mocks.createTemplate.mockResolvedValue(
+      error('FORBIDDEN', 'Account is closed or closure in progress'),
+    );
+    const adapter = new BackendAutomationToolExecutorAdapter(createDependencies());
+
+    const result = await adapter.executeGoalAutomation(createExecutionInput());
+
+    expect(result.find((action) => action.tool === 'create_reminder')).toEqual({
+      tool: 'create_reminder',
+      status: 'failed',
+      message: 'Account is closed or closure in progress',
+    });
+    expect(mocks.createTemplate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts
+++ b/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts
@@ -1,60 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ok } from '@memoflow/contracts/result';
-import type { GoalAutomationExecutionInput } from '@memoflow/ai/ports';
+import type {
+  GoalAutomationExecutionInput,
+  IAnalyticsReadPort,
+  IKnowledgeSourcePort,
+} from '@memoflow/ai/ports';
+import type { GoalApplicationPort } from '@memoflow/goal';
+import type { TaskApplicationPort } from '@memoflow/task';
+import type { ReminderApplicationPort } from '@memoflow/reminder';
 
-import { BackendAutomationToolExecutorAdapter } from './backend-automation-tool-executor.adapter';
+import {
+  BackendAutomationToolExecutorAdapter,
+  type BackendAutomationToolExecutorDependencies,
+} from './backend-automation-tool-executor.adapter';
 
 const mocks = vi.hoisted(() => ({
   createGoal: vi.fn(),
   createTaskTemplate: vi.fn(),
-  createReminderTemplate: vi.fn(),
-  createReminderPrismaModule: vi.fn(),
+  createTemplate: vi.fn(),
   listRelevantNotes: vi.fn(),
   buildContext: vi.fn(),
 }));
 
-vi.mock('@memoflow/goal', () => ({
-  createGoalPrismaModule: vi.fn(() => ({
-    api: {
-      createGoal: mocks.createGoal,
-    },
-  })),
-}));
-
-vi.mock('@memoflow/task', () => ({
-  createTaskPrismaModule: vi.fn(() => ({
-    api: {
+function createDependencies(): BackendAutomationToolExecutorDependencies {
+  return {
+    goalApplicationPort: { createGoal: mocks.createGoal } as unknown as GoalApplicationPort,
+    taskApplicationPort: {
       createTaskTemplate: mocks.createTaskTemplate,
-    },
-  })),
-  PrismaTaskBindingReadPort: class {
-    constructor() {}
-    checkActiveTaskBindings = vi.fn().mockResolvedValue({ hasActiveBindings: false, activeCount: 0 });
-  },
-}));
-
-// Historical W4-baseline note: this test hoists the module mock so the adapter test
-// never statically imports the reminder package (keeps the api project free of a
-// lazy-load boundary violation); W5 does not refactor the test semantics.
-vi.mock('@memoflow/reminder', () => ({
-  createReminderPrismaModule: mocks.createReminderPrismaModule,
-}));
-
-vi.mock('./repository-knowledge-source.adapter', () => ({
-  RepositoryKnowledgeSourceAdapter: vi.fn(function RepositoryKnowledgeSourceAdapter() {
-    return {
+    } as unknown as TaskApplicationPort,
+    reminderApplicationPort: {
+      createTemplate: mocks.createTemplate,
+    } as unknown as ReminderApplicationPort,
+    knowledgeSource: {
       listRelevantNotes: mocks.listRelevantNotes,
-    };
-  }),
-}));
-
-vi.mock('./controlled-analytics-read.adapter', () => ({
-  ControlledAnalyticsReadAdapter: vi.fn(function ControlledAnalyticsReadAdapter() {
-    return {
-      buildContext: mocks.buildContext,
-    };
-  }),
-}));
+    } as unknown as IKnowledgeSourcePort,
+    analyticsRead: { buildContext: mocks.buildContext } as unknown as IAnalyticsReadPort,
+  };
+}
 
 function createExecutionInput(): GoalAutomationExecutionInput {
   return {
@@ -115,11 +97,6 @@ function createExecutionInput(): GoalAutomationExecutionInput {
 describe('BackendAutomationToolExecutorAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.createReminderPrismaModule.mockImplementation(() => ({
-      api: {
-        createTemplate: mocks.createReminderTemplate,
-      },
-    }));
     mocks.createGoal.mockResolvedValue(
       ok({
         goalId: 'goal-1',
@@ -142,7 +119,7 @@ describe('BackendAutomationToolExecutorAdapter', () => {
         todayInstanceCreated: false,
       }),
     );
-    mocks.createReminderTemplate.mockResolvedValue(
+    mocks.createTemplate.mockResolvedValue(
       ok({
         id: 'reminder-template-1',
         name: 'Weekly Agent review',
@@ -151,10 +128,7 @@ describe('BackendAutomationToolExecutorAdapter', () => {
   });
 
   it('executes approved goal, key result, task template, and reminder drafts with their reviewed fields', async () => {
-    const adapter = new BackendAutomationToolExecutorAdapter(
-      {} as ConstructorParameters<typeof BackendAutomationToolExecutorAdapter>[0],
-      'storage',
-    );
+    const adapter = new BackendAutomationToolExecutorAdapter(createDependencies());
     const now = new Date('2026-06-10T01:00:00.000Z').getTime();
     const expectedReminderStart = new Date(now);
     expectedReminderStart.setHours(10, 30, 0, 0);
@@ -201,7 +175,7 @@ describe('BackendAutomationToolExecutorAdapter', () => {
           }),
         }),
       );
-      expect(mocks.createReminderTemplate).toHaveBeenCalledWith(
+      expect(mocks.createTemplate).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'Weekly Agent review',
           description: 'Review goal progress and choose the next focus.',
@@ -234,10 +208,7 @@ describe('BackendAutomationToolExecutorAdapter', () => {
 
   it('skips dependent actions when goal creation fails', async () => {
     mocks.createGoal.mockRejectedValueOnce(new Error('Goal service unavailable'));
-    const adapter = new BackendAutomationToolExecutorAdapter(
-      {} as ConstructorParameters<typeof BackendAutomationToolExecutorAdapter>[0],
-      'storage',
-    );
+    const adapter = new BackendAutomationToolExecutorAdapter(createDependencies());
 
     const result = await adapter.executeGoalAutomation(createExecutionInput());
 
@@ -264,44 +235,23 @@ describe('BackendAutomationToolExecutorAdapter', () => {
       },
     ]);
     expect(mocks.createTaskTemplate).not.toHaveBeenCalled();
-    expect(mocks.createReminderTemplate).not.toHaveBeenCalled();
+    expect(mocks.createTemplate).not.toHaveBeenCalled();
   });
 
-  it('closureChecker blocks when account closure operation is requested or revoking or closing', async () => {
-    let passedClosureChecker: ((identityId: string) => Promise<boolean>) | undefined;
-    mocks.createReminderPrismaModule.mockImplementationOnce(
-      (
-        _db: unknown,
-        options: { closureChecker?: (identityId: string) => Promise<boolean> },
-      ) => {
-        passedClosureChecker = options?.closureChecker;
-        return {
-          api: {
-            createTemplate: mocks.createReminderTemplate,
-          },
-        };
-      },
-    );
+  it('skips unsupported tools with a skipped receipt without touching any port', async () => {
+    const adapter = new BackendAutomationToolExecutorAdapter(createDependencies());
+    const input = createExecutionInput();
+    input.actions = [{ tool: 'unsupported_tool', index: 0 }] as unknown as GoalAutomationExecutionInput['actions'];
 
-    const mockDb = {
-      account: {
-        findUnique: vi.fn().mockResolvedValue({ status: 'Active' }),
-      },
-      accountClosureOperation: {
-        findFirst: vi.fn().mockResolvedValue({ id: 'op-1', phase: 'requested' }),
-      },
-    } as unknown as ConstructorParameters<typeof BackendAutomationToolExecutorAdapter>[0];
+    const result = await adapter.executeGoalAutomation(input);
 
-    new BackendAutomationToolExecutorAdapter(mockDb, 'storage');
-    expect(passedClosureChecker).toBeDefined();
-
-    const isBlocked = await passedClosureChecker!('identity-closing');
-    expect(isBlocked).toBe(true);
-    expect(mockDb.accountClosureOperation.findFirst).toHaveBeenCalledWith({
-      where: {
-        identityId: 'identity-closing',
-        phase: { in: ['requested', 'revoking', 'closing'] },
+    expect(result).toEqual([
+      {
+        tool: 'unsupported_tool',
+        status: 'skipped',
+        message: 'Skipped unsupported tool unsupported_tool',
       },
-    });
+    ]);
+    expect(mocks.createGoal).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.ts
+++ b/apps/api/src/modules/ai/backend-automation-tool-executor.adapter.ts
@@ -15,17 +15,17 @@
  */
 import {
   type GoalAutomationExecutionInput,
+  type IAnalyticsReadPort,
   type IAIAutomationToolExecutorPort,
+  type IKnowledgeSourcePort,
 } from '@memoflow/ai/ports';
 import type { IdentityId } from '@memoflow/contracts';
 import type { GoalAutomationExecutedAction } from '@memoflow/contracts/ai';
 import type { GoalId, KeyResultId } from '@memoflow/contracts/goal';
-import type { PrismaClient } from '@memoflow/database';
-import { createGoalPrismaModule } from '@memoflow/goal';
-import { PrismaTaskBindingReadPort } from '@memoflow/task';
-import { createReminderPrismaModule } from '@memoflow/reminder';
-import { createTaskPrismaModule } from '@memoflow/task';
+import type { GoalApplicationPort } from '@memoflow/goal';
+import type { ReminderApplicationPort } from '@memoflow/reminder';
 import { TaskGoalBindingTrigger, TaskType } from '@memoflow/contracts/task';
+import type { TaskApplicationPort } from '@memoflow/task';
 import { unwrapOrThrowError } from '@memoflow/contracts/result';
 import { createLogger } from '@memoflow/utils/logger';
 // Residual 1007: sole reminder time helpers (local dual retired).
@@ -40,45 +40,49 @@ import {
   readNestedNumber,
 } from '@memoflow/utils/shared';
 
-import { ControlledAnalyticsReadAdapter } from './controlled-analytics-read.adapter';
-import { RepositoryKnowledgeSourceAdapter } from './repository-knowledge-source.adapter';
-
 const logger = createLogger('BackendAutomationToolExecutor');
 // Residual 1015: buildRecurrenceRule elevated to @memoflow/utils/shared.
 // Residual 1013/1011/1009/1007: related helpers elevated to @memoflow/utils/shared.
 
+/**
+ * Dependencies the AI automation tool executor needs from the API host runtime.
+ * AI 自动化工具执行器需要从 API 宿主运行时拿到的依赖。
+ *
+ * The executor only orchestrates these already-composed application ports and
+ * read adapters. It never constructs a feature module, never reads Prisma, and
+ * owns no module lifecycle — the API runtime composes Goal/Task/Reminder once
+ * and injects the same `instance.api` object identities here.
+ *
+ * 执行器只编排这些已组装好的 application port 与读取 adapter。它不构造任何
+ * feature module、不读取 Prisma、也不拥有 module 生命周期——API runtime 只组装
+ * Goal/Task/Reminder 一次，并把同一个 `instance.api` 对象 identity 注入此处。
+ */
+export interface BackendAutomationToolExecutorDependencies {
+  /** Already-composed Goal application port (`composeGoal(...).applicationPort`). 已组装的 Goal application port（`composeGoal(...).applicationPort`）。 */
+  readonly goalApplicationPort: GoalApplicationPort;
+  /** Already-composed Task application port (`composeTask(...).applicationPort`). 已组装的 Task application port（`composeTask(...).applicationPort`）。 */
+  readonly taskApplicationPort: TaskApplicationPort;
+  /** Already-composed Reminder application port (`composeReminder(...).applicationPort`). 已组装的 Reminder application port（`composeReminder(...).applicationPort`）。 */
+  readonly reminderApplicationPort: ReminderApplicationPort;
+  /** Knowledge source read port built by the AI composer. 由 AI composer 构建的知识源读取 port。 */
+  readonly knowledgeSource: IKnowledgeSourcePort;
+  /** Analytics read port built by the AI composer. 由 AI composer 构建的分析读取 port。 */
+  readonly analyticsRead: IAnalyticsReadPort;
+}
+
 export class BackendAutomationToolExecutorAdapter implements IAIAutomationToolExecutorPort {
-  private readonly goalModule;
-  private readonly taskModule;
-  private readonly reminderModule;
+  private readonly goalApplicationPort;
+  private readonly taskApplicationPort;
+  private readonly reminderApplicationPort;
   private readonly knowledgeSource;
   private readonly analyticsRead;
 
-  constructor(db: PrismaClient, storageBaseDir: string) {
-    this.goalModule = createGoalPrismaModule(db, {
-      taskBindingReadPort: new PrismaTaskBindingReadPort(db),
-    });
-    this.taskModule = createTaskPrismaModule(db);
-    this.reminderModule = createReminderPrismaModule(db, {
-      closureChecker: async (identityId: string) => {
-        const account = await db.account.findUnique({
-          where: { id: identityId },
-          select: { status: true },
-        });
-        if (!account || account.status === 'Deactivated' || account.status === 'Closed') {
-          return true;
-        }
-        const pendingClosure = await db.accountClosureOperation.findFirst({
-          where: {
-            identityId,
-            phase: { in: ['requested', 'revoking', 'closing'] },
-          },
-        });
-        return pendingClosure !== null;
-      },
-    });
-    this.knowledgeSource = new RepositoryKnowledgeSourceAdapter(db, storageBaseDir);
-    this.analyticsRead = new ControlledAnalyticsReadAdapter(db);
+  constructor(dependencies: BackendAutomationToolExecutorDependencies) {
+    this.goalApplicationPort = dependencies.goalApplicationPort;
+    this.taskApplicationPort = dependencies.taskApplicationPort;
+    this.reminderApplicationPort = dependencies.reminderApplicationPort;
+    this.knowledgeSource = dependencies.knowledgeSource;
+    this.analyticsRead = dependencies.analyticsRead;
   }
 
   async executeGoalAutomation(
@@ -127,7 +131,7 @@ export class BackendAutomationToolExecutorAdapter implements IAIAutomationToolEx
           hasCreatedGoal: Boolean(createdGoalId),
         });
         if (action.tool === 'create_goal') {
-          const result = await this.goalModule.api.createGoal(
+          const result = await this.goalApplicationPort.createGoal(
             {
               name: input.plan.goal.title,
               description: input.plan.goal.description,
@@ -221,7 +225,7 @@ export class BackendAutomationToolExecutorAdapter implements IAIAutomationToolEx
             throw new Error(`Missing task template draft for index ${action.index ?? -1}`);
           }
 
-          const result = await this.taskModule.api.createTaskTemplate({
+          const result = await this.taskApplicationPort.createTaskTemplate({
             identityId: input.identityId as IdentityId,
             name: taskTemplate.name,
             description: taskTemplate.description ?? null,
@@ -276,7 +280,7 @@ export class BackendAutomationToolExecutorAdapter implements IAIAutomationToolEx
             throw new Error(`Missing reminder draft for index ${action.index ?? -1}`);
           }
 
-          const result = await this.reminderModule.api.createTemplate(
+          const result = await this.reminderApplicationPort.createTemplate(
             buildReminderTemplateInput(reminder),
             {
               identityId: input.identityId,

--- a/apps/api/src/runtime/compose-ai.spec.ts
+++ b/apps/api/src/runtime/compose-ai.spec.ts
@@ -11,7 +11,9 @@
  *   and treats explicit `null` as disabled without an environment read
  * - forwards the six-field repository set (incl. the checkpoint pair) and the
  *   five host ports into createAIModule with exact object identity
- * - passes the assembled instance into createAIApiModule({ instance })
+ * - constructs the executor with the injected Goal/Task/Reminder application
+ *   ports plus the SAME knowledge-source / analytics-read adapters used by the
+ *   AI module (single module instance set)
  *
  * 验证 composeAI()：
  * - 按计划 §2.3 顺序装配 AI（Prisma 集合 → config 解析 → 宿主 adapter →
@@ -21,7 +23,8 @@
  *   视为禁用且不做环境读取
  * - 把六字段仓储集合（含 checkpoint pair）与五个宿主 port 以精确对象 identity
  *   传入 createAIModule
- * - 把装配好的 instance 传入 createAIApiModule({ instance })
+ * - 用注入的 Goal/Task/Reminder application port 加上与 AI 模块相同的
+ *   knowledge-source / analytics-read adapter（单套 module instance）构造 executor
  *
  * All package factories/classes and the app-local host adapters are mocked with
  * vi.fn() so the spec can assert invocation order and constructor arguments.
@@ -33,6 +36,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PrismaClient } from '@memoflow/database';
 import type { RepositoryApplicationPort } from '@memoflow/repository';
+import type { GoalApplicationPort } from '@memoflow/goal';
+import type { TaskApplicationPort } from '@memoflow/task';
+import type { ReminderApplicationPort } from '@memoflow/reminder';
 
 vi.mock('@memoflow/ai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@memoflow/ai')>();
@@ -102,7 +108,21 @@ import { RepositoryKnowledgeSourceAdapter } from '../modules/ai/repository-knowl
 
 const fakeDb = { tag: 'fake-db' } as unknown as PrismaClient;
 const fakeRepositoryApiPort = { tag: 'fake-repository-port' } as unknown as RepositoryApplicationPort;
+const fakeGoalApplicationPort = { tag: 'fake-goal-port' } as unknown as GoalApplicationPort;
+const fakeTaskApplicationPort = { tag: 'fake-task-port' } as unknown as TaskApplicationPort;
+const fakeReminderApplicationPort = {
+  tag: 'fake-reminder-port',
+} as unknown as ReminderApplicationPort;
 const fakeStorageBaseDir = '/tmp/fake-repository-storage';
+
+const aiDependencies = {
+  db: fakeDb,
+  repositoryApiPort: fakeRepositoryApiPort,
+  repositoryStorageBaseDir: fakeStorageBaseDir,
+  goalApplicationPort: fakeGoalApplicationPort,
+  taskApplicationPort: fakeTaskApplicationPort,
+  reminderApplicationPort: fakeReminderApplicationPort,
+};
 
 const mockRepositorySet = {
   conversationRepository: { tag: 'conversation' },
@@ -162,7 +182,7 @@ beforeEach(() => {
 
 describe('composeAI assembly order', () => {
   it('assembles in plan §2.3 order and returns an IApiModule-compatible handle', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     const prismaOrder = vi.mocked(createAIPrismaRepositories).mock.invocationCallOrder[0];
     const configOrder = vi.mocked(getAIServiceRuntimeConfig).mock.invocationCallOrder[0];
@@ -185,7 +205,7 @@ describe('composeAI assembly order', () => {
   });
 
   it('constructs the five app-local host adapters from the exact db / repository port / storage dir identities', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     expect(RepositoryKnowledgeNotePersistenceAdapter).toHaveBeenCalledTimes(1);
     expect(RepositoryKnowledgeNotePersistenceAdapter).toHaveBeenCalledWith(fakeRepositoryApiPort);
@@ -200,18 +220,24 @@ describe('composeAI assembly order', () => {
     expect(ControlledAnalyticsReadAdapter).toHaveBeenCalledWith(fakeDb);
 
     expect(BackendAutomationToolExecutorAdapter).toHaveBeenCalledTimes(1);
-    expect(BackendAutomationToolExecutorAdapter).toHaveBeenCalledWith(fakeDb, fakeStorageBaseDir);
+    expect(BackendAutomationToolExecutorAdapter).toHaveBeenCalledWith({
+      goalApplicationPort: fakeGoalApplicationPort,
+      taskApplicationPort: fakeTaskApplicationPort,
+      reminderApplicationPort: fakeReminderApplicationPort,
+      knowledgeSource: vi.mocked(RepositoryKnowledgeSourceAdapter).mock.results[0].value,
+      analyticsRead: vi.mocked(ControlledAnalyticsReadAdapter).mock.results[0].value,
+    });
   });
 
   it('creates the Prisma repository set exactly once with the exact db identity', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     expect(createAIPrismaRepositories).toHaveBeenCalledTimes(1);
     expect(createAIPrismaRepositories).toHaveBeenCalledWith(fakeDb);
   });
 
   it('forwards the six-field repository set (incl. checkpoint pair) and host ports into createAIModule', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     const moduleCall = vi.mocked(createAIModule).mock.calls[0][0];
     expect(moduleCall.conversationRepository).toBe(mockRepositorySet.conversationRepository);
@@ -230,7 +256,7 @@ describe('composeAI assembly order', () => {
   });
 
   it('passes the assembled instance into createAIApiModule({ instance })', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     const instance = vi.mocked(createAIModule).mock.results[0].value;
     expect(createAIApiModule).toHaveBeenCalledTimes(1);
@@ -247,12 +273,7 @@ describe('composeAI config branches', () => {
       timeoutMs: 1000,
     };
 
-    composeAI({
-      db: fakeDb,
-      repositoryApiPort: fakeRepositoryApiPort,
-      repositoryStorageBaseDir: fakeStorageBaseDir,
-      aiServiceRuntimeConfig: config,
-    });
+    composeAI({ ...aiDependencies, aiServiceRuntimeConfig: config });
 
     expect(getAIServiceRuntimeConfig).not.toHaveBeenCalled();
 
@@ -277,12 +298,7 @@ describe('composeAI config branches', () => {
       timeoutMs: 1000,
     };
 
-    composeAI({
-      db: fakeDb,
-      repositoryApiPort: fakeRepositoryApiPort,
-      repositoryStorageBaseDir: fakeStorageBaseDir,
-      aiServiceRuntimeConfig: config,
-    });
+    composeAI({ ...aiDependencies, aiServiceRuntimeConfig: config });
 
     const hostOrder = hostAdapterMocks
       .map((adapter) => vi.mocked(adapter).mock.invocationCallOrder[0])
@@ -302,7 +318,7 @@ describe('composeAI config branches', () => {
     };
     vi.mocked(getAIServiceRuntimeConfig).mockReturnValue(resolvedConfig);
 
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     expect(getAIServiceRuntimeConfig).toHaveBeenCalledTimes(1);
     for (const adapter of serviceAdapterMocks) {
@@ -312,12 +328,7 @@ describe('composeAI config branches', () => {
   });
 
   it('treats explicit null as disabled: no env read and every optional service port stays undefined', () => {
-    composeAI({
-      db: fakeDb,
-      repositoryApiPort: fakeRepositoryApiPort,
-      repositoryStorageBaseDir: fakeStorageBaseDir,
-      aiServiceRuntimeConfig: null,
-    });
+    composeAI({ ...aiDependencies, aiServiceRuntimeConfig: null });
 
     expect(getAIServiceRuntimeConfig).not.toHaveBeenCalled();
     for (const adapter of serviceAdapterMocks) {
@@ -333,7 +344,7 @@ describe('composeAI config branches', () => {
   it('treats a missing config as disabled: no service adapter and every optional service port stays undefined', () => {
     vi.mocked(getAIServiceRuntimeConfig).mockReturnValue(null);
 
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
 
     expect(getAIServiceRuntimeConfig).toHaveBeenCalledTimes(1);
     for (const adapter of serviceAdapterMocks) {
@@ -347,7 +358,7 @@ describe('composeAI config branches', () => {
   });
 
   it('always constructs the evaluation-report file adapter in both branches', () => {
-    composeAI({ db: fakeDb, repositoryApiPort: fakeRepositoryApiPort, repositoryStorageBaseDir: fakeStorageBaseDir });
+    composeAI(aiDependencies);
     expect(AIEvaluationReportFileAdapter).toHaveBeenCalledTimes(1);
     expect(vi.mocked(createAIModule).mock.calls[0][0].evaluationReportPort).toBe(
       vi.mocked(AIEvaluationReportFileAdapter).mock.results[0].value,
@@ -370,12 +381,7 @@ describe('composeAI config branches', () => {
       serviceName: 'memoflow-api-test',
       timeoutMs: 1000,
     };
-    composeAI({
-      db: fakeDb,
-      repositoryApiPort: fakeRepositoryApiPort,
-      repositoryStorageBaseDir: fakeStorageBaseDir,
-      aiServiceRuntimeConfig: config,
-    });
+    composeAI({ ...aiDependencies, aiServiceRuntimeConfig: config });
     expect(AIEvaluationReportFileAdapter).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/runtime/compose-ai.surface.spec.ts
+++ b/apps/api/src/runtime/compose-ai.surface.spec.ts
@@ -32,7 +32,7 @@ describe('AI API runtime composer surface', () => {
   it('main.ts composes AI via composeAI({ db: prisma, repositoryApiPort, repositoryStorageBaseDir, goal/task/reminder applicationPorts })', () => {
     expect(main).toContain("from './runtime/compose-ai'");
     expect(main).toMatch(
-      /composeAI\(\{\s*db: prisma,\s*repositoryApiPort: repositoryApiModule\.getApplicationPort\(\),\s*repositoryStorageBaseDir,\s*goalApplicationPort: goalComposed\.applicationPort,\s*taskApplicationPort: taskComposed\.applicationPort,\s*reminderApplicationPort: reminderComposed\.applicationPort,\s*\}/,
+      /composeAI\(\{\s*db: prisma,\s*repositoryApiPort: repositoryApiModule\.getApplicationPort\(\),\s*repositoryStorageBaseDir,\s*goalApplicationPort: goalComposed\.applicationPort,\s*taskApplicationPort: taskComposed\.applicationPort,\s*reminderApplicationPort: reminderComposed\.executorReminderPort,\s*\}/,
     );
     expect(main).toContain('.register(aiApiModule)');
   });
@@ -51,7 +51,7 @@ describe('AI API runtime composer surface', () => {
   it('main.ts feeds the composed goal/task/reminder application ports into composeAI and registers their .module handles', () => {
     expect(main).toContain('goalComposed.applicationPort');
     expect(main).toContain('taskComposed.applicationPort');
-    expect(main).toContain('reminderComposed.applicationPort');
+    expect(main).toContain('reminderComposed.executorReminderPort');
     expect(main).toContain('.register(taskComposed.module)');
     expect(main).toContain('.register(goalComposed.module)');
     expect(main).not.toMatch(/create(Goal|Task|Reminder)PrismaModule/);

--- a/apps/api/src/runtime/compose-ai.surface.spec.ts
+++ b/apps/api/src/runtime/compose-ai.surface.spec.ts
@@ -29,23 +29,32 @@ describe('AI API runtime composer surface', () => {
   const composer = readFileSync(resolve(apiDir, 'runtime/compose-ai.ts'), 'utf8');
   const transportModule = readFileSync(aiPackageApiModule, 'utf8');
 
-  it('main.ts composes AI via composeAI({ db: prisma, repositoryApiPort, repositoryStorageBaseDir })', () => {
+  it('main.ts composes AI via composeAI({ db: prisma, repositoryApiPort, repositoryStorageBaseDir, goal/task/reminder applicationPorts })', () => {
     expect(main).toContain("from './runtime/compose-ai'");
     expect(main).toMatch(
-      /composeAI\(\{\s*db: prisma,\s*repositoryApiPort: repositoryApiModule\.getApplicationPort\(\),\s*repositoryStorageBaseDir,\s*\}/,
+      /composeAI\(\{\s*db: prisma,\s*repositoryApiPort: repositoryApiModule\.getApplicationPort\(\),\s*repositoryStorageBaseDir,\s*goalApplicationPort: goalComposed\.applicationPort,\s*taskApplicationPort: taskComposed\.applicationPort,\s*reminderApplicationPort: reminderComposed\.applicationPort,\s*\}/,
     );
     expect(main).toContain('.register(aiApiModule)');
   });
 
-  it('keeps the AI registration between Task and Goal (taskApiModule → aiApiModule → goalApiModule)', () => {
-    const taskIndex = main.indexOf('.register(taskApiModule)');
+  it('keeps the AI registration between Task and Goal (taskComposed.module → aiApiModule → goalComposed.module)', () => {
+    const taskIndex = main.indexOf('.register(taskComposed.module)');
     const aiIndex = main.indexOf('.register(aiApiModule)');
-    const goalIndex = main.indexOf('.register(goalApiModule)');
+    const goalIndex = main.indexOf('.register(goalComposed.module)');
     expect(taskIndex).toBeGreaterThan(-1);
     expect(aiIndex).toBeGreaterThan(-1);
     expect(goalIndex).toBeGreaterThan(-1);
     expect(taskIndex).toBeLessThan(aiIndex);
     expect(aiIndex).toBeLessThan(goalIndex);
+  });
+
+  it('main.ts feeds the composed goal/task/reminder application ports into composeAI and registers their .module handles', () => {
+    expect(main).toContain('goalComposed.applicationPort');
+    expect(main).toContain('taskComposed.applicationPort');
+    expect(main).toContain('reminderComposed.applicationPort');
+    expect(main).toContain('.register(taskComposed.module)');
+    expect(main).toContain('.register(goalComposed.module)');
+    expect(main).not.toMatch(/create(Goal|Task|Reminder)PrismaModule/);
   });
 
   it('main.ts no longer names createAIApiModule/AIApiModuleContext or imports the ai/api seam', () => {
@@ -94,6 +103,20 @@ describe('AI API runtime composer surface', () => {
         expect(transportModule).not.toContain(pattern);
       }
     }
+  });
+
+  it('automation tool executor adapter is DB/module-free: no PrismaClient, create*PrismaModule or feature /server deep import', () => {
+    const executor = readFileSync(
+      resolve(apiDir, 'modules/ai/backend-automation-tool-executor.adapter.ts'),
+      'utf8',
+    );
+    expect(executor).not.toContain('PrismaClient');
+    expect(executor).not.toContain('createGoalPrismaModule');
+    expect(executor).not.toContain('createTaskPrismaModule');
+    expect(executor).not.toContain('createReminderPrismaModule');
+    expect(executor).not.toContain('PrismaTaskBindingReadPort');
+    expect(executor).not.toMatch(/@memoflow\/(goal|task|reminder)\/server/);
+    expect(executor).toContain('interface BackendAutomationToolExecutorDependencies');
   });
 
   it('AI transport module.ts keeps the twelve exact relative mounts in order', () => {

--- a/apps/api/src/runtime/compose-ai.ts
+++ b/apps/api/src/runtime/compose-ai.ts
@@ -77,7 +77,15 @@ export interface ComposeAIDependencies {
   readonly goalApplicationPort: GoalApplicationPort;
   /** The shared Task application port composed once by the API runtime (`composeTask(...).applicationPort`). API runtime 只组装一次并共享的 Task application port（`composeTask(...).applicationPort`）。 */
   readonly taskApplicationPort: TaskApplicationPort;
-  /** The shared Reminder application port composed once by the API runtime (`composeReminder(...).applicationPort`). API runtime 只组装一次并共享的 Reminder application port（`composeReminder(...).applicationPort`）。 */
+  /**
+   * The Reminder application port wired for the AI executor — the host's
+   * executor-facing port (`composeReminder(...).executorReminderPort`), whose
+   * `createTemplate` uses the frozen merge-base closure predicate rather than
+   * the module's account-active checker.
+   *
+   * 为 AI executor 预留的 Reminder application port（`composeReminder(...).executorReminderPort`），
+   * 其 `createTemplate` 使用冻结的 merge-base 闭户谓词，而非模块的账户激活检查器。
+   */
   readonly reminderApplicationPort: ReminderApplicationPort;
   /**
    * Optional ai-service runtime config override. When omitted or `undefined`,

--- a/apps/api/src/runtime/compose-ai.ts
+++ b/apps/api/src/runtime/compose-ai.ts
@@ -53,6 +53,9 @@ import {
   type AIApiModuleDef,
 } from '@memoflow/ai/api';
 import type { RepositoryApplicationPort } from '@memoflow/repository';
+import type { GoalApplicationPort } from '@memoflow/goal';
+import type { TaskApplicationPort } from '@memoflow/task';
+import type { ReminderApplicationPort } from '@memoflow/reminder';
 import { BackendAutomationToolExecutorAdapter } from '../modules/ai/backend-automation-tool-executor.adapter';
 import { ControlledAnalyticsReadAdapter } from '../modules/ai/controlled-analytics-read.adapter';
 import { RepositoryKnowledgeIndexStatusAdapter } from '../modules/ai/repository-knowledge-index-status.adapter';
@@ -70,6 +73,12 @@ export interface ComposeAIDependencies {
   readonly repositoryApiPort: RepositoryApplicationPort;
   /** Host-resolved repository storage base directory. 宿主导出的仓库存储基础目录。 */
   readonly repositoryStorageBaseDir: string;
+  /** The shared Goal application port composed once by the API runtime (`composeGoal(...).applicationPort`). API runtime 只组装一次并共享的 Goal application port（`composeGoal(...).applicationPort`）。 */
+  readonly goalApplicationPort: GoalApplicationPort;
+  /** The shared Task application port composed once by the API runtime (`composeTask(...).applicationPort`). API runtime 只组装一次并共享的 Task application port（`composeTask(...).applicationPort`）。 */
+  readonly taskApplicationPort: TaskApplicationPort;
+  /** The shared Reminder application port composed once by the API runtime (`composeReminder(...).applicationPort`). API runtime 只组装一次并共享的 Reminder application port（`composeReminder(...).applicationPort`）。 */
+  readonly reminderApplicationPort: ReminderApplicationPort;
   /**
    * Optional ai-service runtime config override. When omitted or `undefined`,
    * the composer reads the config lazily via `getAIServiceRuntimeConfig()`;
@@ -97,8 +106,10 @@ export interface ComposeAIDependencies {
  *    lazily when it is omitted; an explicit `null` disables the remote
  *    ai-service adapters without an environment read.
  * 3. Build the five app-local host adapters from db + repositoryApiPort +
- *    repositoryStorageBaseDir (knowledge-note persistence, knowledge source,
- *    knowledge index status, analytics read, automation tool executor).
+ *    repositoryStorageBaseDir + the injected Goal/Task/Reminder application
+ *    ports (knowledge-note persistence, knowledge source, knowledge index
+ *    status, analytics read, automation tool executor). The executor only
+ *    orchestrates the injected ports; it never constructs a feature module.
  * 4. Build the eight config-backed AIService adapters when a config exists
  *    (chat execution, goal planning, goal automation, knowledge ingestion /
  *    query / note generation, analytics query, agent runtime); always the
@@ -114,9 +125,11 @@ export interface ComposeAIDependencies {
  *    API-only 的 agent + LangGraph checkpoint pair）。
  * 2. 解析 ai-service runtime config：优先使用注入的覆盖；省略时延迟读取；
  *    显式 `null` 禁用远端 ai-service adapter 且不做环境读取。
- * 3. 用 db + repositoryApiPort + repositoryStorageBaseDir 构建五个 app-local
- *    宿主 adapter（knowledge-note persistence、knowledge source、knowledge
- *    index status、analytics read、automation tool executor）。
+ * 3. 用 db + repositoryApiPort + repositoryStorageBaseDir + 注入的
+ *    Goal/Task/Reminder application port 构建五个 app-local 宿主 adapter
+ *    （knowledge-note persistence、knowledge source、knowledge index status、
+ *    analytics read、automation tool executor）。executor 只编排注入的 port，
+ *    绝不构造 feature module。
  * 4. 存在 config 时构建八个 config-backed AIService adapter（chat execution、
  *    goal planning、goal automation、knowledge ingestion/query/note
  *    generation、analytics query、agent runtime）；evaluation-report 文件
@@ -166,10 +179,13 @@ export function composeAI(dependencies: ComposeAIDependencies): AIApiModuleDef {
     dependencies.repositoryApiPort,
   );
   const analyticsReadPort = new ControlledAnalyticsReadAdapter(dependencies.db);
-  const automationToolExecutorPort = new BackendAutomationToolExecutorAdapter(
-    dependencies.db,
-    dependencies.repositoryStorageBaseDir,
-  );
+  const automationToolExecutorPort = new BackendAutomationToolExecutorAdapter({
+    goalApplicationPort: dependencies.goalApplicationPort,
+    taskApplicationPort: dependencies.taskApplicationPort,
+    reminderApplicationPort: dependencies.reminderApplicationPort,
+    knowledgeSource: knowledgeSourcePort,
+    analyticsRead: analyticsReadPort,
+  });
 
   const chatExecutionPort = config ? new AIServiceChatExecutionAdapter(config) : undefined;
   const goalPlanningPort = config ? new AIServiceGoalPlanningAdapter(config) : undefined;

--- a/apps/api/src/runtime/compose-data-portability.spec.ts
+++ b/apps/api/src/runtime/compose-data-portability.spec.ts
@@ -27,6 +27,8 @@
 
 import type { Express, Router } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { PrismaClient } from '@memoflow/database';
 import type { DataPortabilityApiModuleContext } from '@memoflow/data-portability/api';
 
@@ -168,5 +170,18 @@ describe('composeDataPortability structural registration', () => {
 
     composed.module.destroy?.();
     expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('composeDataPortability layering boundary', () => {
+  it('imports Prisma ingredients from the public package surface only', () => {
+    const composer = readFileSync(resolve(__dirname, './compose-data-portability.ts'), 'utf8');
+
+    expect(composer).toContain("from '@memoflow/data-portability'");
+    expect(composer).toContain("from '@memoflow/data-portability/api'");
+    expect(composer).not.toMatch(/from '.*server\/application\/prisma-adapters'/);
+    expect(composer).not.toMatch(/from '.*server\/application\/import-store\/prisma-data-portability-import-store'/);
+    expect(composer).not.toContain('new PrismaDataPortabilityImportStore');
+    expect(composer).not.toContain('new PrismaFocusSessionAdapter');
   });
 });

--- a/apps/api/src/runtime/compose-goal.spec.ts
+++ b/apps/api/src/runtime/compose-goal.spec.ts
@@ -108,6 +108,8 @@ describe('composeGoal assembly order', () => {
       focusModeRepository: repoSet.focusModeRepository,
       goalWriteTransactionRunner: repoSet.goalWriteTransactionRunner,
       habitRepository: repoSet.habitRepository,
+      relationRepository: repoSet.relationRepository,
+      walletRepository: repoSet.walletRepository,
       taskBindingReadPort: fakeReadPort,
     });
     expect(moduleCall.runtimeContributions).toContain(

--- a/apps/api/src/runtime/compose-goal.spec.ts
+++ b/apps/api/src/runtime/compose-goal.spec.ts
@@ -124,12 +124,15 @@ describe('composeGoal assembly order', () => {
     expect(createGoalApiModule).toHaveBeenCalledWith({ instance });
   });
 
-  it('returns a module handle with name Goal plus register and destroy', () => {
-    const handle = composeGoal({ db: fakeDb, taskBindingReadPort: fakeReadPort });
+  it('returns a module handle with name Goal plus register and destroy, and the same instance.api as applicationPort', () => {
+    const composed = composeGoal({ db: fakeDb, taskBindingReadPort: fakeReadPort });
 
-    expect(handle).toMatchObject({ name: 'Goal' });
-    expect(typeof handle.register).toBe('function');
-    expect(typeof handle.destroy).toBe('function');
+    expect(composed.module).toMatchObject({ name: 'Goal' });
+    expect(typeof composed.module.register).toBe('function');
+    expect(typeof composed.module.destroy).toBe('function');
+
+    const instance = createGoalModule.mock.results[0].value;
+    expect(composed.applicationPort).toBe(instance.api);
   });
 });
 
@@ -154,7 +157,7 @@ describe('composeGoal structural registration', () => {
   });
 
   it('mounts /goals + /goal-folders on the router and starts the owned instance', () => {
-    const handle = composeGoal({ db: fakeDb, taskBindingReadPort: fakeReadPort });
+    const composed = composeGoal({ db: fakeDb, taskBindingReadPort: fakeReadPort });
 
     const instance = createGoalModule.mock.results[0].value;
     const startSpy = vi.spyOn(instance, 'start');
@@ -170,13 +173,13 @@ describe('composeGoal structural registration', () => {
       openApiRegistry: undefined,
     };
 
-    expect(() => handle.register(context)).not.toThrow();
+    expect(() => composed.module.register(context)).not.toThrow();
     expect(routerUse).toHaveBeenCalledWith('/goals', expect.anything());
     expect(routerUse).toHaveBeenCalledWith('/goal-folders', expect.anything());
 
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    handle.destroy?.();
+    composed.module.destroy?.();
     expect(disposeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/runtime/compose-goal.surface.spec.ts
+++ b/apps/api/src/runtime/compose-goal.surface.spec.ts
@@ -25,7 +25,7 @@ describe('goal API runtime composer surface', () => {
     expect(main).toMatch(
       /composeGoal\(\{\s*db: prisma,\s*taskBindingReadPort: new PrismaTaskBindingReadPort\(prisma\),?\s*\}/,
     );
-    expect(main).toContain('.register(goalApiModule)');
+    expect(main).toContain('.register(goalComposed.module)');
   });
 
   it('main.ts no longer references createGoalApiModule or the goal/api seam', () => {

--- a/apps/api/src/runtime/compose-goal.ts
+++ b/apps/api/src/runtime/compose-goal.ts
@@ -43,6 +43,7 @@ import {
   createGoalPrismaRepositories,
   createGoalRuntimeContribution,
   normalizeGoalRuntimeContributions,
+  type GoalApplicationPort,
   type GoalRuntimeContributionsInput,
 } from '@memoflow/goal';
 import {
@@ -62,6 +63,17 @@ export interface ComposeGoalDependencies {
   readonly taskBindingReadPort: GoalDependencyReadPort;
   /** Extra runtime contributions from the host (e.g. schedule projection). 宿主提供的额外运行时贡献。 */
   readonly runtimeContributions?: GoalRuntimeContributionsInput;
+}
+
+/**
+ * Composed goal surface for the API host.
+ * 目标在 API 宿主的组装结果。
+ */
+export interface ComposedGoal {
+  /** Already-bound IApiModule-compatible handle (transport + lifecycle only). 已绑定的 IApiModule 兼容 handle（只负责 transport 与生命周期）。 */
+  readonly module: GoalApiModuleDef;
+  /** The transport-neutral application port (`instance.api`) for sibling modules to orchestrate. 供兄弟模块编排的与传输无关 application port（`instance.api`）。 */
+  readonly applicationPort: GoalApplicationPort;
 }
 
 /**
@@ -94,11 +106,11 @@ export interface ComposeGoalDependencies {
  * 其 destroy() 会 dispose 所属实例。
  *
  * @param dependencies - ComposeGoalDependencies with the runtime Prisma client.
- * @returns GoalApiModuleDef — an already-bound IApiModule-compatible handle.
+ * @returns ComposedGoal — the bound module handle and the shared application port.
  */
 export function composeGoal(
   dependencies: ComposeGoalDependencies,
-): GoalApiModuleDef {
+): ComposedGoal {
   const {
     goalRepository,
     goalFolderRepository,
@@ -135,5 +147,8 @@ export function composeGoal(
     runtimeContributions,
   });
 
-  return createGoalApiModule({ instance });
+  return {
+    module: createGoalApiModule({ instance }),
+    applicationPort: instance.api,
+  };
 }

--- a/apps/api/src/runtime/compose-goal.ts
+++ b/apps/api/src/runtime/compose-goal.ts
@@ -106,6 +106,8 @@ export function composeGoal(
     focusModeRepository,
     goalWriteTransactionRunner,
     habitRepository,
+    relationRepository,
+    walletRepository,
   } = createGoalPrismaRepositories(dependencies.db);
 
   const listenerRuntime = createGoalEventListenersRuntime({
@@ -127,6 +129,8 @@ export function composeGoal(
     focusModeRepository,
     goalWriteTransactionRunner,
     habitRepository,
+    relationRepository,
+    walletRepository,
     taskBindingReadPort: dependencies.taskBindingReadPort,
     runtimeContributions,
   });

--- a/apps/api/src/runtime/compose-reminder.spec.ts
+++ b/apps/api/src/runtime/compose-reminder.spec.ts
@@ -54,7 +54,7 @@ vi.mock('@memoflow/reminder/api', async (importOriginal) => {
   };
 });
 
-import { composeReminder } from './compose-reminder';
+import { composeReminder, createExecutorClosureChecker } from './compose-reminder';
 import {
   createReminderModule,
   createReminderPrismaRepositories,
@@ -152,6 +152,7 @@ describe('composeReminder assembly order', () => {
 
     const instance = createReminderModule.mock.results[0].value;
     expect(composed.applicationPort).toBe(instance.api);
+    expect(composed.executorReminderPort).toBe(instance.api);
     expect(composed.repositories.reminderTemplateRepository).toBe(
       instance.reminderTemplateRepository,
     );
@@ -169,6 +170,108 @@ describe('composeReminder assembly order', () => {
 
     const moduleCall = createReminderModule.mock.calls[0][0];
     expect(moduleCall.closureChecker).toBe(hostClosureChecker);
+  });
+
+  it('exposes an executor reminder port with the frozen closure checker when provided', () => {
+    const executorClosureChecker = async (_identityId: string): Promise<boolean> => false;
+    const composed = composeReminder({ db: fakeDb, closureChecker, executorClosureChecker });
+
+    const instance = createReminderModule.mock.results[0].value;
+    // The module api keeps the module checker; the executor port swaps only
+    // createTemplate to the executor use case carrying the frozen predicate.
+    expect(composed.applicationPort).toBe(instance.api);
+    expect(composed.executorReminderPort).not.toBe(instance.api);
+    expect(composed.executorReminderPort.createTemplate).not.toBe(instance.api.createTemplate);
+    expect(composed.executorReminderPort.listTemplates).toBe(instance.api.listTemplates);
+  });
+});
+
+describe('createExecutorClosureChecker — merge-base frozen closure predicate', () => {
+  const cases: Array<{
+    name: string;
+    account: { status: string } | null;
+    opPhase: string | null;
+    expectedBlocked: boolean;
+  }> = [
+    { name: 'missing account blocks', account: null, opPhase: null, expectedBlocked: true },
+    {
+      name: 'Deactivated account blocks (no closure op)',
+      account: { status: 'Deactivated' },
+      opPhase: null,
+      expectedBlocked: true,
+    },
+    {
+      name: 'Closed account blocks (no closure op)',
+      account: { status: 'Closed' },
+      opPhase: null,
+      expectedBlocked: true,
+    },
+    {
+      name: 'active account without closure op allows',
+      account: { status: 'Active' },
+      opPhase: null,
+      expectedBlocked: false,
+    },
+    {
+      name: 'active account with requested closure op blocks',
+      account: { status: 'Active' },
+      opPhase: 'requested',
+      expectedBlocked: true,
+    },
+    {
+      name: 'active account with revoking closure op blocks',
+      account: { status: 'Active' },
+      opPhase: 'revoking',
+      expectedBlocked: true,
+    },
+    {
+      name: 'active account with closing closure op blocks',
+      account: { status: 'Active' },
+      opPhase: 'closing',
+      expectedBlocked: true,
+    },
+    {
+      name: 'active account with revoked closure op allows (revoked NOT in merge-base phase set)',
+      account: { status: 'Active' },
+      opPhase: 'revoked',
+      expectedBlocked: false,
+    },
+    {
+      name: 'active account with closed closure op allows (closed NOT in merge-base phase set)',
+      account: { status: 'Active' },
+      opPhase: 'closed',
+      expectedBlocked: false,
+    },
+  ];
+
+  it.each(cases)('$name', async ({ account, opPhase, expectedBlocked }) => {
+    const findUnique = vi.fn().mockResolvedValue(account);
+    const findFirst = vi.fn().mockResolvedValue(
+      opPhase !== null && ['requested', 'revoking', 'closing'].includes(opPhase)
+        ? { id: 'op-1', phase: opPhase }
+        : null,
+    );
+    const db = {
+      account: { findUnique },
+      accountClosureOperation: { findFirst },
+    } as unknown as PrismaClient;
+
+    const checker = createExecutorClosureChecker(db);
+    const isBlocked = await checker('identity-closure');
+
+    expect(isBlocked).toBe(expectedBlocked);
+
+    if (!account || account.status !== 'Active') {
+      // Account status alone decides — the closure table is never queried.
+      expect(findFirst).not.toHaveBeenCalled();
+    } else {
+      expect(findFirst).toHaveBeenCalledWith({
+        where: {
+          identityId: 'identity-closure',
+          phase: { in: ['requested', 'revoking', 'closing'] },
+        },
+      });
+    }
   });
 });
 

--- a/apps/api/src/runtime/compose-reminder.spec.ts
+++ b/apps/api/src/runtime/compose-reminder.spec.ts
@@ -143,7 +143,7 @@ describe('composeReminder assembly order', () => {
     });
   });
 
-  it('returns the module handle, repository view and both schedule sources', () => {
+  it('returns the module handle, application port, repository view and both schedule sources', () => {
     const composed = composeReminder({ db: fakeDb, closureChecker });
 
     expect(composed.module).toMatchObject({ name: 'Reminder' });
@@ -151,6 +151,7 @@ describe('composeReminder assembly order', () => {
     expect(typeof composed.module.destroy).toBe('function');
 
     const instance = createReminderModule.mock.results[0].value;
+    expect(composed.applicationPort).toBe(instance.api);
     expect(composed.repositories.reminderTemplateRepository).toBe(
       instance.reminderTemplateRepository,
     );
@@ -160,6 +161,14 @@ describe('composeReminder assembly order', () => {
     expect(composed.scheduleProjectionSource).toBe(
       createReminderScheduleProjectionSource.mock.results[0].value,
     );
+  });
+
+  it('injects the host closure checker into the reminder module (host-owned, not queried by the AI executor)', () => {
+    const hostClosureChecker = async (_identityId: string): Promise<boolean> => true;
+    composeReminder({ db: fakeDb, closureChecker: hostClosureChecker });
+
+    const moduleCall = createReminderModule.mock.calls[0][0];
+    expect(moduleCall.closureChecker).toBe(hostClosureChecker);
   });
 });
 

--- a/apps/api/src/runtime/compose-reminder.surface.spec.ts
+++ b/apps/api/src/runtime/compose-reminder.surface.spec.ts
@@ -23,9 +23,11 @@ describe('reminder API runtime composer surface', () => {
   const main = readFileSync(resolve(dir, 'main.ts'), 'utf8');
   const composer = readFileSync(resolve(dir, 'runtime/compose-reminder.ts'), 'utf8');
 
-  it('main.ts composes reminder via composeReminder({ db: prisma, closureChecker })', () => {
+  it('main.ts composes reminder via composeReminder({ db: prisma, closureChecker, executorClosureChecker })', () => {
     expect(main).toContain("from './runtime/compose-reminder'");
-    expect(main).toMatch(/composeReminder\(\{\s*db: prisma,\s*closureChecker: accountActiveChecker,?\s*\}/);
+    expect(main).toMatch(
+      /composeReminder\(\{\s*db: prisma,\s*closureChecker: accountActiveChecker,\s*executorClosureChecker,?\s*\}/,
+    );
     expect(main).toContain('.register(reminderComposed.module)');
   });
 

--- a/apps/api/src/runtime/compose-reminder.surface.spec.ts
+++ b/apps/api/src/runtime/compose-reminder.surface.spec.ts
@@ -26,7 +26,7 @@ describe('reminder API runtime composer surface', () => {
   it('main.ts composes reminder via composeReminder({ db: prisma, closureChecker })', () => {
     expect(main).toContain("from './runtime/compose-reminder'");
     expect(main).toMatch(/composeReminder\(\{\s*db: prisma,\s*closureChecker: accountActiveChecker,?\s*\}/);
-    expect(main).toContain('.register(reminderApiModule.module)');
+    expect(main).toContain('.register(reminderComposed.module)');
   });
 
   it('main.ts no longer references createReminderApiModule or the reminder/api seam', () => {
@@ -38,8 +38,8 @@ describe('reminder API runtime composer surface', () => {
     expect(main).not.toMatch(/createReminderPrismaSchedule(Execution|Projection)Source/);
     expect(main).not.toContain("from '@memoflow/reminder/schedule-execution'");
     expect(main).not.toContain("from '@memoflow/reminder/schedule-projection'");
-    expect(main).toContain('reminderApiModule.scheduleExecutionSource');
-    expect(main).toContain('reminderApiModule.scheduleProjectionSource');
+    expect(main).toContain('reminderComposed.scheduleExecutionSource');
+    expect(main).toContain('reminderComposed.scheduleProjectionSource');
   });
 
   it('composer only touches the narrow seams (no deep server import)', () => {

--- a/apps/api/src/runtime/compose-reminder.ts
+++ b/apps/api/src/runtime/compose-reminder.ts
@@ -52,6 +52,7 @@ import {
   createReminderTriggerCronRuntime,
   createReminderScheduleExecutionSource,
   createReminderScheduleProjectionSource,
+  createReminderUseCases,
   type ReminderModuleRuntimeContribution,
   type ReminderRuntimeContributionsInput,
   type IReminderTemplateRepository,
@@ -73,8 +74,63 @@ export interface ComposeReminderDependencies {
   readonly db: PrismaClient;
   /** Host-owned account-active checker (fail-closed for closed accounts). 宿主持有的账户激活检查器（对已关闭账户 fail-closed）。 */
   readonly closureChecker: (identityId: string) => Promise<boolean>;
+  /**
+   * Optional executor-visible closure checker. When provided, the composed
+   * result exposes `executorReminderPort`, whose `createTemplate` uses this
+   * frozen merge-base predicate (account status + requested|revoking|closing
+   * phases) instead of the module's account-active checker. The AI executor
+   * path MUST receive this predicate, not the module checker.
+   *
+   * 可选的 executor 可见闭户检查器。提供后，组装结果暴露 `executorReminderPort`，
+   * 其 `createTemplate` 使用该冻结的 merge-base 谓词（账户状态 +
+   * requested|revoking|closing 阶段），而非模块的账户激活检查器。AI executor
+   * 路径必须收到该谓词，而不是模块检查器。
+   */
+  readonly executorClosureChecker?: (identityId: string) => Promise<boolean>;
   /** Extra runtime contributions from the host. 宿主提供的额外运行时贡献。 */
   readonly runtimeContributions?: ReminderRuntimeContributionsInput;
+}
+
+/**
+ * Build the host-owned executor closure predicate frozen from merge-base.
+ * 构建从 merge-base 冻结的、宿主持有的 executor 闭户谓词。
+ *
+ * Blocks when the account row is missing / `Deactivated` / `Closed`, or when an
+ * active account-closure operation exists in phases `requested` | `revoking` |
+ * `closing`. A `revoked` / `closed` operation alone does NOT block, and the
+ * account status is always inspected first — exactly the predicate the
+ * merge-base executor passed to its own reminder module. It is restored here
+ * so the AI executor path keeps the pre-RefArch behavior while sharing the
+ * single composed reminder instance.
+ *
+ * 账户缺失 / `Deactivated` / `Closed` 时阻断；或存在处于 `requested` | `revoking`
+ * | `closing` 阶段的有效闭户操作时阻断。单独的 `revoked` / `closed` 操作不阻断，
+ * 且始终先检查账户状态——这正是 merge-base 时代 executor 传给其自建提醒模块的
+ * 谓词。在此恢复，使 AI executor 路径在共享单一组合提醒实例的同时保持
+ * RefArch 之前的既有行为。
+ *
+ * @param db - API host-owned Prisma client. API 宿主持有的 Prisma client。
+ * @returns An async predicate returning true to block new reminder work. 返回 true 表示阻断新提醒工作的异步谓词。
+ */
+export function createExecutorClosureChecker(
+  db: PrismaClient,
+): (identityId: string) => Promise<boolean> {
+  return async (identityId: string): Promise<boolean> => {
+    const account = await db.account.findUnique({
+      where: { id: identityId },
+      select: { status: true },
+    });
+    if (!account || account.status === 'Deactivated' || account.status === 'Closed') {
+      return true;
+    }
+    const pendingClosure = await db.accountClosureOperation.findFirst({
+      where: {
+        identityId,
+        phase: { in: ['requested', 'revoking', 'closing'] },
+      },
+    });
+    return pendingClosure !== null;
+  };
 }
 
 /**
@@ -86,6 +142,15 @@ export interface ComposedReminder {
   readonly module: ReminderApiModuleDef;
   /** The transport-neutral application port (`instance.api`) for sibling modules to orchestrate. 供兄弟模块编排的与传输无关 application port（`instance.api`）。 */
   readonly applicationPort: ReminderApplicationPort;
+  /**
+   * The application port the AI executor must consume: its `createTemplate`
+   * uses the frozen merge-base closure predicate when `executorClosureChecker`
+   * is provided, otherwise it is the same object as `applicationPort`.
+   * 供 AI executor 消费的 application port：提供 `executorClosureChecker` 时其
+   * `createTemplate` 使用冻结的 merge-base 闭户谓词，否则与 `applicationPort`
+   * 是同一对象。
+   */
+  readonly executorReminderPort: ReminderApplicationPort;
   /** Repository views exposed to sibling modules in the same host. 暴露给同一宿主内兄弟模块的仓储视图。 */
   readonly repositories: { readonly reminderTemplateRepository: IReminderTemplateRepository };
   /** Schedule execution source built from the SAME repository set. 从同一仓储集合构建的 schedule execution source。 */
@@ -182,9 +247,39 @@ export function composeReminder(
     reminderTemplateRepository,
   });
 
+  // Executor-visible closure path: when the host supplies the frozen
+  // merge-base predicate, expose a port whose createTemplate runs through a
+  // use case carrying that predicate (sharing the SAME repositories as the
+  // single module instance). All other methods delegate to instance.api.
+  // Without an executor checker the executor port is simply the module api.
+  //
+  // Executor 可见的闭户路径：宿主提供冻结的 merge-base 谓词时，暴露一个
+  // createTemplate 走该谓词 use case 的 port（与单一模块实例共享同一套仓储）。
+  // 其余方法全部委托给 instance.api；未提供 executor 检查器时该 port 即模块 api。
+  const executorUseCases =
+    dependencies.executorClosureChecker === undefined
+      ? null
+      : createReminderUseCases({
+          reminderTemplateRepository: repositories.reminderTemplateRepository,
+          reminderGroupRepository: repositories.reminderGroupRepository,
+          reminderResponseRepository: repositories.reminderResponseRepository,
+          userReminderPreferenceRepository: repositories.userReminderPreferenceRepository,
+          closureChecker: dependencies.executorClosureChecker,
+        });
+
+  const executorReminderPort: ReminderApplicationPort =
+    executorUseCases === null
+      ? instance.api
+      : {
+          ...instance.api,
+          createTemplate: (data, ctx) =>
+            executorUseCases.createReminderTemplate.execute(data, ctx),
+        };
+
   return {
     module: createReminderApiModule({ instance }),
     applicationPort: instance.api,
+    executorReminderPort,
     repositories: { reminderTemplateRepository },
     scheduleExecutionSource,
     scheduleProjectionSource,

--- a/apps/api/src/runtime/compose-reminder.ts
+++ b/apps/api/src/runtime/compose-reminder.ts
@@ -62,6 +62,7 @@ import {
 } from '@memoflow/reminder/api';
 import type { ReminderScheduleExecutionSource } from '@memoflow/reminder';
 import type { ReminderScheduleProjectionSource } from '@memoflow/reminder';
+import type { ReminderApplicationPort } from '@memoflow/reminder';
 
 /**
  * Dependencies the reminder composer needs from the API host runtime.
@@ -83,6 +84,8 @@ export interface ComposeReminderDependencies {
 export interface ComposedReminder {
   /** Already-bound IApiModule-compatible handle. 已绑定的 IApiModule 兼容 handle。 */
   readonly module: ReminderApiModuleDef;
+  /** The transport-neutral application port (`instance.api`) for sibling modules to orchestrate. 供兄弟模块编排的与传输无关 application port（`instance.api`）。 */
+  readonly applicationPort: ReminderApplicationPort;
   /** Repository views exposed to sibling modules in the same host. 暴露给同一宿主内兄弟模块的仓储视图。 */
   readonly repositories: { readonly reminderTemplateRepository: IReminderTemplateRepository };
   /** Schedule execution source built from the SAME repository set. 从同一仓储集合构建的 schedule execution source。 */
@@ -142,7 +145,7 @@ function normalizeRuntimeContributions(
  * （Reminder register 是异步的并会被 await），其 destroy() 会 dispose 所属实例。
  *
  * @param dependencies - ComposeReminderDependencies with the runtime Prisma client.
- * @returns ComposedReminder — the bound module handle, repository view and schedule sources.
+ * @returns ComposedReminder — the bound module handle, application port, repository view and schedule sources.
  */
 export function composeReminder(
   dependencies: ComposeReminderDependencies,
@@ -181,6 +184,7 @@ export function composeReminder(
 
   return {
     module: createReminderApiModule({ instance }),
+    applicationPort: instance.api,
     repositories: { reminderTemplateRepository },
     scheduleExecutionSource,
     scheduleProjectionSource,

--- a/apps/api/src/runtime/compose-task.spec.ts
+++ b/apps/api/src/runtime/compose-task.spec.ts
@@ -164,12 +164,15 @@ describe('composeTask assembly without goalProgressHandler', () => {
     expect(createTaskApiModule).toHaveBeenCalledWith({ instance });
   });
 
-  it('returns a module handle with name Task plus register and destroy', () => {
-    const handle = composeTask({ db: fakeDb });
+  it('returns a module handle with name Task plus register and destroy, and the same instance.api as applicationPort', () => {
+    const composed = composeTask({ db: fakeDb });
 
-    expect(handle).toMatchObject({ name: 'Task' });
-    expect(typeof handle.register).toBe('function');
-    expect(typeof handle.destroy).toBe('function');
+    expect(composed.module).toMatchObject({ name: 'Task' });
+    expect(typeof composed.module.register).toBe('function');
+    expect(typeof composed.module.destroy).toBe('function');
+
+    const instance = createTaskModule.mock.results[0].value;
+    expect(composed.applicationPort).toBe(instance.api);
   });
 });
 
@@ -195,7 +198,7 @@ describe('composeTask structural registration', () => {
   });
 
   it('mounts task routes on the router and starts the owned instance', async () => {
-    const handle = composeTask({ db: fakeDb });
+    const composed = composeTask({ db: fakeDb });
 
     const instance = createTaskModule.mock.results[0].value;
     const startSpy = vi.spyOn(instance, 'start');
@@ -211,11 +214,11 @@ describe('composeTask structural registration', () => {
       openApiRegistry: undefined,
     };
 
-    await expect(handle.register(context)).resolves.toBeUndefined();
+    await expect(composed.module.register(context)).resolves.toBeUndefined();
     expect(routerUse).toHaveBeenCalledWith(expect.anything());
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    await handle.destroy?.();
+    await composed.module.destroy?.();
     expect(disposeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/runtime/compose-task.surface.spec.ts
+++ b/apps/api/src/runtime/compose-task.surface.spec.ts
@@ -23,7 +23,7 @@ describe('task API runtime composer surface', () => {
   it('main.ts composes task via composeTask({ db: prisma, runtimeContributions, goalProgressHandler })', () => {
     expect(main).toContain("from './runtime/compose-task'");
     expect(main).toMatch(/composeTask\(\{\s*db: prisma,/);
-    expect(main).toContain('.register(taskApiModule)');
+    expect(main).toContain('.register(taskComposed.module)');
     expect(main).toContain('goalProgressHandler: createGoalTaskProgressPrismaHandler(prisma)');
   });
 

--- a/apps/api/src/runtime/compose-task.ts
+++ b/apps/api/src/runtime/compose-task.ts
@@ -55,6 +55,7 @@ import {
   createTaskPrismaRepositories,
   createTaskRuntimeContribution,
   normalizeTaskRuntimeContributions,
+  type TaskApplicationPort,
   type TaskRuntimeContributionsInput,
 } from '@memoflow/task';
 import {
@@ -74,6 +75,17 @@ export interface ComposeTaskDependencies {
   readonly runtimeContributions?: TaskRuntimeContributionsInput;
   /** Goal's durable Task→Goal progress handler; enables the outbox runtime when present. 目标侧持久 Task→Goal 进度处理器；提供时启用 outbox runtime。 */
   readonly goalProgressHandler?: TaskGoalProgressHandler;
+}
+
+/**
+ * Composed task surface for the API host.
+ * 任务在 API 宿主的组装结果。
+ */
+export interface ComposedTask {
+  /** Already-bound IApiModule-compatible handle (transport + lifecycle only). 已绑定的 IApiModule 兼容 handle（只负责 transport 与生命周期）。 */
+  readonly module: TaskApiModuleDef;
+  /** The transport-neutral application port (`instance.api`) for sibling modules to orchestrate. 供兄弟模块编排的与传输无关 application port（`instance.api`）。 */
+  readonly applicationPort: TaskApplicationPort;
 }
 
 /**
@@ -112,11 +124,11 @@ export interface ComposeTaskDependencies {
  * （Task register 是异步的并会被 await），其 destroy() 会 dispose 所属实例。
  *
  * @param dependencies - ComposeTaskDependencies with the runtime Prisma client.
- * @returns TaskApiModuleDef — an already-bound IApiModule-compatible handle.
+ * @returns ComposedTask — the bound module handle and the shared application port.
  */
 export function composeTask(
   dependencies: ComposeTaskDependencies,
-): TaskApiModuleDef {
+): ComposedTask {
   const {
     taskTemplateRepository,
     taskInstanceRepository,
@@ -147,5 +159,8 @@ export function composeTask(
     runtimeContributions,
   });
 
-  return createTaskApiModule({ instance });
+  return {
+    module: createTaskApiModule({ instance }),
+    applicationPort: instance.api,
+  };
 }

--- a/docs/plan/active/2026-08-15-refarch-phase1-p0-layering.md
+++ b/docs/plan/active/2026-08-15-refarch-phase1-p0-layering.md
@@ -1,0 +1,278 @@
+---
+tags:
+  - plan
+  - active
+  - architecture
+  - reference-architecture
+  - layering
+  - p0
+description: Reference architecture phase 1: remove the remaining Application-to-Prisma layering inversions / 参考架构阶段 1：修正剩余 Application 到 Prisma 的层反转
+created: 2026-08-15T00:00:00Z
+updated: 2026-08-15T00:00:00Z
+---
+
+# Reference Architecture Phase 1: P0 Layering Inversions / 参考架构阶段 1：P0 层反转
+
+## 文档状态
+
+- **状态**：Active，read-only implementation plan；本文只描述实施，不在本轮修改生产代码、测试或既有文档。
+- **基线**：以当前 `main` 工作树的代码、配置和测试为真值。阶段 0 已建立基线，阶段 3 的 host composition root externalization 已完成；当前 API 组合入口使用 `apps/api/src/runtime/compose-*.ts`。
+- **依据**：
+  - `docs/analysis/2026-08-13-architecture-refactor-review.md`：§1 items 3/7、§3.3、§3.9、§4 P0/P1 candidate rows、§6 阶段 1。
+  - `docs/analysis/reference-architecture-source-notes.md`：Ardan consumer-owned Port 与 runtime composition root、Memos transport/service separation 的源码核验。
+  - 当前 Goal、Data Portability、API runtime、governance audit 实现与现有 surface/unit/integration tests。
+
+## 1. 目标与非目标
+
+### 1.1 目标
+
+本阶段只处理评审 §6「阶段 1：修正明确层反转」的最高价值切片，拆为四个可独立审查、可回滚的 PR steps：
+
+1. **Goal relation/wallet（P0）**：`IRelationRepository` 与 `IWalletRepository` 成为 domain-owned Port；Application use case 只依赖 Port；Prisma mapper/repository 移到 `server/infrastructure/adapters/prisma`；通过 Goal module/composer 注入 adapter。
+2. **Data Portability adapters（P1，纳入阶段 1）**：Prisma export/read adapters 与 Prisma import store 从 `server/application` 归位到 `server/infrastructure`；Application 保留 import/read Port、use case 与 `DataPortabilityApplicationPort`。
+3. **AI backend executor（P0）**：API runtime 通过 `compose-goal.ts`、`compose-task.ts`、`compose-reminder.ts` 取得已组装的 Goal/Task/Reminder Application Ports；`BackendAutomationToolExecutorAdapter` 只编排这些 Port 及已有 read Port，不再创建 Prisma module、读取 Prisma 或拥有 module lifecycle。
+4. **Governance（P0 gate）**：完成 steps 1–2 后，启用 `server/domain/**` 与 `server/application/**` 禁止生产代码 import `@memoflow/database` 的 audit rule，并将治理检查作为后续 PR 的硬门禁。
+
+### 1.2 非目标
+
+- 不改变 `ExecutionContext` 或新增 request/execution context 字段。
+- 不做 HTTP/IPC parity 重构；只保留现有共享 Application Port 与 transport 行为。
+- 不引入 Query Cache、Pinia/server-state 迁移或新的前端状态架构。
+- 不改变 AI executor 的 action loop、action ordering、dependency skip/failure policy、receipt 文本或事件触发语义；本阶段只替换依赖装配。
+- 不改变数据库 schema、迁移、索引、Prisma transaction isolation、导入导出 payload、API/IPC 路由、认证或 OpenAPI surface。
+- 不把 Goal relation/wallet 抽成新的 package，不改 ModuleManifest 的业务命令名称；只修正 Port ownership 与 adapter placement。
+- 不处理其余跨模块 runtime adapter、request trace pipeline、Transport parity、cache 或后续阶段 2–6 项。
+
+## 2. 当前状态盘点
+
+### 2.1 Gap table
+
+| 优先级 | 反转 / 现状                                                     | 证据（file:line）                                                                                                                                                                                                                            | 当前问题                                                                                                      | 阶段 1 目标                                                                                                                                                                                     |
+| ------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P0     | Goal relation use case 同文件包含 Port 与 Prisma implementation | `packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts:9-11` import `PrismaClient`；`:32-44` 定义 `IRelationRepository`；`:46-112` 定义 `PrismaRelationRepository` 与 inline mapper                                  | Application 直接依赖 DB；Port 不能由第二种 persistence lane 复用；mapper 归属不清                             | `domain/repositories/i-relation-repository.ts` 只放 Port/DTO/type；`infrastructure/adapters/prisma/{relation-prisma.repository.ts,mappers/prisma-relation.mapper.ts}` 实现 Prisma lane          |
+| P0     | Goal wallet use case 同文件包含 Port 与 Prisma implementation   | `packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts:8-10` import `PrismaClient`；`:30-48` 定义 `IWalletRepository`；`:50-156` 定义 Prisma repository；`:97-133` 内含 `$transaction`                                 | Application 持有 transaction、Decimal/Date row conversion；容易迁移时改变精度、错误和原子性                   | `domain/repositories/i-wallet-repository.ts` 只放 Port/DTO/type；`infrastructure/adapters/prisma/{wallet-prisma.repository.ts,mappers/prisma-wallet.mapper.ts}` 保留全部 DB 语义                |
+| P0     | Goal module wiring 未拥有 relation/wallet repository dependency | `packages/goal/src/server/infrastructure/goal.module.ts:42-96` 的 `GoalModuleDependencies` 只有核心 Goal/Focus/Habit ports；`packages/goal/src/server/infrastructure/module-manifest.ts:8-20` 只接收 use case 类型                           | Prisma repository 虽存在，却没有明确的 deep-module injection seam                                             | 在 `GoalRepositorySet`/`GoalModuleDependencies` 增加可选 relation/wallet Port，Prisma composer 注入，PowerSync lane 不提供；不扩大 `GoalApplicationPort` 或路由 surface                         |
+| P1     | Data Portability Prisma export/read adapters 位于 Application   | `packages/data-portability/src/server/application/prisma-adapters.ts:8-22,24-108` import `PrismaClient` 并实现各 read Port；`packages/data-portability/src/server/infrastructure/prisma.ts:1-18` 反向 import 这些 Application 文件           | Application 目录包含 persistence implementation，治理无法把 Application 视为纯 Port/use case                  | 移到 `server/infrastructure/adapters/prisma-adapters.ts`；`infrastructure/prisma.ts` 只从 infrastructure adapter 组装；`data-portability.dependencies.ts` 与 use cases 不变                     |
+| P1     | Data Portability Prisma import store 位于 Application           | `packages/data-portability/src/server/application/import-store/prisma-data-portability-import-store.ts:8,42-44,218-225` import Prisma 并包装 `$transaction`；Application index `:13-16` 还从该目录导出 Port 类型                             | transaction implementation 泄漏到 Application；PowerSync 已位于 Infrastructure，目录不对称                    | 移到 `server/infrastructure/import-store/prisma-data-portability-import-store.ts`；Application `import-store/index.ts` 只导出 `DataPortabilityImportStore`/`DataPortabilityImportTx` 与输入类型 |
+| P0     | AI backend executor 自己创建三套 feature Prisma module          | `apps/api/src/modules/ai/backend-automation-tool-executor.adapter.ts:23-28` import DB、`createGoalPrismaModule`、`createTaskPrismaModule`、`createReminderPrismaModule`；`:50-82` 构造 module、closure checker、knowledge/analytics adapters | executor 同时拥有跨模块 composition、DB 依赖和 action orchestration；重复 module instance/lifecycle，难以单测 | `apps/api/src/runtime/compose-ai.ts` 接收 Goal/Task/Reminder Application Ports；executor constructor 只接 Port/read adapters；action loop `:84-384` 保持原样                                    |
+| P0     | Governance rule 尚未禁止 Application/Domain → database          | `tools/governance/package-internal-boundary-audit.mjs:25-65` 只检查 package 内层路径；Application forbidden list `:39-47` 没有 external `@memoflow/database`；当前生产 import inventory 正好是上述 Goal 两个文件与 Data Portability 两个文件 | 迁移前无法 fail closed；未来新增反转不会被治理捕获                                                            | steps 1–2 清空 production inventory 后，在同一 audit 增加 exact external-specifier rule；tests 仍按现有 `:166-170` 排除，Infrastructure 可正常 import DB                                        |
+
+### 2.2 现有 host composition 约束
+
+- `apps/api/src/runtime/compose-goal.ts:39-134`、`compose-task.ts:51-150`、`compose-reminder.ts:48-187` 已由 API runtime 选择 Prisma adapter 并创建 instance；Goal/Task composer 当前返回 API module handle，Reminder 已返回 `{ module, repositories, schedule... }`。
+- `packages/goal/src/api/module.ts:13-31,101-130`、`packages/task/src/api/module.ts:13-30,105-134`、`packages/reminder/src/api/module.ts` 都是 instance-bound transport factories；它们只能消费 `instance.api`、挂载路由并管理 lifecycle，不应重新创建 module。
+- `GoalApplicationPort`、`TaskApplicationPort`、`ReminderApplicationPort` 已分别定义在 `packages/goal/src/server/application/goal.application.port.ts:30-198`、`packages/task/src/server/application/task.application.port.ts:36-80`、`packages/reminder/src/server/application/reminder.application.port.ts:25-103`。这些接口是 AI executor 的目标依赖，不新增业务方法。
+- `apps/api/src/main.ts:206-220` 当前先组装 Task、AI，之后才组装 Goal；实现时可以提前创建 Goal composed object 以提供 port，但注册顺序仍保持 `AI` 在 `Goal` 之前（`main.ts:221-233`），避免改变 bootstrap 行为。
+- `packages/data-portability/src/server/infrastructure/prisma.ts:24-27,64-116` 已是 host-facing factory seam；移动实现文件不应改变 `compose-data-portability.ts:76-125` 的装配顺序。
+
+## 3. 契约冻结（实现前必须先签字）
+
+### 3.1 Goal relation/wallet Port
+
+在 Step 1 开始前冻结以下 Port shape；新文件必须提供中英文 JSDoc，Application 只能 type-import：
+
+```ts
+// packages/goal/src/server/domain/repositories/i-relation-repository.ts
+export interface IRelationRepository {
+  create(input: {
+    identityId: string;
+    subject: SubjectRef;
+    relationType: RelationType;
+    object: SubjectRef;
+  }): Promise<RelationDTO>;
+  deleteByIdentityId(identityId: string, id: string): Promise<void>;
+  findBySubject(identityId: string, subject: SubjectRef): Promise<RelationDTO[]>;
+  findByObject(identityId: string, object: SubjectRef): Promise<RelationDTO[]>;
+}
+
+// packages/goal/src/server/domain/repositories/i-wallet-repository.ts
+export interface IWalletRepository {
+  createAccount(input: {
+    identityId: string;
+    name: string;
+    currency?: string;
+  }): Promise<WalletAccountDTO>;
+  listAccounts(identityId: string): Promise<WalletAccountDTO[]>;
+  recordTransaction(input: {
+    identityId: string;
+    accountId: string;
+    type: 'income' | 'expense' | 'transfer';
+    amount: string;
+    category?: string | null;
+    note?: string | null;
+    goalId?: string | null;
+    occurredAt?: number;
+  }): Promise<WalletTransactionDTO>;
+  listTransactions(identityId: string, limit?: number): Promise<WalletTransactionDTO[]>;
+}
+```
+
+- `SubjectTypes`, `RelationTypes`, `SubjectRef`, `RelationDTO`, `WalletAccountDTO` 与 `WalletTransactionDTO` 的 exported names、literal unions、field optionality、timestamp unit 和 return `Promise` 均冻结；只移动 ownership，不改调用方签名。
+- `IRelationRepository` 的 unique-error interpretation 继续在 `CreateRelationUseCase` 完成：message 含 `Unique` 仍返回 `CONFLICT / Relation already exists`；其它异常继续 throw。
+- `IWalletRepository` 的 amount validation 与 `ACCOUNT_NOT_FOUND → NOT_FOUND` 映射继续在 use case 完成；repository 仍可抛出原始 `ACCOUNT_NOT_FOUND`。
+
+### 3.2 Goal Prisma adapter semantics
+
+- `relation-prisma.repository.ts` 只负责 Prisma calls；mapper 负责 `createdAt: Date → number (ms)` 与 persisted string enums → `SubjectType`/`RelationType`，`findBySubject`/`findByObject` 仍按 `createdAt ASC`，delete 仍是 `{ id, identityId }` scoped `deleteMany`。
+- `wallet-prisma.repository.ts` 保留默认 currency `CNY`、所有 Decimal 字段 `.toString()`、所有 Date 字段 `.getTime()`；不得改成 `number` 或浮点 arithmetic。
+- `recordTransaction` 必须保持一个 `db.$transaction(async tx => ...)`：先按 `{ id: accountId, identityId }` 查账户，缺失抛 `ACCOUNT_NOT_FOUND`，再按当前 `income/expense/transfer` delta 规则更新余额并创建 transaction。Step 1 不修正或重新解释既有 `transfer` 业务语义。
+- `createGoalPrismaRepositories`/`createGoalPrismaModule` 是唯一 API Prisma wiring；relation/wallet repository 在此创建并注入 `createGoalModule`。PowerSync repository set 不伪造实现，保持 optional absent；`GoalApplicationPort` 不增加 relation/wallet 方法。
+
+### 3.3 Data Portability contract
+
+- `DataPortabilityImportStore.transaction(fn)` 与 `DataPortabilityImportTx` 的方法和 input types 原样保留；`PrismaDataPortabilityImportStore` 继续把整个 import callback 包在一个 `prisma.$transaction` 内（当前 `:221-225`）。
+- `DataPortabilityDependencies`、`DataPortabilityApplicationPort.exportUserData/importUserData`、各 importer/projection 的顺序、filters、upsert/create 行为均冻结；只改 import path 与目录。
+- `composeDataPortability` 的 wire order 仍是 `db → export dependencies → import store → disclosure port → module instance → API module`；不得因文件移动把 DB 读取回 Application。
+
+### 3.4 AI Application Port and executor contract
+
+- `GoalApplicationPort`、`TaskApplicationPort`、`ReminderApplicationPort` 使用现有 package root type exports；不新增方法、不改变 `Result`、`ExecutionContext`、identity 参数位置或 payload shape。
+- `composeGoal`、`composeTask`、`composeReminder` 的 host-facing return shape 冻结为包含 `module` 与 `applicationPort: instance.api` 的 composed object；Reminder 的现有 `repositories`/schedule source properties 保留。新增 app-runtime exported interfaces 必须有中英文 JSDoc。
+- `ComposeAIDependencies` 增加必需的 `goalApplicationPort`、`taskApplicationPort`、`reminderApplicationPort`；`composeAI` 用它们构造 executor。`db` 仍只供 API runtime 自己的 AI/knowledge/analytics infrastructure 使用。
+- `BackendAutomationToolExecutorAdapter` constructor 冻结为依赖对象（Goal/Task/Reminder application ports + 已有 `IKnowledgeSourcePort` + `IAnalyticsReadPort`）；类不得 import `PrismaClient`、`create*PrismaModule` 或 `PrismaTaskBindingReadPort`。
+- action loop 的 `for` 顺序、`createdGoalId`/key-result dependency maps、skip/fail receipts、logger fields、`continue` 分支和最终 actions array 必须逐项保持。Executor 只替换 `this.goalModule.api`/`this.taskModule.api`/`this.reminderModule.api` 为冻结的 ports；不在同一 PR 拆分 action executor。
+
+## 4. 分步实施（PR-able steps）
+
+### Step 1 — Goal relation/wallet repository migration（P0）
+
+**目标**：Application 只持有 Port/use case；Prisma implementation、mapper、transaction 归 Infrastructure；Goal module 的 Prisma wiring 明确注入 adapter。
+
+**精确文件清单**
+
+- 新增 `packages/goal/src/server/domain/repositories/i-relation-repository.ts`、`i-wallet-repository.ts`；更新 `domain/repositories/index.ts`、`server/domain/index.ts`（若该 barrel 需要转出新 Port）。
+- 修改 `packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts`：删除 `PrismaClient`、`PrismaRelationRepository`、inline `toDTO`；从 domain repository barrel type-import `SubjectRef`、`RelationDTO`、`SubjectTypes`、`RelationTypes`、`IRelationRepository`，保留 validation、error code、use case method signatures。
+- 修改 `packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts`：删除 `PrismaClient`、`PrismaWalletRepository`；从 domain repository barrel type-import DTO/Port，保留所有 validation/error handling。
+- 新增 `packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.ts`、`wallet-prisma.repository.ts`；新增 `adapters/prisma/mappers/prisma-relation.mapper.ts`、`prisma-wallet.mapper.ts`。mapper/repository 的 public exports 添加中英文 JSDoc，并由 `adapters/prisma/index.ts`/`mappers/index.ts` 内部导出。
+- 修改 `packages/goal/src/server/infrastructure/prisma.ts`：`GoalRepositorySet` 增加可选 `relationRepository?: IRelationRepository`、`walletRepository?: IWalletRepository`；`createGoalPrismaRepositories(db)` 创建并返回 Prisma adapter；`createGoalPrismaModule` 把它们传入 `createGoalModule`。`createGoalPowerSyncRepositories` 保持缺省，不创建假 adapter。
+- 修改 `packages/goal/src/server/infrastructure/goal.module.ts`：`GoalModuleDependencies` 接收可选 relation/wallet Port；`createGoalUseCases` 条件性组装 relation/list 与 wallet use cases；`GoalModuleUseCases` 保留可选分支供现有 ModuleManifest/低层测试使用；`GoalApplicationPort` 不变。
+- 修改 `packages/goal/src/server/infrastructure/module-manifest.ts`、相关 server/root barrels 与 `packages/goal/src/index.ts`：更新 Port/use-case import path；只公开 Port/type 或既有 manifest seam，不公开 Prisma concrete class。所有新增 public type/function JSDoc 中英双语。
+- 修改 `apps/api/src/runtime/compose-goal.ts`：透传 repository set 的 relation/wallet fields；不改变 module registration 路由或 listener/runtime contribution 顺序。
+
+**测试与门禁**
+
+- 更新 `packages/goal/src/server/application/use-cases/commands/__tests__/relation.use-cases.spec.ts`、`wallet.use-cases.spec.ts`：mock 从 domain Port import，保留 validation、unique conflict、reverse lookup、positive amount、account-not-found mapping assertions。
+- 新增 `packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.spec.ts` 与 `prisma-wallet.mapper.spec.ts`：锁住 enum/timestamp/Decimal/string conversion。
+- 新增 `packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.integration.test.ts`、`wallet-prisma.repository.integration.test.ts`（使用现有 Goal integration database harness）：锁住 identity scoping、ASC/DESC ordering、唯一冲突、wallet 单 transaction 原子性与 Decimal 精度。
+- 更新 `packages/goal/src/server/infrastructure/__tests__/goal-repositories.surface.spec.ts`、`apps/api/src/runtime/compose-goal.spec.ts`：断言 Prisma composer/module 接收到 relation/wallet Port；PowerSync lane 明确 absent；不创建第二个 module instance。
+- 直接 Vitest gates（不得使用会 hang 的 `pnpm nx run <pkg>:test`）：
+  - `node node_modules/vitest/vitest.mjs run --config packages/goal/vitest.use-cases.config.ts`
+  - `node node_modules/vitest/vitest.mjs run --config packages/goal/vitest.mappers.config.ts`
+  - `node node_modules/vitest/vitest.mjs run --config packages/goal/vitest.integration.config.ts`（需要数据库时执行）
+  - `pnpm nx run goal:typecheck`、`pnpm nx run goal:lint`
+
+**Step 1 完成条件**：`rg` 在 Goal `server/application`/`server/domain` 生产文件中找不到 `@memoflow/database`；Goal Application Port、ModuleManifest command names、error codes、transaction/Decimal semantics 与 baseline 对比无变化。
+
+### Step 2 — Data Portability adapter placement（P1）
+
+**目标**：只移动实现归属，保持 export/import cross-capability transaction behavior 与 Application contracts 完全相同。
+
+**精确文件清单**
+
+- 移动 `packages/data-portability/src/server/application/prisma-adapters.ts` → `packages/data-portability/src/server/infrastructure/adapters/prisma-adapters.ts`，保留 class names、Port implementations、query filters 和返回 row shape。
+- 移动 `packages/data-portability/src/server/application/import-store/prisma-data-portability-import-store.ts` → `packages/data-portability/src/server/infrastructure/import-store/prisma-data-portability-import-store.ts`；新增/更新 `server/infrastructure/import-store/index.ts` 作为 infrastructure-internal barrel。
+- 修改 `packages/data-portability/src/server/infrastructure/prisma.ts:1-18`：从新 infrastructure paths import Prisma adapters/import store；保持 `createPrismaDataPortabilityDependencies` 与 `createPrismaDataPortabilityImportStore` 的 function signatures。
+- 修改 `packages/data-portability/src/server/application/import-store/index.ts`：删除 concrete Prisma export，只保留 `DataPortabilityImportStore`、`DataPortabilityImportTx` 与所有 input type exports。
+- 检查并更新 `packages/data-portability/src/server/application/index.ts`、`server/infrastructure/index.ts`、`server/index.ts`、`packages/data-portability/package.json` exports；Application public surface 不得重新导出 concrete class，Infrastructure public surface 只保留现有 factory/Port shape。
+- `packages/data-portability/src/server/application/data-portability.application.port.ts`、`data-portability.dependencies.ts`、全部 importer/projection/use case 不做逻辑修改；只在有必要时修正 type import。
+
+**测试与门禁**
+
+- 新增 `packages/data-portability/src/server/infrastructure/__tests__/prisma-adapters.surface.spec.ts`：断言 Prisma implementation 位于 infrastructure、Application 只出现 Port/use case import。
+- 新增 `packages/data-portability/src/server/infrastructure/__tests__/prisma-data-portability-import-store.test.ts`：fake Prisma transaction client 验证 callback 只执行一次、所有 writes 仍在同一 `$transaction`。
+- 保持并运行现有 `packages/data-portability/src/server/application/use-cases/__tests__/portable-runtime.test.ts`、import rejection、projection/ref-safety、`server/infrastructure/powersync/__tests__/powersync-round-trip.test.ts`；这些测试锁住 cross-capability export/import ordering、dry-run/rejection 和 PowerSync parity。
+- 更新 `apps/api/src/runtime/compose-data-portability.spec.ts`：factory identity/装配顺序不变，禁止 API composer 从 Application concrete path import。
+- 直接 Vitest gates：
+  - `node node_modules/vitest/vitest.mjs run --config packages/data-portability/vitest.config.ts`
+  - `node node_modules/vitest/vitest.mjs run --config apps/api/vitest.config.ts apps/api/src/runtime/compose-data-portability.spec.ts`
+  - `pnpm nx run data-portability:typecheck`、`pnpm nx run data-portability:lint`
+
+**Step 2 完成条件**：`rg` 只在 `server/infrastructure/**` 找到 Data Portability 的 `PrismaClient` import；import callback、transaction rollback/commit、export filters 与 PowerSync round-trip 与 baseline 一致。
+
+### Step 3 — AI executor depends on Application Ports（P0）
+
+**目标**：API runtime 只创建一次 Goal/Task/Reminder module instance；AI executor 不再创建 feature module 或持有 Prisma/lifecycle。
+
+**精确文件清单**
+
+- 修改 `apps/api/src/modules/ai/backend-automation-tool-executor.adapter.ts`：删除 `PrismaClient`、`createGoalPrismaModule`、`createTaskPrismaModule`、`createReminderPrismaModule`、`PrismaTaskBindingReadPort` imports；新增一个带双语 JSDoc 的 `BackendAutomationToolExecutorDependencies`，注入 `GoalApplicationPort`、`TaskApplicationPort`、`ReminderApplicationPort`、`IKnowledgeSourcePort`、`IAnalyticsReadPort`；保留类名、`executeGoalAutomation(input)` signature 与 action loop。
+- 修改 `apps/api/src/runtime/compose-goal.ts`、`compose-task.ts`：返回 `{ module, applicationPort: instance.api }` composed object；Goal/Task 现有 module handle/lifecycle 只通过 `.module` 交给 bootstrap。不要暴露 Prisma repository 或完整 instance。
+- 修改 `apps/api/src/runtime/compose-reminder.ts`：在现有 `ComposedReminder` 增加 `applicationPort: instance.api`，保留 `module`、repository view、schedule sources。
+- 修改 `apps/api/src/runtime/compose-ai.ts`：`ComposeAIDependencies` 增加上述三个 Application Port；继续在 runtime 构造 `RepositoryKnowledgeSourceAdapter` 与 `ControlledAnalyticsReadAdapter`，用五个已注入 port 构造 executor；AI Prisma repository set、ai-service config branch、checkpoint pair 逻辑不变。
+- 修改 `apps/api/src/main.ts`：在调用 `composeAI` 前得到 `goalComposed.applicationPort`、`taskComposed.applicationPort`、`reminderComposed.applicationPort`；保持 API 注册顺序与现有 `.module` handle 归属；不要在 main 新增第二个 `create*PrismaModule`。
+- 更新 `apps/api/src/runtime/compose-goal.spec.ts`、`compose-task.spec.ts`、`compose-reminder.spec.ts`、`compose-ai.spec.ts`：断言返回的 applicationPort 是同一个 `instance.api`，且 AI executor 收到同一对象 identity。
+- 更新 `apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts`：用 fake Application Ports 替换 package module mocks；保留成功 action 顺序、reviewed fields、goal failure dependency skip、receipt 内容与 unsupported action assertions。当前 closureChecker constructor test 移到 `compose-reminder.spec.ts` 或 API integration test，验证 closure checker 仍由 Reminder composer 注入，而非 executor 自己查询 account tables。
+- 可新增 `apps/api/src/runtime/compose-ai.surface.spec.ts` 断言 executor 文件不含 `@memoflow/database`、`create*PrismaModule` 或 feature `/server` deep import；复用现有 package export audit 风格。
+
+**测试与门禁**
+
+- 直接 Vitest：
+  - `node node_modules/vitest/vitest.mjs run --config apps/api/vitest.config.ts apps/api/src/modules/ai/backend-automation-tool-executor.adapter.test.ts`
+  - `node node_modules/vitest/vitest.mjs run --config apps/api/vitest.config.ts apps/api/src/runtime/compose-goal.spec.ts apps/api/src/runtime/compose-task.spec.ts apps/api/src/runtime/compose-reminder.spec.ts apps/api/src/runtime/compose-ai.spec.ts`
+  - `node node_modules/vitest/vitest.mjs run --config apps/api/vitest.smoke.config.ts`
+- `pnpm nx run api:typecheck`、`pnpm nx run api:lint`；检查 `compose-ai`、API bootstrap 与 module destroy lifecycle。
+- Inventory gates：
+  - `rg -n "createGoalPrismaModule|createTaskPrismaModule|createReminderPrismaModule|@memoflow/database" apps/api/src/modules/ai/backend-automation-tool-executor.adapter.ts` 必须无匹配。
+  - `rg -n "applicationPort" apps/api/src/runtime/compose-{goal,task,reminder,ai}.ts` 必须显示显式 port wiring，不能通过 module singleton/accessor 间接取得。
+
+**Step 3 完成条件**：API、AI runtime 只拥有一套 feature module instance；executor action ordering/receipts/events 与 baseline fixtures 完全一致；AI service unavailable/config-null 分支不变。
+
+### Step 4 — Enable forbidden `@memoflow/database` governance（P0 gate）
+
+**目标**：在 steps 1–2 清空旧 violations 后，将 Application/Domain → database 变成 fail-closed 规则，允许 DB 依赖只出现在 infrastructure/runtime/test scope。
+
+**精确文件清单**
+
+- 修改 `tools/governance/package-internal-boundary-audit.mjs:25-65,178-194`：为 `server/domain` 与 `server/application` 增加 exact external specifier forbidden set `@memoflow/database`；扫描 `from`、dynamic `import()` 与 `import type`（现有 regex 已覆盖），错误包含 `file:line`、layer、specifier。
+- 保持现有 test exclusion `:166-170`（`*.spec.ts`、`*.test.ts`、`__tests__`），不把 integration fixture 当作生产层反转；不要新增 Goal/Data Portability allowlist。`server/infrastructure/**` 不进入该 forbidden external rule。
+- 新增 `tools/governance/__tests__/package-internal-boundary-audit.test.mjs` 或等价 source-scan fixture test：正例为 domain/application import contracts/utils，反例为 `import type { PrismaClient } from '@memoflow/database'`，并验证 test fixture exclusion；如需可测性，将 specifier check 提取到 `tools/governance/lib/` 的纯函数，纯函数与 audit CLI 同时使用。
+- 在 `tools/governance/README.md` 或治理标准的既有规则位置补一条中英双语说明：Application/Domain consume Port only; Prisma concrete code belongs to Infrastructure。不得复制一套平行配置。
+
+**测试与门禁**
+
+- `pnpm nx run memoflow:governance-check --skip-nx-cache` 必须通过；该 target 会执行 package-internal boundary、package export、surface、scope、runtime dependency 等全套审计。
+- Inventory：
+  - `rg -n "from ['\"]@memoflow/database['\"]|import\\(['\"]@memoflow/database" packages/*/src/server/application packages/*/src/server/domain --glob '!**/*.spec.ts' --glob '!**/*.test.ts' --glob '!**/__tests__/**'` 必须返回空。
+  - `rg -n "@memoflow/database" packages/*/src/server/infrastructure apps/api/src/runtime` 只允许 infrastructure/runtime 生产实现。
+- 直接运行 governance unit tests（若新增 fixture），再运行 API/Goal/Data Portability 最近的 typecheck/lint；不得以 Nx package test 替代 direct Vitest。
+
+**Step 4 完成条件**：规则在干净 inventory 上首次通过；后续任何 Application/Domain 生产 DB import 都能在单次 `governance-check` 中 fail closed，并且没有旧路径 allowlist。
+
+## 5. 验证与门禁总表
+
+### 5.1 每步门禁
+
+| 阶段   | Unit / mapper                                                  | Integration / surface                                       | 静态 inventory                                                                   | 必过 target                                           |
+| ------ | -------------------------------------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Step 1 | relation/wallet use-case + mapper direct Vitest                | Prisma repository integration、Goal module/composer surface | Goal application/domain 无 DB import；Port method diff 与契约冻结一致            | `goal:typecheck`、`goal:lint`                         |
+| Step 2 | import store transaction fake、portable use-case direct Vitest | DP PowerSync round-trip、compose-data-portability surface   | DP Prisma classes 只在 infrastructure；Application barrel 无 concrete export     | `data-portability:typecheck`、`data-portability:lint` |
+| Step 3 | executor direct Vitest、composer direct Vitest                 | API smoke、module registration/destroy、AI config branches  | executor 无 DB/module factory/deep import；Application Port object identity 一致 | `api:typecheck`、`api:lint`                           |
+| Step 4 | governance fixture direct Vitest                               | 全 governance audit                                         | Application/Domain DB inventory 为空；无 allowlist                               | `memoflow:governance-check --skip-nx-cache`           |
+
+### 5.2 最终阶段门禁
+
+- [ ] `pnpm nx run memoflow:docs-check --skip-nx-cache` 通过；计划 frontmatter、Markdown links、标题/编码与仓库 docs config 一致。
+- [ ] `pnpm nx run memoflow:governance-check --skip-nx-cache` 通过；没有为本阶段新增生产 allowlist 或 baseline exception。
+- [ ] Goal/DP/API direct Vitest 集合、typecheck、lint、API smoke 全部通过；不得运行已知会 hang 的 `pnpm nx run <pkg>:test`。
+- [ ] `rg` inventory 与 package export/surface audit 证明：所有新增 public Port/composed interface 都有中英双语 JSDoc，所有 concrete Prisma class 留在 Infrastructure。
+- [ ] Bootstrap smoke 对比：Goal/Task/Reminder/AI 注册顺序、路由 mounts、destroy reverse order、AI service config-null/unavailable 分支均与 baseline 相同。
+- [ ] 变更 diff 只包含四个步骤所列的 production/test/governance 文件；本计划之外的 ExecutionContext、Query Cache、Transport parity 和 action loop 变更视为 gate failure。
+
+## 6. 风险与回滚
+
+| 风险                                          | 触发点                                                                                                                                   | 预防 / 证据                                                                                                                                                                             | 回滚动作                                                                                                                       |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Goal transaction / Decimal / error-code 漂移  | Wallet repository 拆出 `$transaction` 或 mapper 后把 Decimal 转成 number；Relation unique error 不再映射 `CONFLICT`；identity scope 丢失 | 先冻结 3.1–3.2；mapper unit + Prisma integration；对比 `ACCOUNT_NOT_FOUND → NOT_FOUND`、`Unique → CONFLICT`、Date ms 与 string Decimal fixtures                                         | 回滚 Step 1 commit；恢复 adapter 文件位置即可，不改 schema/数据；若仅 mapper 失败，保留 Port move 并回退 mapper implementation |
+| Goal module wiring 产生重复 instance/listener | composer 为 AI 或 manifest 另建 Goal module，或把 runtime contribution 注册两次                                                          | 只从 `composeGoal` 输出 `applicationPort`；AI 不调用 module factory；composer spec 断言同一 `instance.api` identity 与一次 `createGoalModule`                                           | 先恢复 `composeGoal`/`main.ts` wiring，再保留 infrastructure Port move；禁止引入 singleton accessor 作为临时修复               |
+| Data Portability import/export 行为变化       | import store 脱离 callback transaction；read adapter filters/row shape 被重写；Application barrel path 误导调用方                        | 只移动文件；round-trip、dry-run rejection、fake `$transaction` 与 compose wiring tests；保留旧 class names                                                                              | 反向移动两个实现文件并恢复 relative imports；不回退 Port/use-case contracts 或 PowerSync 实现                                  |
+| AI action ordering / receipts / events 变化   | executor constructor refactor 顺带拆 loop、错误分支或重新创建 feature module；Application Port 不是同一 instance                         | 先冻结 loop；`backend-automation-tool-executor.adapter.test.ts` 锁 action sequence、skip/fail receipt、reviewed fields；compose tests 锁 object identity；API smoke 锁 module lifecycle | 回滚 Step 3 wiring；保留 Goal/DP layering fixes；不得通过重新在 executor 中创建 Prisma module 规避测试失败                     |
+| Governance false positive                     | audit 把 test fixture、Infrastructure 或 generated code 当作 Application violation；动态 import pattern 漏报/误报                        | exact specifier rule；复用现有 test exclusion；加 positive/negative fixture；先跑 inventory 再启用无 allowlist规则                                                                      | 回滚 Step 4 audit change，修正纯函数/fixture 后重新启用；不添加长期路径 allowlist 来压过真实反转                               |
+| Public surface / JSDoc 违规                   | 新 domain Port 或 composed interface 未有双语 JSDoc；concrete adapter 被 root/API barrel 导出                                            | surface spec、package-export audit、双语 JSDoc checklist                                                                                                                                | 删除多余 export，保留 package-internal import；不扩大 package subpath                                                          |
+
+## 7. 完成定义
+
+- [ ] 四个 Steps 均以独立 PR-able diff 完成，且每一步在合并前有自己的 direct Vitest/typecheck/lint/surface 证据。
+- [ ] Goal Application/Domain 不 import `@memoflow/database`；Data Portability Application 不包含 Prisma implementation；AI executor 不包含 Prisma/module construction。
+- [ ] `IRelationRepository`、`IWalletRepository`、`DataPortabilityImportStore`、Goal/Task/Reminder/AI Application Port 的冻结 shape 与错误、事务、Decimal、receipt/event 语义保持不变。
+- [ ] `pnpm nx run memoflow:docs-check --skip-nx-cache` 与 `pnpm nx run memoflow:governance-check --skip-nx-cache` 均通过。
+- [ ] 本阶段不宣称阶段 2（Request/Execution Context）、阶段 4（Transport parity）、阶段 5（Query Cache）或阶段 6（长期可观测性）完成。

--- a/docs/plan/archive/2026-08-15-refarch-phase1-p0-layering.md
+++ b/docs/plan/archive/2026-08-15-refarch-phase1-p0-layering.md
@@ -251,12 +251,12 @@ export interface IWalletRepository {
 
 ### 5.2 最终阶段门禁
 
-- [ ] `pnpm nx run memoflow:docs-check --skip-nx-cache` 通过；计划 frontmatter、Markdown links、标题/编码与仓库 docs config 一致。
-- [ ] `pnpm nx run memoflow:governance-check --skip-nx-cache` 通过；没有为本阶段新增生产 allowlist 或 baseline exception。
-- [ ] Goal/DP/API direct Vitest 集合、typecheck、lint、API smoke 全部通过；不得运行已知会 hang 的 `pnpm nx run <pkg>:test`。
-- [ ] `rg` inventory 与 package export/surface audit 证明：所有新增 public Port/composed interface 都有中英双语 JSDoc，所有 concrete Prisma class 留在 Infrastructure。
-- [ ] Bootstrap smoke 对比：Goal/Task/Reminder/AI 注册顺序、路由 mounts、destroy reverse order、AI service config-null/unavailable 分支均与 baseline 相同。
-- [ ] 变更 diff 只包含四个步骤所列的 production/test/governance 文件；本计划之外的 ExecutionContext、Query Cache、Transport parity 和 action loop 变更视为 gate failure。
+- [x] `pnpm nx run memoflow:docs-check --skip-nx-cache` 通过；计划 frontmatter、Markdown links、标题/编码与仓库 docs config 一致。
+- [x] `pnpm nx run memoflow:governance-check --skip-nx-cache` 通过；没有为本阶段新增生产 allowlist 或 baseline exception。
+- [x] Goal/DP/API direct Vitest 集合、typecheck、lint、API smoke 全部通过；不得运行已知会 hang 的 `pnpm nx run <pkg>:test`。
+- [x] `rg` inventory 与 package export/surface audit 证明：所有新增 public Port/composed interface 都有中英双语 JSDoc，所有 concrete Prisma class 留在 Infrastructure。
+- [x] Bootstrap smoke 对比：Goal/Task/Reminder/AI 注册顺序、路由 mounts、destroy reverse order、AI service config-null/unavailable 分支均与 baseline 相同。
+- [x] 变更 diff 只包含四个步骤所列的 production/test/governance 文件；本计划之外的 ExecutionContext、Query Cache、Transport parity 和 action loop 变更视为 gate failure。
 
 ## 6. 风险与回滚
 
@@ -271,8 +271,8 @@ export interface IWalletRepository {
 
 ## 7. 完成定义
 
-- [ ] 四个 Steps 均以独立 PR-able diff 完成，且每一步在合并前有自己的 direct Vitest/typecheck/lint/surface 证据。
-- [ ] Goal Application/Domain 不 import `@memoflow/database`；Data Portability Application 不包含 Prisma implementation；AI executor 不包含 Prisma/module construction。
-- [ ] `IRelationRepository`、`IWalletRepository`、`DataPortabilityImportStore`、Goal/Task/Reminder/AI Application Port 的冻结 shape 与错误、事务、Decimal、receipt/event 语义保持不变。
-- [ ] `pnpm nx run memoflow:docs-check --skip-nx-cache` 与 `pnpm nx run memoflow:governance-check --skip-nx-cache` 均通过。
-- [ ] 本阶段不宣称阶段 2（Request/Execution Context）、阶段 4（Transport parity）、阶段 5（Query Cache）或阶段 6（长期可观测性）完成。
+- [x] 四个 Steps 均以独立 PR-able diff 完成，且每一步在合并前有自己的 direct Vitest/typecheck/lint/surface 证据。
+- [x] Goal Application/Domain 不 import `@memoflow/database`；Data Portability Application 不包含 Prisma implementation；AI executor 不包含 Prisma/module construction。
+- [x] `IRelationRepository`、`IWalletRepository`、`DataPortabilityImportStore`、Goal/Task/Reminder/AI Application Port 的冻结 shape 与错误、事务、Decimal、receipt/event 语义保持不变。
+- [x] `pnpm nx run memoflow:docs-check --skip-nx-cache` 与 `pnpm nx run memoflow:governance-check --skip-nx-cache` 均通过。
+- [x] 本阶段不宣称阶段 2（Request/Execution Context）、阶段 4（Transport parity）、阶段 5（Query Cache）或阶段 6（长期可观测性）完成。

--- a/packages/data-portability/src/server/application/import-store/index.ts
+++ b/packages/data-portability/src/server/application/import-store/index.ts
@@ -30,4 +30,3 @@ export type {
   CreateAIConversationInput,
   CreateAIMessageInput,
 } from './data-portability-import-store';
-export { PrismaDataPortabilityImportStore } from './prisma-data-portability-import-store';

--- a/packages/data-portability/src/server/infrastructure/__tests__/prisma-adapters.surface.spec.ts
+++ b/packages/data-portability/src/server/infrastructure/__tests__/prisma-adapters.surface.spec.ts
@@ -1,0 +1,99 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PrismaFocusSessionAdapter } from '../adapters/prisma-adapters';
+import { PrismaDataPortabilityImportStore } from '../import-store/prisma-data-portability-import-store';
+
+/**
+ * Data Portability Prisma adapter placement surface.
+ * 数据可移植性 Prisma 适配器归属的表面契约。
+ *
+ * RefArch Phase 1 Step 2: the concrete Prisma adapters and the Prisma import
+ * store must live in `server/infrastructure`, and the Application layer must
+ * only hold Port interfaces and use cases — no `PrismaClient` import, no
+ * concrete adapter re-export through the Application barrels.
+ *
+ * 参考架构阶段 1 Step 2：具体 Prisma 适配器与 Prisma import store 必须位于
+ * `server/infrastructure`，Application 层只保留 Port 接口与 use case ——
+ * 不得 import `PrismaClient`，也不得通过 Application barrel 重新导出具体适配器。
+ */
+describe('data portability Prisma adapter placement', () => {
+  it('defines the Prisma adapters and import store in server/infrastructure', () => {
+    const adapterPath = resolve(
+      __dirname,
+      '../adapters/prisma-adapters.ts',
+    );
+    const importStorePath = resolve(
+      __dirname,
+      '../import-store/prisma-data-portability-import-store.ts',
+    );
+
+    expect(readFileSync(adapterPath, 'utf8')).toContain(
+      "import type { PrismaClient } from '@memoflow/database';",
+    );
+    expect(readFileSync(importStorePath, 'utf8')).toContain(
+      "import type { PrismaClient, Prisma } from '@memoflow/database';",
+    );
+
+    expect(PrismaFocusSessionAdapter).toBeDefined();
+    expect(PrismaDataPortabilityImportStore).toBeDefined();
+  });
+
+  it('application layer holds no Prisma import and no concrete adapter re-export', () => {
+    const applicationIndex = readFileSync(
+      resolve(__dirname, '../../application/index.ts'),
+      'utf8',
+    );
+    const importStoreIndex = readFileSync(
+      resolve(__dirname, '../../application/import-store/index.ts'),
+      'utf8',
+    );
+
+    for (const source of [applicationIndex, importStoreIndex]) {
+      expect(source).not.toMatch(/from '@memoflow\/database'/);
+      expect(source).not.toMatch(/PrismaFocusSessionAdapter|PrismaDataPortabilityImportStore/);
+      expect(source).not.toMatch(/prisma-adapters|prisma-data-portability-import-store/);
+    }
+  });
+
+  it('application import-store barrel exports the Port types and input types only', () => {
+    const importStoreIndex = readFileSync(
+      resolve(__dirname, '../../application/import-store/index.ts'),
+      'utf8',
+    );
+
+    expect(importStoreIndex).toContain('DataPortabilityImportStore');
+    expect(importStoreIndex).toContain('DataPortabilityImportTx');
+    expect(importStoreIndex).toContain('UpsertUserSettingInput');
+    expect(importStoreIndex).toContain('CreateAIMessageInput');
+  });
+
+  it('no production file under server/application imports PrismaClient', () => {
+    const applicationDir = resolve(__dirname, '../../application');
+    const productionFiles = collectTsFiles(applicationDir).filter(
+      (file) => !/\.(spec|test)\.ts$/.test(file),
+    );
+
+    expect(productionFiles.length).toBeGreaterThan(0);
+    for (const file of productionFiles) {
+      const source = readFileSync(file, 'utf8');
+      expect(source, `unexpected Prisma import in ${file}`).not.toMatch(
+        /from '@memoflow\/database'/,
+      );
+    }
+  });
+});
+
+function collectTsFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectTsFiles(fullPath));
+    } else if (entry.name.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}

--- a/packages/data-portability/src/server/infrastructure/__tests__/prisma-data-portability-import-store.test.ts
+++ b/packages/data-portability/src/server/infrastructure/__tests__/prisma-data-portability-import-store.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PrismaDataPortabilityImportStore } from '../import-store/prisma-data-portability-import-store';
+
+/**
+ * PrismaDataPortabilityImportStore transaction behaviour.
+ * PrismaDataPortabilityImportStore 的事务行为。
+ *
+ * The store must wrap the whole import callback in a single prisma.$transaction,
+ * invoke the callback exactly once with a DataPortabilityImportTx bound to that
+ * transaction client, and propagate transaction failures unchanged.
+ *
+ * store 必须把整个 import callback 包在单个 prisma.$transaction 内，回调只执行一次，
+ * 并把绑定到该事务客户端的 DataPortabilityImportTx 传给回调，事务失败原样向上传播。
+ */
+describe('PrismaDataPortabilityImportStore', () => {
+  function createFakePrisma() {
+    const writeCalls: string[] = [];
+    const transactionClient = {
+      userSetting: { upsert: vi.fn(async () => undefined) },
+      repository: { create: vi.fn(async () => undefined) },
+      goal: { create: vi.fn(async () => undefined) },
+      taskTemplate: { create: vi.fn(async () => undefined) },
+      scheduleTask: { create: vi.fn(async () => undefined) },
+      reminderResponse: { create: vi.fn(async () => undefined) },
+      editorWorkspace: { create: vi.fn(async () => undefined) },
+      aiConversation: { create: vi.fn(async () => undefined) },
+      aiMessage: { create: vi.fn(async () => undefined) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (fn) => {
+        return fn(transactionClient);
+      }),
+    };
+    return { prisma, transactionClient, writeCalls };
+  }
+
+  it('invokes the import callback exactly once inside one $transaction', async () => {
+    const { prisma } = createFakePrisma();
+    const store = new PrismaDataPortabilityImportStore(prisma as never);
+
+    const callback = vi.fn(async () => 'imported');
+    const result = await store.transaction(callback);
+
+    expect(result).toBe('imported');
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]?.[0]).toBeDefined();
+  });
+
+  it('routes every write to the same $transaction client', async () => {
+    const { prisma, transactionClient } = createFakePrisma();
+    const store = new PrismaDataPortabilityImportStore(prisma as never);
+
+    await store.transaction(async (tx) => {
+      await tx.upsertUserSetting({
+        identityId: 'identity-1',
+        preferences: { locale: 'zh-CN' },
+      });
+      await tx.createRepository({
+        id: 'repo-1',
+        identityId: 'identity-1',
+        name: 'Knowledge',
+        type: 'local',
+        path: '/knowledge',
+        description: null,
+        config: {},
+        status: 'ACTIVE',
+      });
+      await tx.createGoal({
+        id: 'goal-1',
+        identityId: 'identity-1',
+        name: 'Ship',
+        description: null,
+        color: '#000',
+        feasibilityAnalysis: null,
+        motivation: null,
+        status: 'active',
+        importance: 'high',
+        priority: 1,
+        category: null,
+        tags: [],
+        startDate: null,
+        targetDate: null,
+        completedAt: null,
+        folderId: null,
+        parentGoalId: null,
+        sortOrder: 0,
+        reminderConfig: null,
+      });
+    });
+
+    expect(transactionClient.userSetting.upsert).toHaveBeenCalledTimes(1);
+    expect(transactionClient.repository.create).toHaveBeenCalledTimes(1);
+    expect(transactionClient.goal.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates transaction failures unchanged', async () => {
+    const { prisma } = createFakePrisma();
+    const store = new PrismaDataPortabilityImportStore(prisma as never);
+    const error = new Error('boom');
+
+    await expect(
+      store.transaction(async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+});

--- a/packages/data-portability/src/server/infrastructure/adapters/prisma-adapters.ts
+++ b/packages/data-portability/src/server/infrastructure/adapters/prisma-adapters.ts
@@ -1,8 +1,12 @@
 /**
  * Prisma Adapters for Data Portability
+ * 数据可移植性 Prisma 适配器。
  *
  * Direct Prisma queries for modules that don't export repository factories.
  * These implement the dependency interfaces used by the export use case.
+ *
+ * 对未提供仓储工厂的模块执行直接 Prisma 查询，
+ * 实现导出 use case 所需的依赖接口。
  */
 
 import type { PrismaClient } from '@memoflow/database';
@@ -19,7 +23,7 @@ import type {
   EditorGroupRepoPort,
   EditorTabRepoPort,
   AIConversationRepoPort,
-} from './data-portability.dependencies';
+} from '../../application/data-portability.dependencies';
 
 export class PrismaFocusSessionAdapter implements FocusSessionRepoPort {
   constructor(private readonly prisma: PrismaClient) {}

--- a/packages/data-portability/src/server/infrastructure/import-store/index.ts
+++ b/packages/data-portability/src/server/infrastructure/import-store/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Infrastructure-internal barrel for the Data Portability Prisma import store.
+ * 数据可移植性 Prisma import store 的基础设施内部 barrel。
+ *
+ * Concrete adapter classes live in Infrastructure; only the host-facing
+ * factories in `../prisma.ts` consume them, never the Application layer.
+ *
+ * 具体适配器类位于 Infrastructure，仅供 `../prisma.ts` 中的宿主向工厂使用，
+ * Application 层绝不引用。
+ */
+
+export { PrismaDataPortabilityImportStore } from './prisma-data-portability-import-store';

--- a/packages/data-portability/src/server/infrastructure/import-store/prisma-data-portability-import-store.ts
+++ b/packages/data-portability/src/server/infrastructure/import-store/prisma-data-portability-import-store.ts
@@ -1,8 +1,12 @@
 /**
  * Prisma implementation of DataPortabilityImportStore.
+ * DataPortabilityImportStore 的 Prisma 实现。
  *
  * Wraps prisma.$transaction() and delegates each create/upsert
  * to the corresponding Prisma model.
+ *
+ * 将整个 import callback 包装在 prisma.$transaction() 内，
+ * 并把每个 create/upsert 委托给对应的 Prisma model。
  */
 
 import type { PrismaClient, Prisma } from '@memoflow/database';
@@ -37,7 +41,7 @@ import type {
   CreateEditorTabInput,
   CreateAIConversationInput,
   CreateAIMessageInput,
-} from './data-portability-import-store';
+} from '../../application/import-store/data-portability-import-store';
 
 class PrismaDataPortabilityImportTx implements DataPortabilityImportTx {
   constructor(private readonly tx: Prisma.TransactionClient) {}

--- a/packages/data-portability/src/server/infrastructure/prisma.ts
+++ b/packages/data-portability/src/server/infrastructure/prisma.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient } from '@memoflow/database';
-import { PrismaDataPortabilityImportStore } from '../application/import-store/prisma-data-portability-import-store';
+import { PrismaDataPortabilityImportStore } from './import-store/prisma-data-portability-import-store';
 import type { DataPortabilityImportStore } from '../application/import-store/data-portability-import-store';
 import type { DataPortabilityDependencies } from '../application/data-portability.dependencies';
 import {
@@ -15,7 +15,7 @@ import {
   PrismaEditorGroupAdapter,
   PrismaEditorTabAdapter,
   PrismaAIConversationAdapter,
-} from '../application/prisma-adapters';
+} from './adapters/prisma-adapters';
 import {
   createDataPortabilityModule,
   type DataPortabilityModuleInstance,

--- a/packages/goal/src/index.ts
+++ b/packages/goal/src/index.ts
@@ -35,6 +35,8 @@ export {
   type IGoalRecordRepository,
   type IGoalFolderRepository,
   type IFocusModeRepository,
+  type IRelationRepository,
+  type IWalletRepository,
 } from './server';
 export type { IHabitRepository } from './server/application/use-cases/commands/habit.use-cases';
 export type { GoalWriteTransactionRunner } from './server/application/use-cases/commands/goal-write-support';

--- a/packages/goal/src/server/application/use-cases/commands/__tests__/relation.use-cases.spec.ts
+++ b/packages/goal/src/server/application/use-cases/commands/__tests__/relation.use-cases.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { IRelationRepository } from '../../../../domain';
 import {
   CreateRelationUseCase,
   ListRelationsUseCase,
-  type IRelationRepository,
 } from '../relation.use-cases';
 
 function mockRepo(): IRelationRepository {

--- a/packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts
+++ b/packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IWalletRepository } from '../../../../domain';
+import {
+  CreateWalletAccountUseCase,
+  ListWalletUseCase,
+  RecordWalletTransactionUseCase,
+} from '../wallet.use-cases';
+
+function mockRepo(): IWalletRepository {
+  return {
+    createAccount: vi.fn(async (input) => ({
+      id: 'w-1',
+      name: input.name,
+      currency: input.currency ?? 'CNY',
+      balance: '0',
+    })),
+    listAccounts: vi.fn(async () => []),
+    recordTransaction: vi.fn(async (input) => ({
+      id: 't-1',
+      accountId: input.accountId,
+      type: input.type,
+      amount: input.amount,
+      category: input.category ?? null,
+      note: input.note ?? null,
+      goalId: input.goalId ?? null,
+      occurredAt: Date.now(),
+    })),
+    listTransactions: vi.fn(async () => []),
+  };
+}
+
+describe('Wallet use cases (R7)', () => {
+  it('creates a wallet account with a default CNY currency', async () => {
+    const repo = mockRepo();
+    const useCase = new CreateWalletAccountUseCase(repo);
+
+    const result = await useCase.execute('identity-1', { name: '日常' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.currency).toBe('CNY');
+      expect(repo.createAccount).toHaveBeenCalledWith({
+        identityId: 'identity-1',
+        name: '日常',
+      });
+    }
+  });
+
+  it('rejects a blank account name', async () => {
+    const useCase = new CreateWalletAccountUseCase(mockRepo());
+
+    const result = await useCase.execute('identity-1', { name: '   ' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('VALIDATION_ERROR');
+    }
+  });
+
+  it('rejects a non-positive amount', async () => {
+    const repo = mockRepo();
+    const useCase = new RecordWalletTransactionUseCase(repo);
+
+    const result = await useCase.execute('identity-1', {
+      accountId: 'w-1',
+      type: 'expense',
+      amount: '0',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('VALIDATION_ERROR');
+      expect(result.error.message).toBe('Amount must be a positive number');
+    }
+    expect(repo.recordTransaction).not.toHaveBeenCalled();
+  });
+
+  it('maps ACCOUNT_NOT_FOUND to NOT_FOUND', async () => {
+    const repo = mockRepo();
+    repo.recordTransaction = vi.fn(async () => {
+      throw new Error('ACCOUNT_NOT_FOUND');
+    });
+    const useCase = new RecordWalletTransactionUseCase(repo);
+
+    const result = await useCase.execute('identity-1', {
+      accountId: 'missing',
+      type: 'income',
+      amount: '10',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('NOT_FOUND');
+      expect(result.error.message).toBe('Wallet account not found');
+    }
+  });
+
+  it('rethrows non-ACCOUNT_NOT_FOUND repository errors', async () => {
+    const repo = mockRepo();
+    repo.recordTransaction = vi.fn(async () => {
+      throw new Error('DB exploded');
+    });
+    const useCase = new RecordWalletTransactionUseCase(repo);
+
+    await expect(
+      useCase.execute('identity-1', { accountId: 'w-1', type: 'income', amount: '10' }),
+    ).rejects.toThrow('DB exploded');
+  });
+
+  it('lists accounts and transactions together', async () => {
+    const repo = mockRepo();
+    const useCase = new ListWalletUseCase(repo);
+
+    const result = await useCase.execute('identity-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ accounts: [], transactions: [] });
+    }
+    expect(repo.listAccounts).toHaveBeenCalledWith('identity-1');
+    expect(repo.listTransactions).toHaveBeenCalledWith('identity-1', 50);
+  });
+});

--- a/packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts
+++ b/packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts
@@ -1,115 +1,23 @@
 /**
- * R5：跨模块 SubjectRef 关系基础设施（暂驻 goal 包，待 ModuleManifest 重构时抽取）。
+ * R5：跨模块 SubjectRef 关系 use cases（暂驻 goal 包，待 ModuleManifest 重构时抽取）。
  *
  * 连接 Note/Goal/Task/Reminder/Habit 两类主体，维护反向查询：
  * - 正向：某 subject 的关系列表；
  * - 反向：引用某 object 的所有 subject（reverse lookup）。
+ *
+ * 契约纪律：use case 只依赖 domain-owned `IRelationRepository` Port；
+ * Prisma 实现位于 `infrastructure/adapters/prisma/relation-prisma.repository.ts`。
  */
 
 import type { Result } from '@memoflow/contracts/result';
 import { error, ok } from '@memoflow/contracts/result';
-import type { PrismaClient } from '@memoflow/database';
-
-export const SubjectTypes = ['note', 'goal', 'task', 'reminder', 'habit', 'wallet'] as const;
-export type SubjectType = (typeof SubjectTypes)[number];
-
-export const RelationTypes = ['references', 'related', 'depends_on', 'contributes_to'] as const;
-export type RelationType = (typeof RelationTypes)[number];
-
-export interface SubjectRef {
-  type: SubjectType;
-  id: string;
-}
-
-export interface RelationDTO {
-  id: string;
-  subject: SubjectRef;
-  relationType: RelationType;
-  object: SubjectRef;
-  createdAt: number;
-}
-
-export interface IRelationRepository {
-  create(input: {
-    identityId: string;
-    subject: SubjectRef;
-    relationType: RelationType;
-    object: SubjectRef;
-  }): Promise<RelationDTO>;
-  deleteByIdentityId(identityId: string, id: string): Promise<void>;
-  /** 正向：subject 出发的关系。 */
-  findBySubject(identityId: string, subject: SubjectRef): Promise<RelationDTO[]>;
-  /** 反向：谁引用了该 object。 */
-  findByObject(identityId: string, object: SubjectRef): Promise<RelationDTO[]>;
-}
-
-export class PrismaRelationRepository implements IRelationRepository {
-  constructor(private readonly db: PrismaClient) {}
-
-  async create(input: {
-    identityId: string;
-    subject: SubjectRef;
-    relationType: RelationType;
-    object: SubjectRef;
-  }): Promise<RelationDTO> {
-    const row = await this.db.relation.create({
-      data: {
-        id: crypto.randomUUID(),
-        identityId: input.identityId,
-        subjectType: input.subject.type,
-        subjectId: input.subject.id,
-        relationType: input.relationType,
-        objectType: input.object.type,
-        objectId: input.object.id,
-      },
-    });
-    return {
-      id: row.id,
-      subject: { type: row.subjectType as SubjectType, id: row.subjectId },
-      relationType: row.relationType as RelationType,
-      object: { type: row.objectType as SubjectType, id: row.objectId },
-      createdAt: row.createdAt.getTime(),
-    };
-  }
-
-  async deleteByIdentityId(identityId: string, id: string): Promise<void> {
-    await this.db.relation.deleteMany({ where: { id, identityId } });
-  }
-
-  async findBySubject(identityId: string, subject: SubjectRef): Promise<RelationDTO[]> {
-    const rows = await this.db.relation.findMany({
-      where: { identityId, subjectType: subject.type, subjectId: subject.id },
-      orderBy: { createdAt: 'asc' },
-    });
-    return rows.map(toDTO);
-  }
-
-  async findByObject(identityId: string, object: SubjectRef): Promise<RelationDTO[]> {
-    const rows = await this.db.relation.findMany({
-      where: { identityId, objectType: object.type, objectId: object.id },
-      orderBy: { createdAt: 'asc' },
-    });
-    return rows.map(toDTO);
-  }
-}
-
-function toDTO(row: {
-  id: string;
-  subjectType: string;
-  subjectId: string;
-  relationType: string;
-  objectType: string;
-  objectId: string;
-  createdAt: Date;
-}): RelationDTO {
-  return {
-    id: row.id,
-    subject: { type: row.subjectType as SubjectType, id: row.subjectId },
-    relationType: row.relationType as RelationType,
-    object: { type: row.objectType as SubjectType, id: row.objectId },
-    createdAt: row.createdAt.getTime(),
-  };
-}
+import type {
+  IRelationRepository,
+  RelationDTO,
+  RelationType,
+  SubjectRef,
+} from '../../../domain';
+import { SubjectTypes } from '../../../domain';
 
 export class CreateRelationUseCase {
   constructor(private readonly repository: IRelationRepository) {}

--- a/packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts
+++ b/packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts
@@ -1,159 +1,19 @@
 /**
- * R7：Wallet 外部模块试点（暂驻 goal 包，验证 ModuleManifest 扩展性）。
+ * R7：Wallet 外部模块试点 use cases（暂驻 goal 包，验证 ModuleManifest 扩展性）。
  *
  * 契约纪律：钱包写入只依赖本模块表 + 通用 Relation/Activity 端口，
  * 不直接依赖 Goal/Task 数据表（与 Goal 的连接走 Relation contributes_to）。
+ * use case 只依赖 domain-owned `IWalletRepository` Port；
+ * Prisma 实现位于 `infrastructure/adapters/prisma/wallet-prisma.repository.ts`。
  */
 
 import type { Result } from '@memoflow/contracts/result';
 import { error, ok } from '@memoflow/contracts/result';
-import type { PrismaClient } from '@memoflow/database';
-
-export interface WalletAccountDTO {
-  id: string;
-  name: string;
-  currency: string;
-  balance: string; // Decimal → string（精度安全）
-}
-
-export interface WalletTransactionDTO {
-  id: string;
-  accountId: string;
-  type: string;
-  amount: string;
-  category: string | null;
-  note: string | null;
-  goalId: string | null;
-  occurredAt: number;
-}
-
-export interface IWalletRepository {
-  createAccount(input: {
-    identityId: string;
-    name: string;
-    currency?: string;
-  }): Promise<WalletAccountDTO>;
-  listAccounts(identityId: string): Promise<WalletAccountDTO[]>;
-  recordTransaction(input: {
-    identityId: string;
-    accountId: string;
-    type: 'income' | 'expense' | 'transfer';
-    amount: string;
-    category?: string | null;
-    note?: string | null;
-    goalId?: string | null;
-    occurredAt?: number;
-  }): Promise<WalletTransactionDTO>;
-  listTransactions(identityId: string, limit?: number): Promise<WalletTransactionDTO[]>;
-}
-
-export class PrismaWalletRepository implements IWalletRepository {
-  constructor(private readonly db: PrismaClient) {}
-
-  async createAccount(input: {
-    identityId: string;
-    name: string;
-    currency?: string;
-  }): Promise<WalletAccountDTO> {
-    const row = await this.db.walletAccount.create({
-      data: {
-        id: crypto.randomUUID(),
-        identityId: input.identityId,
-        name: input.name,
-        currency: input.currency ?? 'CNY',
-      },
-    });
-    return {
-      id: row.id,
-      name: row.name,
-      currency: row.currency,
-      balance: row.balance.toString(),
-    };
-  }
-
-  async listAccounts(identityId: string): Promise<WalletAccountDTO[]> {
-    const rows = await this.db.walletAccount.findMany({
-      where: { identityId },
-      orderBy: { createdAt: 'asc' },
-    });
-    return rows.map((r) => ({
-      id: r.id,
-      name: r.name,
-      currency: r.currency,
-      balance: r.balance.toString(),
-    }));
-  }
-
-  async recordTransaction(input: {
-    identityId: string;
-    accountId: string;
-    type: 'income' | 'expense' | 'transfer';
-    amount: string;
-    category?: string | null;
-    note?: string | null;
-    goalId?: string | null;
-    occurredAt?: number;
-  }): Promise<WalletTransactionDTO> {
-    return this.db.$transaction(async (tx) => {
-      const account = await tx.walletAccount.findFirst({
-        where: { id: input.accountId, identityId: input.identityId },
-      });
-      if (!account) {
-        throw new Error('ACCOUNT_NOT_FOUND');
-      }
-      const delta =
-        input.type === 'income' ? input.amount : `-${input.amount}`;
-      await tx.walletAccount.update({
-        where: { id: account.id },
-        data: { balance: { increment: delta } },
-      });
-      const row = await tx.walletTransaction.create({
-        data: {
-          id: crypto.randomUUID(),
-          accountId: input.accountId,
-          identityId: input.identityId,
-          type: input.type,
-          amount: input.amount,
-          category: input.category ?? null,
-          note: input.note ?? null,
-          goalId: input.goalId ?? null,
-          occurredAt: new Date(input.occurredAt ?? Date.now()),
-        },
-      });
-      return {
-        id: row.id,
-        accountId: row.accountId,
-        type: row.type,
-        amount: row.amount.toString(),
-        category: row.category,
-        note: row.note,
-        goalId: row.goalId,
-        occurredAt: row.occurredAt.getTime(),
-      };
-    });
-  }
-
-  async listTransactions(
-    identityId: string,
-    limit?: number,
-  ): Promise<WalletTransactionDTO[]> {
-    const rows = await this.db.walletTransaction.findMany({
-      where: { identityId },
-      orderBy: { occurredAt: 'desc' },
-      take: limit ?? 50,
-    });
-    return rows.map((r) => ({
-      id: r.id,
-      accountId: r.accountId,
-      type: r.type,
-      amount: r.amount.toString(),
-      category: r.category,
-      note: r.note,
-      goalId: r.goalId,
-      occurredAt: r.occurredAt.getTime(),
-    }));
-  }
-}
+import type {
+  IWalletRepository,
+  WalletAccountDTO,
+  WalletTransactionDTO,
+} from '../../../domain';
 
 export class CreateWalletAccountUseCase {
   constructor(private readonly repository: IWalletRepository) {}

--- a/packages/goal/src/server/domain/index.ts
+++ b/packages/goal/src/server/domain/index.ts
@@ -53,6 +53,23 @@ export type {
   SnapshotQueryResult,
 } from './repositories';
 
+// R5 关系 / R7 钱包 仓储 Port（domain-owned）
+export {
+  SubjectTypes,
+  RelationTypes,
+  type SubjectType,
+  type RelationType,
+  type SubjectRef,
+  type RelationDTO,
+  type IRelationRepository,
+} from './repositories';
+
+export type {
+  IWalletRepository,
+  WalletAccountDTO,
+  WalletTransactionDTO,
+} from './repositories';
+
 // 领域服务（只保留真正的领域服务）
 export {
   FocusSessionPolicy,

--- a/packages/goal/src/server/domain/repositories/i-relation-repository.ts
+++ b/packages/goal/src/server/domain/repositories/i-relation-repository.ts
@@ -1,0 +1,57 @@
+/**
+ * R5 关系仓储 Port（domain-owned）。
+ * R5 Relation repository Port (domain-owned).
+ *
+ * 连接 Note/Goal/Task/Reminder/Habit/Wallet 两类主体（subject → object），
+ * 维护正向与反向查询；Prisma 实现位于 infrastructure/adapters/prisma。
+ * Connects two subject references (subject → object) across
+ * Note/Goal/Task/Reminder/Habit/Wallet and maintains forward and reverse
+ * lookups; the Prisma implementation lives in infrastructure/adapters/prisma.
+ */
+
+/** 支持的主体类型 / Supported subject types. */
+export const SubjectTypes = ['note', 'goal', 'task', 'reminder', 'habit', 'wallet'] as const;
+export type SubjectType = (typeof SubjectTypes)[number];
+
+/** 支持的关系类型 / Supported relation types. */
+export const RelationTypes = ['references', 'related', 'depends_on', 'contributes_to'] as const;
+export type RelationType = (typeof RelationTypes)[number];
+
+/** 主体引用 / Subject reference. */
+export interface SubjectRef {
+  type: SubjectType;
+  id: string;
+}
+
+/** 关系 DTO（createdAt 为毫秒时间戳）/ Relation DTO (createdAt in epoch milliseconds). */
+export interface RelationDTO {
+  id: string;
+  subject: SubjectRef;
+  relationType: RelationType;
+  object: SubjectRef;
+  createdAt: number;
+}
+
+/**
+ * 关系仓储 Port / Relation repository Port.
+ *
+ * @remarks
+ * - `create` 的唯一约束冲突由 `CreateRelationUseCase` 解释为 `CONFLICT`；
+ *   本 Port 保持原始错误抛出。Unique constraint violations are interpreted
+ *   by `CreateRelationUseCase` as `CONFLICT`; this Port keeps throwing raw errors.
+ * - 所有查询按 identityId 隔离（identity scoping）。
+ *   All queries are scoped by identityId.
+ */
+export interface IRelationRepository {
+  create(input: {
+    identityId: string;
+    subject: SubjectRef;
+    relationType: RelationType;
+    object: SubjectRef;
+  }): Promise<RelationDTO>;
+  deleteByIdentityId(identityId: string, id: string): Promise<void>;
+  /** 正向：从 subject 出发的关系 / Forward: relations starting from subject. */
+  findBySubject(identityId: string, subject: SubjectRef): Promise<RelationDTO[]>;
+  /** 反向：谁引用了该 object / Reverse: who references this object. */
+  findByObject(identityId: string, object: SubjectRef): Promise<RelationDTO[]>;
+}

--- a/packages/goal/src/server/domain/repositories/i-wallet-repository.ts
+++ b/packages/goal/src/server/domain/repositories/i-wallet-repository.ts
@@ -1,0 +1,62 @@
+/**
+ * R7 钱包仓储 Port（domain-owned）。
+ * R7 Wallet repository Port (domain-owned).
+ *
+ * 钱包写入只依赖本模块表（WalletAccount/WalletTransaction），与 Goal 的连接走
+ * Relation contributes_to；Prisma 实现位于 infrastructure/adapters/prisma。
+ * Wallet writes depend only on its own tables; the Goal link goes through a
+ * Relation contributes_to; the Prisma implementation lives in
+ * infrastructure/adapters/prisma.
+ */
+
+/** 钱包账户 DTO（balance 为 Decimal → string，精度安全）。/ Wallet account DTO (balance kept as string for Decimal precision). */
+export interface WalletAccountDTO {
+  id: string;
+  name: string;
+  currency: string;
+  balance: string;
+}
+
+/** 钱包交易 DTO（amount 为 Decimal → string，occurredAt 为毫秒时间戳）。/ Wallet transaction DTO (amount as string, occurredAt in epoch milliseconds). */
+export interface WalletTransactionDTO {
+  id: string;
+  accountId: string;
+  type: string;
+  amount: string;
+  category: string | null;
+  note: string | null;
+  goalId: string | null;
+  occurredAt: number;
+}
+
+/**
+ * 钱包仓储 Port / Wallet repository Port.
+ *
+ * @remarks
+ * - amount 校验与 `ACCOUNT_NOT_FOUND → NOT_FOUND` 映射由 use case 完成；
+ *   本 Port 可抛出原始 `ACCOUNT_NOT_FOUND` 错误。Amount validation and the
+ *   `ACCOUNT_NOT_FOUND → NOT_FOUND` mapping happen in the use cases; this Port
+ *   may throw the raw `ACCOUNT_NOT_FOUND` error.
+ * - `recordTransaction` 由实现保证单事务原子性（余额更新 + 交易写入同生共死）。
+ *   Implementations must keep the balance update and the transaction insert
+ *   atomic inside one database transaction.
+ */
+export interface IWalletRepository {
+  createAccount(input: {
+    identityId: string;
+    name: string;
+    currency?: string;
+  }): Promise<WalletAccountDTO>;
+  listAccounts(identityId: string): Promise<WalletAccountDTO[]>;
+  recordTransaction(input: {
+    identityId: string;
+    accountId: string;
+    type: 'income' | 'expense' | 'transfer';
+    amount: string;
+    category?: string | null;
+    note?: string | null;
+    goalId?: string | null;
+    occurredAt?: number;
+  }): Promise<WalletTransactionDTO>;
+  listTransactions(identityId: string, limit?: number): Promise<WalletTransactionDTO[]>;
+}

--- a/packages/goal/src/server/domain/repositories/index.ts
+++ b/packages/goal/src/server/domain/repositories/index.ts
@@ -8,3 +8,17 @@ export type { IGoalFolderRepository } from './i-goal-folder-repository';
 export type { IGoalRepository } from './i-goal-repository';
 export type { IWeightSnapshotRepository, SnapshotQueryResult } from './i-weight-snapshot-repository';
 export type { IGoalRecordRepository, GoalRecordQueryOptions } from './i-goal-record-repository';
+export {
+  SubjectTypes,
+  RelationTypes,
+  type SubjectType,
+  type RelationType,
+  type SubjectRef,
+  type RelationDTO,
+  type IRelationRepository,
+} from './i-relation-repository';
+export type {
+  IWalletRepository,
+  WalletAccountDTO,
+  WalletTransactionDTO,
+} from './i-wallet-repository';

--- a/packages/goal/src/server/infrastructure/__tests__/goal-repositories.surface.spec.ts
+++ b/packages/goal/src/server/infrastructure/__tests__/goal-repositories.surface.spec.ts
@@ -15,6 +15,8 @@ import {
   type IGoalRecordRepository,
   type IGoalRepository,
   type IHabitRepository,
+  type IRelationRepository,
+  type IWalletRepository,
   type GoalModuleInstance,
 } from '../../../../src';
 import { createGoalPrismaModule } from '../prisma';
@@ -46,12 +48,16 @@ describe('goal repository factories surface', () => {
     expect(set).toHaveProperty('focusModeRepository');
     expect(set).toHaveProperty('goalWriteTransactionRunner');
     expect(set).toHaveProperty('habitRepository');
+    expect(set).toHaveProperty('relationRepository');
+    expect(set).toHaveProperty('walletRepository');
     const typed: GoalRepositorySet = set;
     expect(typeof typed.goalWriteTransactionRunner.run).toBe('function');
     expect(typeof typed.habitRepository?.findByIdentityId).toBe('function');
+    expect(typeof typed.relationRepository?.findBySubject).toBe('function');
+    expect(typeof typed.walletRepository?.listAccounts).toBe('function');
   });
 
-  it('createGoalPowerSyncRepositories returns the same Port shape without habitRepository', () => {
+  it('createGoalPowerSyncRepositories returns the same Port shape without Prisma-only repositories', () => {
     const set = createGoalPowerSyncRepositories(fakeElectronDb);
     const requiredNames = [
       'goalRepository',
@@ -64,13 +70,15 @@ describe('goal repository factories surface', () => {
       expect(set).toHaveProperty(name);
     }
     expect(set).not.toHaveProperty('habitRepository');
+    expect(set).not.toHaveProperty('relationRepository');
+    expect(set).not.toHaveProperty('walletRepository');
     const typed: GoalRepositorySet = set;
     expect(typeof typed.goalWriteTransactionRunner.run).toBe('function');
   });
 
   it('Prisma and PowerSync sets agree on all non-optional Port field names', () => {
     const prismaKeys = Object.keys(createGoalPrismaRepositories(fakePrisma)).filter(
-      (key) => key !== 'habitRepository',
+      (key) => !['habitRepository', 'relationRepository', 'walletRepository'].includes(key),
     );
     const powerSyncKeys = Object.keys(createGoalPowerSyncRepositories(fakeElectronDb));
     expect(prismaKeys.sort()).toEqual(powerSyncKeys.sort());
@@ -118,6 +126,10 @@ describe('goal repository factories surface', () => {
       'GoalRecordPrismaRepository',
       'PrismaGoalWriteTransactionRunner',
       'PrismaHabitRepository',
+      'RelationPrismaRepository',
+      'WalletPrismaRepository',
+      'PrismaRelationMapper',
+      'PrismaWalletMapper',
       'GoalPowerSyncRepository',
       'GoalFolderPowerSyncRepository',
       'GoalRecordPowerSyncRepository',
@@ -150,6 +162,8 @@ describe('goal repository factories surface', () => {
     const habit = (_t: IHabitRepository) => undefined;
     const goal = (_t: IGoalRepository) => undefined;
     const record = (_t: IGoalRecordRepository) => undefined;
+    const relation = (_t: IRelationRepository) => undefined;
+    const wallet = (_t: IWalletRepository) => undefined;
 
     expect(typeof run).toBe('function');
     expect(typeof folder).toBe('function');
@@ -157,6 +171,8 @@ describe('goal repository factories surface', () => {
     expect(typeof habit).toBe('function');
     expect(typeof goal).toBe('function');
     expect(typeof record).toBe('function');
+    expect(typeof relation).toBe('function');
+    expect(typeof wallet).toBe('function');
   });
 
   it('infrastructure public barrel keeps ingredient factories, set types and port types only', async () => {
@@ -179,6 +195,10 @@ describe('goal repository factories surface', () => {
       'FocusModePrismaRepository',
       'GoalRecordPrismaRepository',
       'PrismaGoalWriteTransactionRunner',
+      'RelationPrismaRepository',
+      'WalletPrismaRepository',
+      'PrismaRelationMapper',
+      'PrismaWalletMapper',
       'GoalPowerSyncRepository',
       'PowerSyncGoalWriteTransactionRunner',
     ]) {

--- a/packages/goal/src/server/infrastructure/adapters/prisma/index.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/index.ts
@@ -6,4 +6,6 @@ export { GoalFolderPrismaRepository } from './goal-folder-prisma.repository';
 export { GoalRecordPrismaRepository } from './goal-record-prisma.repository';
 export { PrismaGoalWriteTransactionRunner } from './prisma-goal-write-transaction-runner';
 export { PrismaGoalReliableOperationAdapter } from './prisma-goal-reliable-operation.adapter';
+export { RelationPrismaRepository } from './relation-prisma.repository';
+export { WalletPrismaRepository } from './wallet-prisma.repository';
 export * from './mappers';

--- a/packages/goal/src/server/infrastructure/adapters/prisma/mappers/index.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/mappers/index.ts
@@ -11,3 +11,5 @@ export { PrismaGoalRecordMapper } from './prisma-goal-record-mapper';
 export { PrismaFocusSessionMapper } from './prisma-focus-session-mapper';
 export { PrismaFocusModeMapper } from './prisma-focus-mode-mapper';
 export { PrismaWeightSnapshotMapper } from './prisma-weight-snapshot-mapper';
+export { PrismaRelationMapper } from './prisma-relation.mapper';
+export { PrismaWalletMapper } from './prisma-wallet.mapper';

--- a/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.spec.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { Relation as PrismaRelation } from '@memoflow/database';
+import { PrismaRelationMapper } from './prisma-relation.mapper';
+
+describe('PrismaRelationMapper', () => {
+  it('maps persisted string enums to frozen unions and createdAt to epoch ms', () => {
+    const row = {
+      id: 'rel-1',
+      identityId: 'identity-1',
+      subjectType: 'note',
+      subjectId: 'note-1',
+      relationType: 'depends_on',
+      objectType: 'goal',
+      objectId: 'goal-1',
+      createdAt: new Date(1_700_000_000_000),
+      updatedAt: new Date(1_700_000_000_001),
+    } as PrismaRelation;
+
+    const dto = PrismaRelationMapper.toDTO(row);
+
+    expect(dto.id).toBe('rel-1');
+    expect(dto.subject).toEqual({ type: 'note', id: 'note-1' });
+    expect(dto.relationType).toBe('depends_on');
+    expect(dto.object).toEqual({ type: 'goal', id: 'goal-1' });
+    expect(dto.createdAt).toBe(1_700_000_000_000);
+  });
+
+  it('maps lists and preserves ordering', () => {
+    const rows = [
+      {
+        id: 'rel-1',
+        identityId: 'identity-1',
+        subjectType: 'task',
+        subjectId: 'task-1',
+        relationType: 'references',
+        objectType: 'goal',
+        objectId: 'goal-1',
+        createdAt: new Date(1_000),
+        updatedAt: new Date(1_001),
+      },
+      {
+        id: 'rel-2',
+        identityId: 'identity-1',
+        subjectType: 'habit',
+        subjectId: 'habit-1',
+        relationType: 'contributes_to',
+        objectType: 'goal',
+        objectId: 'goal-2',
+        createdAt: new Date(2_000),
+        updatedAt: new Date(2_001),
+      },
+    ] as PrismaRelation[];
+
+    const dtos = PrismaRelationMapper.toDTOList(rows);
+
+    expect(dtos).toHaveLength(2);
+    expect(dtos[0]).toMatchObject({ id: 'rel-1', relationType: 'references' });
+    expect(dtos[1]).toMatchObject({ id: 'rel-2', subject: { type: 'habit', id: 'habit-1' } });
+  });
+});

--- a/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.ts
@@ -1,0 +1,28 @@
+import type { Relation as PrismaRelation } from '@memoflow/database';
+import type { RelationDTO, RelationType, SubjectType } from '../../../../domain';
+
+/**
+ * Prisma Relation 行 → RelationDTO 映射器 / Prisma Relation row → RelationDTO mapper.
+ *
+ * 将持久化的字符串枚举转换为冻结的 `SubjectType`/`RelationType` 联合类型，
+ * 并把 `createdAt` 从 Date 转为毫秒时间戳（number）。
+ * Converts the persisted string enums into the frozen `SubjectType`/`RelationType`
+ * unions and normalizes `createdAt` from Date into an epoch-millisecond number.
+ */
+export class PrismaRelationMapper {
+  /** 单行转换 / Maps a single Prisma row to RelationDTO. */
+  static toDTO(row: PrismaRelation): RelationDTO {
+    return {
+      id: row.id,
+      subject: { type: row.subjectType as SubjectType, id: row.subjectId },
+      relationType: row.relationType as RelationType,
+      object: { type: row.objectType as SubjectType, id: row.objectId },
+      createdAt: row.createdAt.getTime(),
+    };
+  }
+
+  /** 批量转换 / Maps Prisma rows to RelationDTO[]. */
+  static toDTOList(rows: PrismaRelation[]): RelationDTO[] {
+    return rows.map((row) => PrismaRelationMapper.toDTO(row));
+  }
+}

--- a/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.spec.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  WalletAccount as PrismaWalletAccount,
+  WalletTransaction as PrismaWalletTransaction,
+} from '@memoflow/database';
+import { PrismaWalletMapper } from './prisma-wallet.mapper';
+
+/** Decimal-like value exposing the same `.toString()` surface the mapper uses. */
+function decimalLike(value: string): unknown {
+  return { toString: () => value };
+}
+
+describe('PrismaWalletMapper', () => {
+  it('maps a WalletAccount row keeping balance as a Decimal-precise string', () => {
+    const row = {
+      id: 'acc-1',
+      identityId: 'identity-1',
+      name: '日常',
+      currency: 'CNY',
+      balance: decimalLike('1234567890123.456789'),
+      createdAt: new Date(1_000),
+      updatedAt: new Date(1_001),
+    } as unknown as PrismaWalletAccount;
+
+    const dto = PrismaWalletMapper.toAccountDTO(row);
+
+    expect(dto).toEqual({
+      id: 'acc-1',
+      name: '日常',
+      currency: 'CNY',
+      balance: '1234567890123.456789',
+    });
+  });
+
+  it('maps a WalletTransaction row keeping amount string and occurredAt epoch ms', () => {
+    const row = {
+      id: 'tx-1',
+      accountId: 'acc-1',
+      identityId: 'identity-1',
+      type: 'income',
+      amount: decimalLike('0.1'),
+      category: 'salary',
+      note: null,
+      goalId: 'goal-1',
+      occurredAt: new Date(1_700_000_000_000),
+      createdAt: new Date(1_700_000_000_000),
+    } as unknown as PrismaWalletTransaction;
+
+    const dto = PrismaWalletMapper.toTransactionDTO(row);
+
+    expect(dto).toEqual({
+      id: 'tx-1',
+      accountId: 'acc-1',
+      type: 'income',
+      amount: '0.1',
+      category: 'salary',
+      note: null,
+      goalId: 'goal-1',
+      occurredAt: 1_700_000_000_000,
+    });
+  });
+
+  it('preserves Decimal precision without float arithmetic', () => {
+    const row = {
+      id: 'tx-2',
+      accountId: 'acc-1',
+      identityId: 'identity-1',
+      type: 'expense',
+      amount: decimalLike('999999999999.000001'),
+      category: null,
+      note: 'precision',
+      goalId: null,
+      occurredAt: new Date(2_000),
+      createdAt: new Date(2_000),
+    } as unknown as PrismaWalletTransaction;
+
+    expect(PrismaWalletMapper.toTransactionDTO(row).amount).toBe('999999999999.000001');
+  });
+});

--- a/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.ts
@@ -1,0 +1,38 @@
+import type {
+  WalletAccount as PrismaWalletAccount,
+  WalletTransaction as PrismaWalletTransaction,
+} from '@memoflow/database';
+import type { WalletAccountDTO, WalletTransactionDTO } from '../../../../domain';
+
+/**
+ * Prisma Wallet 行 → Wallet DTO 映射器 / Prisma Wallet row → Wallet DTO mapper.
+ *
+ * 保留 Decimal 字段的字符串表示（禁止浮点运算），并把 Date 转为毫秒时间戳。
+ * Preserves the string representation of Decimal fields (no float arithmetic)
+ * and converts Date fields into epoch-millisecond numbers.
+ */
+export class PrismaWalletMapper {
+  /** 账户行转换 / Maps a Prisma WalletAccount row to WalletAccountDTO. */
+  static toAccountDTO(row: PrismaWalletAccount): WalletAccountDTO {
+    return {
+      id: row.id,
+      name: row.name,
+      currency: row.currency,
+      balance: row.balance.toString(),
+    };
+  }
+
+  /** 交易行转换 / Maps a Prisma WalletTransaction row to WalletTransactionDTO. */
+  static toTransactionDTO(row: PrismaWalletTransaction): WalletTransactionDTO {
+    return {
+      id: row.id,
+      accountId: row.accountId,
+      type: row.type,
+      amount: row.amount.toString(),
+      category: row.category,
+      note: row.note,
+      goalId: row.goalId,
+      occurredAt: row.occurredAt.getTime(),
+    };
+  }
+}

--- a/packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.integration.test.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.integration.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { IdentityId } from '@memoflow/domain-shared';
+import {
+  cleanAll,
+  disconnectPrisma,
+  getPrisma,
+  seedAccount,
+} from '../../../../__tests__/integration-helpers';
+import type { PrismaClient } from '@memoflow/database';
+import { RelationPrismaRepository } from './relation-prisma.repository';
+import type { SubjectRef } from '../../../../domain';
+
+async function seedIdentity(): Promise<string> {
+  const identityId = IdentityId.generate();
+  await seedAccount({ id: identityId });
+  return identityId;
+}
+
+describe('RelationPrismaRepository integration (R5)', () => {
+  let db: PrismaClient;
+  let repository: RelationPrismaRepository;
+
+  afterAll(async () => {
+    await cleanAll();
+    await disconnectPrisma();
+  });
+
+  beforeEach(async () => {
+    await cleanAll();
+    db = await getPrisma();
+    repository = new RelationPrismaRepository(db);
+  });
+
+  it('creates a relation and returns a DTO with epoch-ms createdAt', async () => {
+    const identityId = await seedIdentity();
+
+    const dto = await repository.create({
+      identityId,
+      subject: { type: 'note', id: 'note-1' },
+      relationType: 'references',
+      object: { type: 'goal', id: 'goal-1' },
+    });
+
+    expect(dto.id).toBeTruthy();
+    expect(dto.subject).toEqual({ type: 'note', id: 'note-1' });
+    expect(dto.relationType).toBe('references');
+    expect(dto.object).toEqual({ type: 'goal', id: 'goal-1' });
+    expect(typeof dto.createdAt).toBe('number');
+  });
+
+  it('scopes forward/reverse lookups by identityId', async () => {
+    const identityId = await seedIdentity();
+    const otherIdentityId = await seedIdentity();
+
+    await repository.create({
+      identityId,
+      subject: { type: 'note', id: 'note-1' },
+      relationType: 'references',
+      object: { type: 'goal', id: 'goal-1' },
+    });
+    await repository.create({
+      identityId: otherIdentityId,
+      subject: { type: 'note', id: 'note-1' },
+      relationType: 'references',
+      object: { type: 'goal', id: 'goal-1' },
+    });
+
+    const forward = await repository.findBySubject(identityId, { type: 'note', id: 'note-1' });
+    const reverse = await repository.findByObject(identityId, { type: 'goal', id: 'goal-1' });
+
+    expect(forward).toHaveLength(1);
+    expect(reverse).toHaveLength(1);
+    expect(reverse[0]?.subject).toEqual({ type: 'note', id: 'note-1' });
+  });
+
+  it('orders findBySubject results by createdAt ASC', async () => {
+    const identityId = await seedIdentity();
+    const subject: SubjectRef = { type: 'task', id: 'task-1' };
+
+    await db.relation.create({
+      data: {
+        id: 'rel-2',
+        identityId,
+        subjectType: 'task',
+        subjectId: 'task-1',
+        relationType: 'related',
+        objectType: 'goal',
+        objectId: 'goal-2',
+        createdAt: new Date(2_000),
+      },
+    });
+    await db.relation.create({
+      data: {
+        id: 'rel-1',
+        identityId,
+        subjectType: 'task',
+        subjectId: 'task-1',
+        relationType: 'references',
+        objectType: 'goal',
+        objectId: 'goal-1',
+        createdAt: new Date(1_000),
+      },
+    });
+
+    const dtos = await repository.findBySubject(identityId, subject);
+
+    expect(dtos.map((d) => d.id)).toEqual(['rel-1', 'rel-2']);
+  });
+
+  it('throws a unique-constraint error when the same relation already exists', async () => {
+    const identityId = await seedIdentity();
+    const input = {
+      identityId,
+      subject: { type: 'goal', id: 'goal-1' },
+      relationType: 'contributes_to',
+      object: { type: 'goal', id: 'goal-2' },
+    };
+
+    await repository.create(input);
+
+    await expect(repository.create(input)).rejects.toThrow(/Unique/i);
+  });
+
+  it('deletes only the identity-owned relation row', async () => {
+    const identityId = await seedIdentity();
+    const otherIdentityId = await seedIdentity();
+
+    const mine = await repository.create({
+      identityId,
+      subject: { type: 'note', id: 'note-1' },
+      relationType: 'references',
+      object: { type: 'goal', id: 'goal-1' },
+    });
+    await repository.create({
+      identityId: otherIdentityId,
+      subject: { type: 'note', id: 'note-1' },
+      relationType: 'references',
+      object: { type: 'goal', id: 'goal-1' },
+    });
+
+    await repository.deleteByIdentityId(identityId, mine.id);
+
+    expect(await db.relation.count({ where: { identityId } })).toBe(0);
+    expect(await db.relation.count({ where: { identityId: otherIdentityId } })).toBe(1);
+  });
+});

--- a/packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.ts
@@ -1,0 +1,66 @@
+import type { PrismaClient } from '@memoflow/database';
+import type {
+  IRelationRepository,
+  RelationDTO,
+  RelationType,
+  SubjectRef,
+} from '../../../domain';
+import { PrismaRelationMapper } from './mappers/prisma-relation.mapper';
+
+/**
+ * Prisma 关系仓储（R5）/ Prisma relation repository (R5).
+ *
+ * 只负责 Prisma 调用；行转换交给 `PrismaRelationMapper`。
+ * `findBySubject`/`findByObject` 保持 createdAt ASC，delete 保持
+ * `{ id, identityId }` 作用域的 deleteMany。
+ * Owns only the Prisma calls; row conversion is delegated to
+ * `PrismaRelationMapper`. `findBySubject`/`findByObject` stay createdAt ASC and
+ * delete stays a `{ id, identityId }`-scoped deleteMany.
+ */
+export class RelationPrismaRepository implements IRelationRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  /** 创建关系（id 由实现生成）/ Creates a relation with an implementation-generated id. */
+  async create(input: {
+    identityId: string;
+    subject: SubjectRef;
+    relationType: RelationType;
+    object: SubjectRef;
+  }): Promise<RelationDTO> {
+    const row = await this.db.relation.create({
+      data: {
+        id: crypto.randomUUID(),
+        identityId: input.identityId,
+        subjectType: input.subject.type,
+        subjectId: input.subject.id,
+        relationType: input.relationType,
+        objectType: input.object.type,
+        objectId: input.object.id,
+      },
+    });
+    return PrismaRelationMapper.toDTO(row);
+  }
+
+  /** 按 `{ id, identityId }` 作用域删除 / Deletes scoped by `{ id, identityId }`. */
+  async deleteByIdentityId(identityId: string, id: string): Promise<void> {
+    await this.db.relation.deleteMany({ where: { id, identityId } });
+  }
+
+  /** 正向查询（createdAt ASC）/ Forward lookup ordered by createdAt ASC. */
+  async findBySubject(identityId: string, subject: SubjectRef): Promise<RelationDTO[]> {
+    const rows = await this.db.relation.findMany({
+      where: { identityId, subjectType: subject.type, subjectId: subject.id },
+      orderBy: { createdAt: 'asc' },
+    });
+    return PrismaRelationMapper.toDTOList(rows);
+  }
+
+  /** 反向查询（createdAt ASC）/ Reverse lookup ordered by createdAt ASC. */
+  async findByObject(identityId: string, object: SubjectRef): Promise<RelationDTO[]> {
+    const rows = await this.db.relation.findMany({
+      where: { identityId, objectType: object.type, objectId: object.id },
+      orderBy: { createdAt: 'asc' },
+    });
+    return PrismaRelationMapper.toDTOList(rows);
+  }
+}

--- a/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.integration.test.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.integration.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { IdentityId } from '@memoflow/domain-shared';
+import {
+  cleanAll,
+  disconnectPrisma,
+  getPrisma,
+  seedAccount,
+} from '../../../../__tests__/integration-helpers';
+import type { PrismaClient } from '@memoflow/database';
+import { WalletPrismaRepository } from './wallet-prisma.repository';
+
+async function seedIdentity(): Promise<string> {
+  const identityId = IdentityId.generate();
+  await seedAccount({ id: identityId });
+  return identityId;
+}
+
+describe('WalletPrismaRepository integration (R7)', () => {
+  let db: PrismaClient;
+  let repository: WalletPrismaRepository;
+
+  afterAll(async () => {
+    await cleanAll();
+    await disconnectPrisma();
+  });
+
+  beforeEach(async () => {
+    await cleanAll();
+    db = await getPrisma();
+    repository = new WalletPrismaRepository(db);
+  });
+
+  it('creates an account with a default CNY currency and zero balance', async () => {
+    const identityId = await seedIdentity();
+
+    const account = await repository.createAccount({ identityId, name: '日常' });
+
+    expect(account).toMatchObject({ name: '日常', currency: 'CNY', balance: '0' });
+    expect(account.id).toBeTruthy();
+  });
+
+  it('scopes accounts by identityId', async () => {
+    const identityId = await seedIdentity();
+    const otherIdentityId = await seedIdentity();
+
+    await repository.createAccount({ identityId, name: 'A' });
+    await repository.createAccount({ identityId: otherIdentityId, name: 'Foreign' });
+
+    const accounts = await repository.listAccounts(identityId);
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.name).toBe('A');
+  });
+
+  it('records an income and updates the balance with Decimal precision', async () => {
+    const identityId = await seedIdentity();
+    const account = await repository.createAccount({ identityId, name: 'A' });
+
+    const tx = await repository.recordTransaction({
+      identityId,
+      accountId: account.id,
+      type: 'income',
+      amount: '1234.5678901234',
+      category: 'salary',
+      note: 'Jan',
+      goalId: 'goal-1',
+      occurredAt: 1_700_000_000_000,
+    });
+
+    expect(tx).toMatchObject({
+      accountId: account.id,
+      type: 'income',
+      amount: '1234.5678901234',
+      category: 'salary',
+      note: 'Jan',
+      goalId: 'goal-1',
+      occurredAt: 1_700_000_000_000,
+    });
+
+    const reloaded = await repository.listAccounts(identityId);
+    expect(reloaded[0]?.balance).toBe('1234.5678901234');
+  });
+
+  it('decrements the balance for an expense', async () => {
+    const identityId = await seedIdentity();
+    const account = await repository.createAccount({ identityId, name: 'A' });
+
+    await repository.recordTransaction({ identityId, accountId: account.id, type: 'income', amount: '100' });
+    await repository.recordTransaction({ identityId, accountId: account.id, type: 'expense', amount: '40.5' });
+
+    const reloaded = await repository.listAccounts(identityId);
+    expect(reloaded[0]?.balance).toBe('59.5');
+  });
+
+  it('orders transactions by occurredAt DESC', async () => {
+    const identityId = await seedIdentity();
+    const account = await repository.createAccount({ identityId, name: 'A' });
+
+    await repository.recordTransaction({
+      identityId,
+      accountId: account.id,
+      type: 'income',
+      amount: '1',
+      occurredAt: 1_000,
+    });
+    await repository.recordTransaction({
+      identityId,
+      accountId: account.id,
+      type: 'income',
+      amount: '2',
+      occurredAt: 2_000,
+    });
+
+    const transactions = await repository.listTransactions(identityId);
+
+    expect(transactions.map((t) => t.amount)).toEqual(['2', '1']);
+  });
+
+  it('wraps balance update + transaction insert in a single db transaction', async () => {
+    const identityId = await seedIdentity();
+    const account = await repository.createAccount({ identityId, name: 'A' });
+
+    let txCount = 0;
+    const spied = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === '$transaction') {
+          return async (cb: (tx: PrismaClient) => Promise<unknown>) => {
+            txCount += 1;
+            return target.$transaction(cb);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as unknown as PrismaClient;
+    const spiedRepo = new WalletPrismaRepository(spied);
+
+    await spiedRepo.recordTransaction({
+      identityId,
+      accountId: account.id,
+      type: 'income',
+      amount: '10',
+    });
+
+    expect(txCount).toBe(1);
+  });
+
+  it('throws ACCOUNT_NOT_FOUND and persists nothing when the account is missing', async () => {
+    const identityId = await seedIdentity();
+
+    await expect(
+      repository.recordTransaction({
+        identityId,
+        accountId: 'missing-account',
+        type: 'income',
+        amount: '10',
+      }),
+    ).rejects.toThrow('ACCOUNT_NOT_FOUND');
+
+    expect(await db.walletTransaction.count({ where: { identityId } })).toBe(0);
+  });
+
+  it('rolls back the balance when the transaction insert fails (atomicity)', async () => {
+    const identityId = await seedIdentity();
+    const account = await repository.createAccount({ identityId, name: 'A' });
+
+    await expect(
+      repository.recordTransaction({
+        identityId,
+        accountId: account.id,
+        type: 'income',
+        amount: '100',
+        occurredAt: NaN,
+      }),
+    ).rejects.toThrow();
+
+    const reloaded = await repository.listAccounts(identityId);
+    expect(reloaded[0]?.balance).toBe('0');
+    expect(await db.walletTransaction.count({ where: { identityId } })).toBe(0);
+  });
+});

--- a/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.ts
@@ -1,0 +1,104 @@
+import type { PrismaClient } from '@memoflow/database';
+import type {
+  IWalletRepository,
+  WalletAccountDTO,
+  WalletTransactionDTO,
+} from '../../../domain';
+import { PrismaWalletMapper } from './mappers/prisma-wallet.mapper';
+
+/**
+ * Prisma 钱包仓储（R7）/ Prisma wallet repository (R7).
+ *
+ * 保留默认 currency `CNY`、所有 Decimal 字段 `.toString()`、所有 Date 字段
+ * `.getTime()`；`recordTransaction` 保持单个 `db.$transaction`：先按
+ * `{ id: accountId, identityId }` 查账户，缺失抛 `ACCOUNT_NOT_FOUND`，
+ * 再按 `income/expense/transfer` delta 规则更新余额并创建交易。
+ * Keeps the default `CNY` currency, `.toString()` on all Decimal fields,
+ * `.getTime()` on all Date fields, and `recordTransaction` inside one
+ * `db.$transaction`: find the account by `{ id: accountId, identityId }`,
+ * throw `ACCOUNT_NOT_FOUND` when missing, then update the balance by the
+ * `income/expense/transfer` delta rule and insert the transaction.
+ */
+export class WalletPrismaRepository implements IWalletRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  /** 创建账户（默认 currency CNY）/ Creates an account with default currency CNY. */
+  async createAccount(input: {
+    identityId: string;
+    name: string;
+    currency?: string;
+  }): Promise<WalletAccountDTO> {
+    const row = await this.db.walletAccount.create({
+      data: {
+        id: crypto.randomUUID(),
+        identityId: input.identityId,
+        name: input.name,
+        currency: input.currency ?? 'CNY',
+      },
+    });
+    return PrismaWalletMapper.toAccountDTO(row);
+  }
+
+  /** 按身份列出账户（createdAt ASC）/ Lists accounts by identity ordered by createdAt ASC. */
+  async listAccounts(identityId: string): Promise<WalletAccountDTO[]> {
+    const rows = await this.db.walletAccount.findMany({
+      where: { identityId },
+      orderBy: { createdAt: 'asc' },
+    });
+    return rows.map((r) => PrismaWalletMapper.toAccountDTO(r));
+  }
+
+  /** 记账（单事务：查账户 → 更新余额 → 写交易）/ Records a transaction in one db transaction. */
+  async recordTransaction(input: {
+    identityId: string;
+    accountId: string;
+    type: 'income' | 'expense' | 'transfer';
+    amount: string;
+    category?: string | null;
+    note?: string | null;
+    goalId?: string | null;
+    occurredAt?: number;
+  }): Promise<WalletTransactionDTO> {
+    return this.db.$transaction(async (tx) => {
+      const account = await tx.walletAccount.findFirst({
+        where: { id: input.accountId, identityId: input.identityId },
+      });
+      if (!account) {
+        throw new Error('ACCOUNT_NOT_FOUND');
+      }
+      const delta =
+        input.type === 'income' ? input.amount : `-${input.amount}`;
+      await tx.walletAccount.update({
+        where: { id: account.id },
+        data: { balance: { increment: delta } },
+      });
+      const row = await tx.walletTransaction.create({
+        data: {
+          id: crypto.randomUUID(),
+          accountId: input.accountId,
+          identityId: input.identityId,
+          type: input.type,
+          amount: input.amount,
+          category: input.category ?? null,
+          note: input.note ?? null,
+          goalId: input.goalId ?? null,
+          occurredAt: new Date(input.occurredAt ?? Date.now()),
+        },
+      });
+      return PrismaWalletMapper.toTransactionDTO(row);
+    });
+  }
+
+  /** 按身份列出交易（occurredAt DESC，limit 默认 50）/ Lists transactions by identity ordered by occurredAt DESC. */
+  async listTransactions(
+    identityId: string,
+    limit?: number,
+  ): Promise<WalletTransactionDTO[]> {
+    const rows = await this.db.walletTransaction.findMany({
+      where: { identityId },
+      orderBy: { occurredAt: 'desc' },
+      take: limit ?? 50,
+    });
+    return rows.map((r) => PrismaWalletMapper.toTransactionDTO(r));
+  }
+}

--- a/packages/goal/src/server/infrastructure/goal.module.ts
+++ b/packages/goal/src/server/infrastructure/goal.module.ts
@@ -20,6 +20,8 @@ import type {
   IGoalFolderRepository,
   IGoalRecordRepository,
   IFocusModeRepository,
+  IRelationRepository,
+  IWalletRepository,
 } from '../domain';
 import { GoalPolicy, FocusSessionPolicy } from '../domain';
 import {
@@ -70,6 +72,15 @@ import {
   ListHabitUseCase,
   type IHabitRepository,
 } from '../application/use-cases/commands/habit.use-cases';
+import {
+  CreateRelationUseCase,
+  ListRelationsUseCase,
+} from '../application/use-cases/commands/relation.use-cases';
+import {
+  CreateWalletAccountUseCase,
+  ListWalletUseCase,
+  RecordWalletTransactionUseCase,
+} from '../application/use-cases/commands/wallet.use-cases';
 
 const logger = createLogger('GoalModule');
 
@@ -96,6 +107,10 @@ export interface GoalModuleDependencies {
   readonly runtimeContributions?: GoalRuntimeContributionsInput;
   /** R4：习惯仓储（可选；提供时启用 habit use cases）。 */
   readonly habitRepository?: IHabitRepository;
+  /** R5：关系仓储（可选；提供时启用 relation use cases）。 */
+  readonly relationRepository?: IRelationRepository;
+  /** R7：钱包仓储（可选；提供时启用 wallet use cases）。 */
+  readonly walletRepository?: IWalletRepository;
 }
 
 /**
@@ -127,6 +142,17 @@ export interface GoalModuleUseCases {
     readonly create: CreateHabitUseCase;
     readonly checkIn: RecordHabitCheckInUseCase;
     readonly list: ListHabitUseCase;
+  };
+  // R5 Relation / 关系
+  readonly relation?: {
+    readonly create: CreateRelationUseCase;
+    readonly list: ListRelationsUseCase;
+  };
+  // R7 Wallet / 钱包
+  readonly wallet?: {
+    readonly createAccount: CreateWalletAccountUseCase;
+    readonly recordTransaction: RecordWalletTransactionUseCase;
+    readonly list: ListWalletUseCase;
   };
   // Goal CRUD / 目标增删改查
   readonly createGoal: CreateGoalUseCase;
@@ -226,6 +252,8 @@ export function createGoalUseCases(deps: GoalModuleDependencies): GoalModuleUseC
   const focusSessionPolicy = new FocusSessionPolicy();
 
   const habitRepository: IHabitRepository | undefined = deps.habitRepository;
+  const relationRepository: IRelationRepository | undefined = deps.relationRepository;
+  const walletRepository: IWalletRepository | undefined = deps.walletRepository;
 
   return {
     // R4 Habit（可选：未注入仓储时不启用）
@@ -235,6 +263,25 @@ export function createGoalUseCases(deps: GoalModuleDependencies): GoalModuleUseC
             create: new CreateHabitUseCase(habitRepository),
             checkIn: new RecordHabitCheckInUseCase(habitRepository),
             list: new ListHabitUseCase(habitRepository),
+          },
+        }
+      : {}),
+    // R5 Relation（可选：未注入仓储时不启用）
+    ...(relationRepository
+      ? {
+          relation: {
+            create: new CreateRelationUseCase(relationRepository),
+            list: new ListRelationsUseCase(relationRepository),
+          },
+        }
+      : {}),
+    // R7 Wallet（可选：未注入仓储时不启用）
+    ...(walletRepository
+      ? {
+          wallet: {
+            createAccount: new CreateWalletAccountUseCase(walletRepository),
+            recordTransaction: new RecordWalletTransactionUseCase(walletRepository),
+            list: new ListWalletUseCase(walletRepository),
           },
         }
       : {}),

--- a/packages/goal/src/server/infrastructure/index.ts
+++ b/packages/goal/src/server/infrastructure/index.ts
@@ -30,6 +30,8 @@ export type {
   IGoalFolderRepository,
   IGoalRecordRepository,
   IGoalRepository,
+  IRelationRepository,
+  IWalletRepository,
 } from '../domain';
 export type { GoalWriteTransactionRunner } from '../application/use-cases/commands/goal-write-support';
 export type { IHabitRepository } from '../application/use-cases/commands/habit.use-cases';

--- a/packages/goal/src/server/infrastructure/prisma.ts
+++ b/packages/goal/src/server/infrastructure/prisma.ts
@@ -15,6 +15,8 @@ import {
   GoalPrismaRepository,
   GoalRecordPrismaRepository,
   PrismaGoalWriteTransactionRunner,
+  RelationPrismaRepository,
+  WalletPrismaRepository,
 } from './adapters/prisma';
 import { PrismaHabitRepository } from './adapters/prisma/prisma-habit.repository';
 import { createGoalScheduleExecutionSource } from './schedule-execution-source';
@@ -28,6 +30,8 @@ import type {
   IGoalFolderRepository,
   IGoalRecordRepository,
   IGoalRepository,
+  IRelationRepository,
+  IWalletRepository,
 } from '../domain';
 import type { IHabitRepository } from '../application/use-cases/commands/habit.use-cases';
 import type { GoalWriteTransactionRunner } from '../application/use-cases/commands/goal-write-support';
@@ -46,6 +50,10 @@ import type { GoalWriteTransactionRunner } from '../application/use-cases/comman
  * `habitRepository` is optional because PowerSync has no habit adapter;
  * only the Prisma lane supplies it.
  * `habitRepository` 是可选的，因为 PowerSync 没有习惯适配器；仅 Prisma 一条线提供它。
+ *
+ * `relationRepository`/`walletRepository` are optional for the same reason:
+ * PowerSync stays default-absent (no fake adapters are created).
+ * `relationRepository`/`walletRepository` 同理可选：PowerSync 保持缺省，不伪造实现。
  */
 export interface GoalRepositorySet {
   readonly goalRepository: IGoalRepository;
@@ -54,6 +62,10 @@ export interface GoalRepositorySet {
   readonly focusModeRepository: IFocusModeRepository;
   readonly goalWriteTransactionRunner: GoalWriteTransactionRunner;
   readonly habitRepository?: IHabitRepository;
+  /** R5：关系仓储（仅 Prisma 提供）/ Relation repository (Prisma lane only). */
+  readonly relationRepository?: IRelationRepository;
+  /** R7：钱包仓储（仅 Prisma 提供）/ Wallet repository (Prisma lane only). */
+  readonly walletRepository?: IWalletRepository;
 }
 
 /**
@@ -90,6 +102,8 @@ export function createGoalPrismaModule(
     focusModeRepository,
     goalWriteTransactionRunner,
     habitRepository,
+    relationRepository,
+    walletRepository,
   } = createGoalPrismaRepositories(db);
   return createGoalModule({
     goalRepository,
@@ -100,6 +114,8 @@ export function createGoalPrismaModule(
     taskBindingReadPort: options.taskBindingReadPort,
     runtimeContributions: options?.runtimeContributions,
     habitRepository,
+    relationRepository,
+    walletRepository,
   });
 }
 
@@ -126,6 +142,10 @@ export function createGoalPrismaRepositories(db: PrismaClient): GoalRepositorySe
     goalWriteTransactionRunner: new PrismaGoalWriteTransactionRunner(db),
     // R4：习惯仓储（Habit 模块）
     habitRepository: new PrismaHabitRepository(db),
+    // R5：关系仓储（Relation 模块）
+    relationRepository: new RelationPrismaRepository(db),
+    // R7：钱包仓储（Wallet 外部模块）
+    walletRepository: new WalletPrismaRepository(db),
   };
 }
 

--- a/tools/governance/README.md
+++ b/tools/governance/README.md
@@ -1,5 +1,21 @@
 # Governance tools
 
+## Package-Internal Boundary: `@memoflow/database`
+
+`package-internal-boundary-audit.mjs` is the fail-closed gate: `server/domain` and
+`server/application` production code must not import `@memoflow/database` (or any other
+Prisma concrete code). Application/Domain consume Port only; Prisma concrete code belongs
+to Infrastructure. DB deps are allowed only in `server/infrastructure`, host runtime
+composers (`apps/*/src/runtime`) and test fixtures (`.spec.ts` / `.test.ts` / `__tests__`).
+
+`server/domain` 与 `server/application` 的生产代码禁止 import `@memoflow/database`（及其它
+Prisma 具体实现）。Application/Domain 只消费 Port；Prisma 具体实现属于 Infrastructure。
+DB 依赖只允许出现在 `server/infrastructure`、宿主 runtime composer
+（`apps/*/src/runtime`）与测试 fixture（`.spec.ts` / `.test.ts` / `__tests__`）中。
+
+The check lives in `lib/package-internal-boundary.mjs` (pure function, shared with the
+CLI and unit tests); the rule set is defined in `package-internal-boundary-audit.mjs`.
+
 ## Dual Registry
 
 - **Machine source of truth**: [`dual-registry.json`](./dual-registry.json)

--- a/tools/governance/README.md
+++ b/tools/governance/README.md
@@ -1,17 +1,19 @@
 # Governance tools
 
-## Package-Internal Boundary: `@memoflow/database`
+## Package-Internal Boundary: `@memoflow/database` & `@prisma/client`
 
 `package-internal-boundary-audit.mjs` is the fail-closed gate: `server/domain` and
 `server/application` production code must not import `@memoflow/database` or any of its
-exported subpaths (e.g. `@memoflow/database/prisma`). Application/Domain consume Port only;
-Prisma concrete code (exposed through `@memoflow/database`) belongs to Infrastructure. DB
+exported subpaths (e.g. `@memoflow/database/prisma`), nor `@prisma/client` directly.
+Application/Domain consume Port only; Prisma concrete code (exposed through
+`@memoflow/database`, backed by `@prisma/client`) belongs to Infrastructure. DB
 deps are allowed only in `server/infrastructure`, host runtime composers
 (`apps/*/src/runtime`) and test fixtures (`.spec.ts` / `.test.ts` / `__tests__`).
 
 `server/domain` 与 `server/application` 的生产代码禁止 import `@memoflow/database` 及其所有
-导出的子路径（如 `@memoflow/database/prisma`）。Application/Domain 只消费 Port；Prisma
-具体实现（经 `@memoflow/database` 暴露）属于 Infrastructure。DB 依赖只允许出现在
+导出的子路径（如 `@memoflow/database/prisma`），也禁止直接 import `@prisma/client`。
+Application/Domain 只消费 Port；Prisma 具体实现（经 `@memoflow/database` 暴露、由
+`@prisma/client` 支撑）属于 Infrastructure。DB 依赖只允许出现在
 `server/infrastructure`、宿主 runtime composer（`apps/*/src/runtime`）与测试
 fixture（`.spec.ts` / `.test.ts` / `__tests__`）中。
 

--- a/tools/governance/README.md
+++ b/tools/governance/README.md
@@ -3,18 +3,28 @@
 ## Package-Internal Boundary: `@memoflow/database`
 
 `package-internal-boundary-audit.mjs` is the fail-closed gate: `server/domain` and
-`server/application` production code must not import `@memoflow/database` (or any other
-Prisma concrete code). Application/Domain consume Port only; Prisma concrete code belongs
-to Infrastructure. DB deps are allowed only in `server/infrastructure`, host runtime
-composers (`apps/*/src/runtime`) and test fixtures (`.spec.ts` / `.test.ts` / `__tests__`).
+`server/application` production code must not import `@memoflow/database` or any of its
+exported subpaths (e.g. `@memoflow/database/prisma`). Application/Domain consume Port only;
+Prisma concrete code (exposed through `@memoflow/database`) belongs to Infrastructure. DB
+deps are allowed only in `server/infrastructure`, host runtime composers
+(`apps/*/src/runtime`) and test fixtures (`.spec.ts` / `.test.ts` / `__tests__`).
 
-`server/domain` 与 `server/application` 的生产代码禁止 import `@memoflow/database`（及其它
-Prisma 具体实现）。Application/Domain 只消费 Port；Prisma 具体实现属于 Infrastructure。
-DB 依赖只允许出现在 `server/infrastructure`、宿主 runtime composer
-（`apps/*/src/runtime`）与测试 fixture（`.spec.ts` / `.test.ts` / `__tests__`）中。
+`server/domain` 与 `server/application` 的生产代码禁止 import `@memoflow/database` 及其所有
+导出的子路径（如 `@memoflow/database/prisma`）。Application/Domain 只消费 Port；Prisma
+具体实现（经 `@memoflow/database` 暴露）属于 Infrastructure。DB 依赖只允许出现在
+`server/infrastructure`、宿主 runtime composer（`apps/*/src/runtime`）与测试
+fixture（`.spec.ts` / `.test.ts` / `__tests__`）中。
 
 The check lives in `lib/package-internal-boundary.mjs` (pure function, shared with the
 CLI and unit tests); the rule set is defined in `package-internal-boundary-audit.mjs`.
+
+The matcher covers `from '…'`, bare side-effect `import '…'`, `import type … from '…'` and
+dynamic `import('…')`. Comment-interleaved forms (e.g. `import /* x */ '@memoflow/database'`)
+are not matched — keep imports in the canonical forms above.
+
+匹配器覆盖 `from '…'`、裸副作用 `import '…'`、`import type … from '…'` 与动态
+`import('…')`。注释穿插形式（如 `import /* x */ '@memoflow/database'`）不会被匹配——请保持
+导入使用上述规范形式。
 
 ## Dual Registry
 

--- a/tools/governance/__tests__/package-internal-boundary.test.mjs
+++ b/tools/governance/__tests__/package-internal-boundary.test.mjs
@@ -8,13 +8,13 @@ import {
 const APPLICATION_RULE = {
   layer: 'server/application',
   forbidden: ['server/transport', 'server/infrastructure', 'client', 'electron', 'api'],
-  forbiddenExternalSpecifiers: ['@memoflow/database'],
+  forbiddenExternalSpecifiers: ['@memoflow/database', '@prisma/client'],
 };
 
 const DOMAIN_RULE = {
   layer: 'server/domain',
   forbidden: ['server/application', 'server/transport', 'server/infrastructure', 'client', 'electron', 'api'],
-  forbiddenExternalSpecifiers: ['@memoflow/database'],
+  forbiddenExternalSpecifiers: ['@memoflow/database', '@prisma/client'],
 };
 
 describe('findBoundaryViolations — forbidden external @memoflow/database', () => {
@@ -127,6 +127,37 @@ describe('findBoundaryViolations — forbidden external @memoflow/database', () 
     expect(violations).toHaveLength(1);
     expect(violations[0].specifier).toBe('@memoflow/database/prisma');
   });
+
+  it('flags `import { PrismaClient } from "@prisma/client"` in server/application', () => {
+    const content = "import { PrismaClient } from '@prisma/client';\n\nexport const create = async (db: PrismaClient) => db.user.findMany();\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      file: 'packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts',
+      line: 1,
+      layer: 'server/application',
+      specifier: '@prisma/client',
+    });
+    expect(violations[0].message).toContain("forbidden external specifier '@prisma/client'");
+  });
+
+  it('flags `import { PrismaClient } from "@prisma/client"` in server/domain', () => {
+    const content = "import { PrismaClient } from '@prisma/client';\n\nexport const x: PrismaClient | null = null;\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/domain/repositories/i-repository.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      layer: 'server/domain',
+      specifier: '@prisma/client',
+    });
+  });
 });
 
 describe('findBoundaryViolations — positive cases', () => {
@@ -180,6 +211,18 @@ describe('findBoundaryViolations — positive cases', () => {
 
   it('allows `@memoflow/database` in server/infrastructure (rule has no forbidden external specifiers)', () => {
     const content = "import { prisma } from '@memoflow/database';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/infrastructure/adapters/prisma.ts',
+      layer: 'server/infrastructure',
+      forbidden: ['client', 'electron', 'api'],
+      forbiddenExternalSpecifiers: [],
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows `@prisma/client` in server/infrastructure (rule has no forbidden external specifiers)', () => {
+    const content = "import { PrismaClient } from '@prisma/client';\n";
     const violations = findBoundaryViolations({
       content,
       relPath: 'packages/foo/src/server/infrastructure/adapters/prisma.ts',

--- a/tools/governance/__tests__/package-internal-boundary.test.mjs
+++ b/tools/governance/__tests__/package-internal-boundary.test.mjs
@@ -61,6 +61,34 @@ describe('findBoundaryViolations — forbidden external @memoflow/database', () 
     expect(violations).toHaveLength(1);
     expect(violations[0].specifier).toBe('@memoflow/database');
   });
+
+  it('flags bare side-effect `import "@memoflow/database"` in server/application', () => {
+    const content = "import '@memoflow/database';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/application/bootstrap-db.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      file: 'packages/foo/src/server/application/bootstrap-db.ts',
+      line: 1,
+      layer: 'server/application',
+      specifier: '@memoflow/database',
+    });
+  });
+
+  it('flags bare side-effect `import "@memoflow/database"` in server/domain', () => {
+    const content = "import '@memoflow/database';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/domain/setup.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].layer).toBe('server/domain');
+    expect(violations[0].specifier).toBe('@memoflow/database');
+  });
 });
 
 describe('findBoundaryViolations — positive cases', () => {
@@ -88,6 +116,26 @@ describe('findBoundaryViolations — positive cases', () => {
       content,
       relPath: 'packages/goal/src/server/domain/repositories/i-relation-repository.ts',
       ...DOMAIN_RULE,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows bare side-effect `import "@memoflow/utils"` in server/domain', () => {
+    const content = "import '@memoflow/utils';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/domain/side-effect.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows bare side-effect `import "@memoflow/utils"` in server/application', () => {
+    const content = "import '@memoflow/utils';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/application/side-effect.ts',
+      ...APPLICATION_RULE,
     });
     expect(violations).toEqual([]);
   });

--- a/tools/governance/__tests__/package-internal-boundary.test.mjs
+++ b/tools/governance/__tests__/package-internal-boundary.test.mjs
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findBoundaryViolations,
+  getWithinPackageLayer,
+  shouldSkipSourceFile,
+} from '../lib/package-internal-boundary.mjs';
+
+const APPLICATION_RULE = {
+  layer: 'server/application',
+  forbidden: ['server/transport', 'server/infrastructure', 'client', 'electron', 'api'],
+  forbiddenExternalSpecifiers: ['@memoflow/database'],
+};
+
+const DOMAIN_RULE = {
+  layer: 'server/domain',
+  forbidden: ['server/application', 'server/transport', 'server/infrastructure', 'client', 'electron', 'api'],
+  forbiddenExternalSpecifiers: ['@memoflow/database'],
+};
+
+describe('findBoundaryViolations — forbidden external @memoflow/database', () => {
+  it('flags `import type { PrismaClient } from "@memoflow/database"` in server/application', () => {
+    const content = [
+      "import type { PrismaClient } from '@memoflow/database';",
+      '',
+      "export const create = async (db: PrismaClient) => db.user.findMany();",
+    ].join('\n');
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      file: 'packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts',
+      line: 1,
+      layer: 'server/application',
+      specifier: '@memoflow/database',
+    });
+  });
+
+  it('flags `import { PrismaClient } from "@memoflow/database"` in server/domain', () => {
+    const content = "import { PrismaClient } from '@memoflow/database';\n\nexport const x: PrismaClient | null = null;\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/domain/repositories/i-repository.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].layer).toBe('server/domain');
+    expect(violations[0].specifier).toBe('@memoflow/database');
+    expect(violations[0].message).toContain("forbidden external specifier '@memoflow/database'");
+  });
+
+  it('flags dynamic `import("@memoflow/database")` in server/application', () => {
+    const content = "const db = await import('@memoflow/database');\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/application/lazy.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe('@memoflow/database');
+  });
+});
+
+describe('findBoundaryViolations — positive cases', () => {
+  it('allows server/application importing domain Port / contracts / utils', () => {
+    const content = [
+      "import type { IRelationRepository, RelationDTO } from '../../domain/repositories';",
+      "import { SomeContractType } from '@memoflow/contracts/goal';",
+      "import { someUtil } from '@memoflow/utils';",
+      "import { localHelper } from './local-helper';",
+    ].join('\n');
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows server/domain importing from itself and shared layers', () => {
+    const content = [
+      "import type { SubjectRef } from '../aggregates/subject';",
+      "import { ValueObject } from '@memoflow/domain-shared';",
+    ].join('\n');
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/goal/src/server/domain/repositories/i-relation-repository.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('shouldSkipSourceFile — test fixture exclusion', () => {
+  it('skips *.spec.ts, *.test.ts and __tests__ paths', () => {
+    expect(shouldSkipSourceFile('relation.use-cases.spec.ts', '/x/relation.use-cases.spec.ts')).toBe(true);
+    expect(shouldSkipSourceFile('prisma.test.ts', '/x/prisma.test.ts')).toBe(true);
+    expect(shouldSkipSourceFile('index.ts', '/x/__tests__/index.ts')).toBe(true);
+  });
+
+  it('does not skip production files (fixture exclusion only)', () => {
+    expect(shouldSkipSourceFile('relation.use-cases.ts', '/x/relation.use-cases.ts')).toBe(false);
+    expect(shouldSkipSourceFile('prisma.repository.ts', '/x/infrastructure/prisma.repository.ts')).toBe(false);
+  });
+});
+
+describe('getWithinPackageLayer', () => {
+  it('resolves in-package server layer targets', () => {
+    expect(getWithinPackageLayer('@/server/infrastructure')).toBe('server/infrastructure');
+    expect(getWithinPackageLayer('../../server/infrastructure')).toBe('server/infrastructure');
+    expect(getWithinPackageLayer('@/server/transport')).toBe('server/transport');
+  });
+
+  it('returns null for external specifiers', () => {
+    expect(getWithinPackageLayer('@memoflow/database')).toBeNull();
+    expect(getWithinPackageLayer('@memoflow/contracts/goal')).toBeNull();
+  });
+});

--- a/tools/governance/__tests__/package-internal-boundary.test.mjs
+++ b/tools/governance/__tests__/package-internal-boundary.test.mjs
@@ -89,6 +89,44 @@ describe('findBoundaryViolations — forbidden external @memoflow/database', () 
     expect(violations[0].layer).toBe('server/domain');
     expect(violations[0].specifier).toBe('@memoflow/database');
   });
+
+  it('flags subpath `import { prisma } from "@memoflow/database/prisma"` in server/application', () => {
+    const content = "import { prisma } from '@memoflow/database/prisma';\n\nexport const client = prisma;\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/application/db/prisma.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      file: 'packages/foo/src/server/application/db/prisma.ts',
+      layer: 'server/application',
+      specifier: '@memoflow/database/prisma',
+    });
+    expect(violations[0].message).toContain("forbidden external specifier '@memoflow/database/prisma'");
+  });
+
+  it('flags deeper subpath `import type ... from "@memoflow/database/prisma/generated"` in server/domain', () => {
+    const content = "import type { PrismaClient } from '@memoflow/database/prisma/generated';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/domain/repositories/i-repository.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe('@memoflow/database/prisma/generated');
+  });
+
+  it('flags bare side-effect `import "@memoflow/database/prisma"` in server/domain', () => {
+    const content = "import '@memoflow/database/prisma';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/domain/setup.ts',
+      ...DOMAIN_RULE,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe('@memoflow/database/prisma');
+  });
 });
 
 describe('findBoundaryViolations — positive cases', () => {
@@ -135,6 +173,31 @@ describe('findBoundaryViolations — positive cases', () => {
     const violations = findBoundaryViolations({
       content,
       relPath: 'packages/goal/src/server/application/side-effect.ts',
+      ...APPLICATION_RULE,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows `@memoflow/database` in server/infrastructure (rule has no forbidden external specifiers)', () => {
+    const content = "import { prisma } from '@memoflow/database';\n";
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/infrastructure/adapters/prisma.ts',
+      layer: 'server/infrastructure',
+      forbidden: ['client', 'electron', 'api'],
+      forbiddenExternalSpecifiers: [],
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('does not flag specifiers that merely share a prefix with the forbidden root', () => {
+    const content = [
+      "import { x } from '@memoflow/databaseX';",
+      "import { schema } from '@memoflow/database-schema';",
+    ].join('\n');
+    const violations = findBoundaryViolations({
+      content,
+      relPath: 'packages/foo/src/server/application/unrelated.ts',
       ...APPLICATION_RULE,
     });
     expect(violations).toEqual([]);

--- a/tools/governance/lib/package-internal-boundary.mjs
+++ b/tools/governance/lib/package-internal-boundary.mjs
@@ -30,7 +30,7 @@ export const LEGACY_LAYER_NAMES = new Set([
   'electron-entry',
 ]);
 
-const IMPORT_SPECIFIER_PATTERN = /(?:from\s+['"]|import\s*\(\s*['"])([^'"]+)['"]/g;
+const IMPORT_SPECIFIER_PATTERN = /(?:from\s+['"]|import\s*\(\s*['"]|import\s+['"])([^'"]+)['"]/g;
 
 /**
  * Determine whether an entry inside a walked layer directory should be skipped
@@ -90,8 +90,8 @@ function lineAt(content, index) {
 
 /**
  * Scan file content for layering violations against `rule`.
- * Covers `from '…'`, dynamic `import('…')` and `import type … from '…'`
- * (all matched by the shared pattern).
+ * Covers `from '…'`, bare side-effect `import '…'`, dynamic `import('…')`
+ * and `import type … from '…'` (all matched by the shared pattern).
  *
  * @param {object} input
  * @param {string} input.content  file source

--- a/tools/governance/lib/package-internal-boundary.mjs
+++ b/tools/governance/lib/package-internal-boundary.mjs
@@ -1,0 +1,136 @@
+/**
+ * Package-Internal Boundary audit (pure logic).
+ *
+ * Extracted so the audit CLI and unit tests share the same specifier checks.
+ * Enforces in-package layering (e.g. `server/application` must not import
+ * `server/infrastructure`) plus exact forbidden external specifiers
+ * (`server/domain` / `server/application` must not import `@memoflow/database`:
+ * Application/Domain consume Port only; Prisma concrete code belongs to
+ * Infrastructure — Application/Domain 只消费 Port；Prisma 具体实现属于 Infrastructure).
+ */
+
+import { extname } from 'node:path';
+
+export const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.cts']);
+export const SERVER_SUBLAYERS = new Set(['domain', 'application', 'transport', 'infrastructure']);
+export const LEGACY_LAYER_NAMES = new Set([
+  'domain-server',
+  'domain-client',
+  'domain-shared',
+  'application-server',
+  'application-client',
+  'client',
+  'electron',
+  'infrastructure-server',
+  'infrastructure-client',
+  'controllers',
+  'api',
+  'contracts',
+  'mocks',
+  'electron-entry',
+]);
+
+const IMPORT_SPECIFIER_PATTERN = /(?:from\s+['"]|import\s*\(\s*['"])([^'"]+)['"]/g;
+
+/**
+ * Determine whether an entry inside a walked layer directory should be skipped
+ * from the audit. Mirrors the historical CLI behavior: non-source files,
+ * `*.spec.ts` / `*.test.ts` and anything under `__tests__` are test fixtures,
+ * not production layering violations.
+ */
+export function shouldSkipSourceFile(entryName, fullPath) {
+  if (!SOURCE_EXTENSIONS.has(extname(entryName))) return true;
+  if (entryName.endsWith('.test.ts') || entryName.endsWith('.spec.ts')) return true;
+  if (fullPath.includes('__tests__')) return true;
+  return false;
+}
+
+/**
+ * Map an import specifier to the in-package layer it targets, or `null` for
+ * external specifiers / non-layer relative paths.
+ */
+export function getWithinPackageLayer(specifier) {
+  if (specifier.startsWith('@/')) {
+    return getLayerFromParts(specifier.slice(2).split('/'));
+  }
+
+  if (specifier.startsWith('../') || specifier.startsWith('./')) {
+    const parts = specifier.split('/').filter((part) => part !== '.' && part !== '..');
+    return getLayerFromParts(parts);
+  }
+
+  return null;
+}
+
+function getLayerFromParts(parts) {
+  if (parts.length === 0) return null;
+
+  if (parts[0] === 'server' && SERVER_SUBLAYERS.has(parts[1])) {
+    return `server/${parts[1]}`;
+  }
+
+  if (SERVER_SUBLAYERS.has(parts[0])) {
+    return `server/${parts[0]}`;
+  }
+
+  if (LEGACY_LAYER_NAMES.has(parts[0])) {
+    return parts[0];
+  }
+
+  return null;
+}
+
+function lineAt(content, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (content[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+/**
+ * Scan file content for layering violations against `rule`.
+ * Covers `from '…'`, dynamic `import('…')` and `import type … from '…'`
+ * (all matched by the shared pattern).
+ *
+ * @param {object} input
+ * @param {string} input.content  file source
+ * @param {string} input.relPath  repo-relative path (for reporting)
+ * @param {string} input.layer    current rule layer (`server/domain` …)
+ * @param {string[]} input.forbidden             forbidden in-package layer targets
+ * @param {string[]} [input.forbiddenExternalSpecifiers] exact forbidden external specifiers
+ * @returns {Array<{file:string, line:number, layer:string, specifier:string, message:string}>}
+ */
+export function findBoundaryViolations({
+  content,
+  relPath,
+  layer,
+  forbidden,
+  forbiddenExternalSpecifiers = [],
+}) {
+  const violations = [];
+  let match;
+  while ((match = IMPORT_SPECIFIER_PATTERN.exec(content)) !== null) {
+    const specifier = match[1];
+    const line = lineAt(content, match.index);
+    const withinPackageTarget = getWithinPackageLayer(specifier);
+    if (withinPackageTarget && forbidden.includes(withinPackageTarget)) {
+      violations.push({
+        file: relPath,
+        line,
+        layer,
+        specifier,
+        message: `${layer} must not import from ${withinPackageTarget} (found: '${specifier}')`,
+      });
+    } else if (forbiddenExternalSpecifiers.includes(specifier)) {
+      violations.push({
+        file: relPath,
+        line,
+        layer,
+        specifier,
+        message: `${layer} must not import forbidden external specifier '${specifier}' (Application/Domain consume Port only; Prisma concrete code belongs to Infrastructure)`,
+      });
+    }
+  }
+  return violations;
+}

--- a/tools/governance/lib/package-internal-boundary.mjs
+++ b/tools/governance/lib/package-internal-boundary.mjs
@@ -5,7 +5,8 @@
  * Enforces in-package layering (e.g. `server/application` must not import
  * `server/infrastructure`) plus forbidden external specifier roots
  * (`server/domain` / `server/application` must not import `@memoflow/database`
- * or any of its exported subpaths like `@memoflow/database/prisma`:
+ * or any of its exported subpaths like `@memoflow/database/prisma`, nor
+ * `@prisma/client` directly:
  * Application/Domain consume Port only; Prisma concrete code belongs to
  * Infrastructure — Application/Domain 只消费 Port；Prisma 具体实现属于 Infrastructure).
  */

--- a/tools/governance/lib/package-internal-boundary.mjs
+++ b/tools/governance/lib/package-internal-boundary.mjs
@@ -3,8 +3,9 @@
  *
  * Extracted so the audit CLI and unit tests share the same specifier checks.
  * Enforces in-package layering (e.g. `server/application` must not import
- * `server/infrastructure`) plus exact forbidden external specifiers
- * (`server/domain` / `server/application` must not import `@memoflow/database`:
+ * `server/infrastructure`) plus forbidden external specifier roots
+ * (`server/domain` / `server/application` must not import `@memoflow/database`
+ * or any of its exported subpaths like `@memoflow/database/prisma`:
  * Application/Domain consume Port only; Prisma concrete code belongs to
  * Infrastructure — Application/Domain 只消费 Port；Prisma 具体实现属于 Infrastructure).
  */
@@ -31,6 +32,19 @@ export const LEGACY_LAYER_NAMES = new Set([
 ]);
 
 const IMPORT_SPECIFIER_PATTERN = /(?:from\s+['"]|import\s*\(\s*['"]|import\s+['"])([^'"]+)['"]/g;
+
+/**
+ * Fail-closed match for a forbidden external specifier. A forbidden root
+ * (`@memoflow/database`) also matches every exported subpath
+ * (`@memoflow/database/prisma`, `@memoflow/database/...`) so subpath imports
+ * cannot bypass the rule. Unrelated specifiers keep exact matching
+ * (`@memoflow/databaseX` is not touched).
+ */
+export function isForbiddenExternalSpecifier(specifier, forbiddenExternalSpecifiers) {
+  return forbiddenExternalSpecifiers.some(
+    (forbidden) => specifier === forbidden || specifier.startsWith(`${forbidden}/`),
+  );
+}
 
 /**
  * Determine whether an entry inside a walked layer directory should be skipped
@@ -98,7 +112,8 @@ function lineAt(content, index) {
  * @param {string} input.relPath  repo-relative path (for reporting)
  * @param {string} input.layer    current rule layer (`server/domain` …)
  * @param {string[]} input.forbidden             forbidden in-package layer targets
- * @param {string[]} [input.forbiddenExternalSpecifiers] exact forbidden external specifiers
+ * @param {string[]} [input.forbiddenExternalSpecifiers] forbidden external specifier roots
+ *   (subpaths of a root, e.g. `@memoflow/database/prisma`, are forbidden too)
  * @returns {Array<{file:string, line:number, layer:string, specifier:string, message:string}>}
  */
 export function findBoundaryViolations({
@@ -122,7 +137,7 @@ export function findBoundaryViolations({
         specifier,
         message: `${layer} must not import from ${withinPackageTarget} (found: '${specifier}')`,
       });
-    } else if (forbiddenExternalSpecifiers.includes(specifier)) {
+    } else if (isForbiddenExternalSpecifier(specifier, forbiddenExternalSpecifiers)) {
       violations.push({
         file: relPath,
         line,

--- a/tools/governance/package-internal-boundary-audit.mjs
+++ b/tools/governance/package-internal-boundary-audit.mjs
@@ -23,7 +23,7 @@ const FORBIDDEN_LEGACY_LAYERS = [
   'electron-entry',
 ];
 
-const FORBIDDEN_DB_SPECIFIERS = ['@memoflow/database'];
+const FORBIDDEN_DB_SPECIFIERS = ['@memoflow/database', '@prisma/client'];
 
 const GOVERNANCE_LAYER_RULES = [
   {

--- a/tools/governance/package-internal-boundary-audit.mjs
+++ b/tools/governance/package-internal-boundary-audit.mjs
@@ -8,7 +8,8 @@
  */
 
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join, relative, extname } from 'node:path';
+import { join, relative } from 'node:path';
+import { findBoundaryViolations, shouldSkipSourceFile } from './lib/package-internal-boundary.mjs';
 
 const ROOT = join(import.meta.dirname, '..', '..');
 const PACKAGES_DIR = join(ROOT, 'packages');
@@ -22,6 +23,8 @@ const FORBIDDEN_LEGACY_LAYERS = [
   'electron-entry',
 ];
 
+const FORBIDDEN_DB_SPECIFIERS = ['@memoflow/database'];
+
 const GOVERNANCE_LAYER_RULES = [
   {
     layer: 'server/domain',
@@ -34,6 +37,7 @@ const GOVERNANCE_LAYER_RULES = [
       'api',
       ...FORBIDDEN_LEGACY_LAYERS,
     ],
+    forbiddenExternalSpecifiers: FORBIDDEN_DB_SPECIFIERS,
   },
   {
     layer: 'server/application',
@@ -45,6 +49,7 @@ const GOVERNANCE_LAYER_RULES = [
       'api',
       ...FORBIDDEN_LEGACY_LAYERS,
     ],
+    forbiddenExternalSpecifiers: FORBIDDEN_DB_SPECIFIERS,
   },
   {
     layer: 'server/transport',
@@ -83,24 +88,6 @@ const EXCEPTIONS = new Set([
 ]);
 
 const KNOWN_VIOLATIONS = new Set();
-const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.cts']);
-const SERVER_SUBLAYERS = new Set(['domain', 'application', 'transport', 'infrastructure']);
-const LEGACY_LAYER_NAMES = new Set([
-  'domain-server',
-  'domain-client',
-  'domain-shared',
-  'application-server',
-  'application-client',
-  'client',
-  'electron',
-  'infrastructure-server',
-  'infrastructure-client',
-  'controllers',
-  'api',
-  'contracts',
-  'mocks',
-  'electron-entry',
-]);
 
 function main() {
   const packages = readdirSync(PACKAGES_DIR, { withFileTypes: true })
@@ -128,7 +115,7 @@ function main() {
   const uniqueViolations = [];
   const seen = new Set();
   for (const violation of violations) {
-    const key = `${violation.file}: ${violation.message}`;
+    const key = `${violation.file}:${violation.line}: ${violation.message}`;
     if (seen.has(key)) continue;
     seen.add(key);
 
@@ -142,7 +129,7 @@ function main() {
   if (uniqueViolations.length > 0) {
     console.error(`❌ Package-Internal Boundary Audit FAILED — ${uniqueViolations.length} new violation(s):\n`);
     for (const violation of uniqueViolations) {
-      console.error(`  ${violation.file}: ${violation.message}`);
+      console.error(`  ${violation.file}:${violation.line}: ${violation.message}`);
     }
     console.error('\nSee docs/standards/architecture.md for package-internal layering rules.');
     process.exit(1);
@@ -163,65 +150,21 @@ function walkLayer(dir, rule, violations, countFile) {
     }
     if (!entry.isFile()) continue;
 
-    const ext = extname(entry.name);
-    if (!SOURCE_EXTENSIONS.has(ext)) continue;
-    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue;
-    if (fullPath.includes('__tests__')) continue;
+    if (shouldSkipSourceFile(entry.name, fullPath)) continue;
 
     countFile();
     const content = readFileSync(fullPath, 'utf8').replace(/^﻿/, '');
     const relPath = relative(ROOT, fullPath).replaceAll('\\', '/');
-    checkImports(content, relPath, rule, violations);
+    violations.push(
+      ...findBoundaryViolations({
+        content,
+        relPath,
+        layer: rule.layer,
+        forbidden: rule.forbidden,
+        forbiddenExternalSpecifiers: rule.forbiddenExternalSpecifiers,
+      }),
+    );
   }
-}
-
-function checkImports(content, relPath, rule, violations) {
-  const importPattern = /(?:from\s+['"]|import\s*\(\s*['"])([^'"]+)['"]/g;
-
-  let match;
-  while ((match = importPattern.exec(content)) !== null) {
-    const specifier = match[1];
-    const withinPackageTarget = getWithinPackageLayer(specifier);
-    if (!withinPackageTarget) continue;
-
-    if (rule.forbidden.includes(withinPackageTarget)) {
-      violations.push({
-        file: relPath,
-        message: `${rule.layer} must not import from ${withinPackageTarget} (found: '${specifier}')`,
-      });
-    }
-  }
-}
-
-function getWithinPackageLayer(specifier) {
-  if (specifier.startsWith('@/')) {
-    return getLayerFromParts(specifier.slice(2).split('/'));
-  }
-
-  if (specifier.startsWith('../') || specifier.startsWith('./')) {
-    const parts = specifier.split('/').filter((part) => part !== '.' && part !== '..');
-    return getLayerFromParts(parts);
-  }
-
-  return null;
-}
-
-function getLayerFromParts(parts) {
-  if (parts.length === 0) return null;
-
-  if (parts[0] === 'server' && SERVER_SUBLAYERS.has(parts[1])) {
-    return `server/${parts[1]}`;
-  }
-
-  if (SERVER_SUBLAYERS.has(parts[0])) {
-    return `server/${parts[0]}`;
-  }
-
-  if (LEGACY_LAYER_NAMES.has(parts[0])) {
-    return parts[0];
-  }
-
-  return null;
 }
 
 main();

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -5277,6 +5277,26 @@
       ]
     },
     {
+      "path": "packages/data-portability/src/server/infrastructure/__tests__/prisma-adapters.surface.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/data-portability/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/data-portability/vitest.config.ts"
+      ]
+    },
+    {
+      "path": "packages/data-portability/src/server/infrastructure/__tests__/prisma-data-portability-import-store.test.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/data-portability/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/data-portability/vitest.config.ts"
+      ]
+    },
+    {
       "path": "packages/data-portability/src/server/infrastructure/powersync/__tests__/powersync-export-dependencies.test.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -9977,14 +9997,14 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 30
+      "fileCount": 32
     },
     {
       "id": "packages/data-portability/vitest.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 30
+      "fileCount": 32
     },
     {
       "id": "packages/database/vitest.config.ts",
@@ -10621,6 +10641,8 @@
       "packages/data-portability/src/server/application/use-cases/projections/to-timestamp-keep-boundary.surface.spec.ts",
       "packages/data-portability/src/server/infrastructure/__tests__/data-portability-module-partial-start.spec.ts",
       "packages/data-portability/src/server/infrastructure/__tests__/data-portability-repositories.surface.spec.ts",
+      "packages/data-portability/src/server/infrastructure/__tests__/prisma-adapters.surface.spec.ts",
+      "packages/data-portability/src/server/infrastructure/__tests__/prisma-data-portability-import-store.test.ts",
       "packages/data-portability/src/server/infrastructure/powersync/__tests__/powersync-export-dependencies.test.ts",
       "packages/data-portability/src/server/infrastructure/powersync/__tests__/powersync-import-store.test.ts",
       "packages/data-portability/src/server/infrastructure/powersync/__tests__/powersync-round-trip.test.ts",
@@ -10975,7 +10997,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 934,
+    "unit": 936,
     "integration": 25,
     "smoke": 2,
     "boundary-ipc": 9,

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -9763,6 +9763,14 @@
       "measurementCollectors": []
     },
     {
+      "path": "tools/governance/__tests__/package-internal-boundary.test.mjs",
+      "primarySuite": "governance",
+      "collectors": [
+        "tools/governance/vitest.config.ts"
+      ],
+      "measurementCollectors": []
+    },
+    {
       "path": "tools/governance/__tests__/scope-constraint.test.mjs",
       "primarySuite": "governance",
       "collectors": [
@@ -10326,7 +10334,7 @@
       "type": "primary",
       "suite": "governance",
       "runner": "vitest",
-      "fileCount": 5
+      "fileCount": 6
     },
     {
       "id": "test-system-v2:test",
@@ -11004,6 +11012,6 @@
     "boundary-main": 5,
     "e2e": 63,
     "perf": 4,
-    "governance": 30
+    "governance": 31
   }
 }

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -5798,6 +5798,17 @@
       ]
     },
     {
+      "path": "packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/goal/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/goal/vitest.config.ts",
+        "packages/goal/vitest.use-cases.config.ts"
+      ]
+    },
+    {
       "path": "packages/goal/src/server/application/use-cases/queries/__tests__/get-current-focus-mode.test.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -6284,6 +6295,28 @@
       ]
     },
     {
+      "path": "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/goal/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/goal/vitest.config.ts",
+        "packages/goal/vitest.mappers.config.ts"
+      ]
+    },
+    {
+      "path": "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/goal/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/goal/vitest.config.ts",
+        "packages/goal/vitest.mappers.config.ts"
+      ]
+    },
+    {
       "path": "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-weight-snapshot-mapper.additional.spec.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -6304,6 +6337,22 @@
         "packages/goal/vitest.config.ts",
         "packages/goal/vitest.mappers.config.ts"
       ]
+    },
+    {
+      "path": "packages/goal/src/server/infrastructure/adapters/prisma/relation-prisma.repository.integration.test.ts",
+      "primarySuite": "integration",
+      "collectors": [
+        "packages/goal/vitest.integration.config.ts"
+      ],
+      "measurementCollectors": []
+    },
+    {
+      "path": "packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.integration.test.ts",
+      "primarySuite": "integration",
+      "collectors": [
+        "packages/goal/vitest.integration.config.ts"
+      ],
+      "measurementCollectors": []
     },
     {
       "path": "packages/goal/src/server/infrastructure/build-task-name-keep-boundary.surface.spec.ts",
@@ -9963,35 +10012,35 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 90
+      "fileCount": 93
     },
     {
       "id": "packages/goal/vitest.integration.config.ts",
       "type": "primary",
       "suite": "integration",
       "runner": "vitest",
-      "fileCount": 2
+      "fileCount": 4
     },
     {
       "id": "packages/goal/vitest.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 90
+      "fileCount": 93
     },
     {
       "id": "packages/goal/vitest.use-cases.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 34
+      "fileCount": 35
     },
     {
       "id": "packages/goal/vitest.mappers.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 9
+      "fileCount": 11
     },
     {
       "id": "packages/governance/vitest.config.ts",
@@ -10617,6 +10666,7 @@
       "packages/goal/src/server/application/use-cases/commands/__tests__/update-goal-key-result.test.ts",
       "packages/goal/src/server/application/use-cases/commands/__tests__/update-goal-review.test.ts",
       "packages/goal/src/server/application/use-cases/commands/__tests__/update-goal.test.ts",
+      "packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts",
       "packages/goal/src/server/application/use-cases/queries/__tests__/get-current-focus-mode.test.ts",
       "packages/goal/src/server/application/use-cases/queries/__tests__/get-goal-aggregate.test.ts",
       "packages/goal/src/server/application/use-cases/queries/__tests__/get-goal-folder.test.ts",
@@ -10663,6 +10713,8 @@
       "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-goal-mapper.additional.spec.ts",
       "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-goal-mapper.spec.ts",
       "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-goal-record-mapper.spec.ts",
+      "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-relation.mapper.spec.ts",
+      "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-wallet.mapper.spec.ts",
       "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-weight-snapshot-mapper.additional.spec.ts",
       "packages/goal/src/server/infrastructure/adapters/prisma/mappers/prisma-weight-snapshot-mapper.spec.ts",
       "packages/goal/src/server/infrastructure/build-task-name-keep-boundary.surface.spec.ts",
@@ -10923,8 +10975,8 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 931,
-    "integration": 23,
+    "unit": 934,
+    "integration": 25,
     "smoke": 2,
     "boundary-ipc": 9,
     "boundary-main": 5,


### PR DESCRIPTION
Implements Phase 1 of docs/analysis/2026-08-13-architecture-refactor-review.md (based on ardanlabs/service + usememos/memos source verification).

**4 steps + 4 review rounds (PASS):**
- Step 1: Goal relation/wallet Prisma repos moved from application use-cases → infrastructure adapters (domain ports, mappers,  + Decimal preserved)
- Step 2: Data Portability Prisma adapters moved application → infrastructure (import store, transaction once, PowerSync parity)
- Step 3: AI backend executor now depends on 5 injected Application Ports (no create*PrismaModule/Prisma; one composed instance set)
- Step 4: fail-closed governance — Application/Domain forbidden @memoflow/database (+ subpaths) and @prisma/client; verified with real probes (exit 1)

**Review rounds**: R1 FAIL (2 P1) → fixed; R2 FAIL (1 P2) → fixed; R3 FAIL (1 P2) → fixed; R4 **PASS** (0 findings, 655 files 0 violations).

Tests: goal 203 use-cases + 26 mappers + 20 integration; dp 139; api 206; smoke 61; governance 56. No behavior change vs merge-base except restored executor closure predicate (matrix-tested).