### PR TITLE
feat(ai): Vue thin entry + default dispatch with restricted fallback (agent-host Step C+D)

### DIFF
--- a/apps/desktop/src/renderer/platform/di-app.ts
+++ b/apps/desktop/src/renderer/platform/di-app.ts
@@ -37,6 +37,7 @@ import {
   LOGOUT_HANDLER_KEY,
   PROFILE_LOCK_HANDLER_KEY,
   DESKTOP_ACCESS_SNAPSHOT_KEY,
+  ASSISTANT_SURFACE_KEY,
   defaultModuleCapsules,
 } from '@memoflow/app-vue/di';
 import { createDashboardIpcAdapter } from '@memoflow/app-vue/modules/dashboard/adapters';
@@ -73,7 +74,12 @@ export function installDesktopAppServices(app: App): void {
 
   app.provide(SETTING_SERVICE_KEY, createSettingIpcClient(resultIpcClient));
 
-  app.provide(AI_SERVICE_KEY, createAIIpcClient(resultIpcClient));
+  // Residual 351/Step D: dispatch first by default; host passes the policy
+  // explicitly (plan §3.2/§4.5).
+  app.provide(
+    AI_SERVICE_KEY,
+    createAIIpcClient(resultIpcClient, { dispatchPolicy: 'prefer_dispatch' }),
+  );
 
   app.provide(RULE_SERVICE_KEY, createGovernanceIpcClient(resultIpcClient));
 
@@ -82,6 +88,8 @@ export function installDesktopAppServices(app: App): void {
   app.provide(DASHBOARD_SERVICE_KEY, createDashboardIpcAdapter(resultIpcClient));
   // V2 shell capsule navigation (UI_REDESIGN_V2_PLAN §2.2 / Brief §12-4)
   app.provide(MODULE_CAPSULES_KEY, defaultModuleCapsules);
+  // Residual 349: Desktop renderer advertises the 'desktop' assistant surface.
+  app.provide(ASSISTANT_SURFACE_KEY, 'desktop');
 
   // Generic desktop bridge used by business IPC recovery and window controls.
   app.provide(DESKTOP_AUTH_API_KEY, bridge);

--- a/apps/web/src/platform/di-app.ts
+++ b/apps/web/src/platform/di-app.ts
@@ -25,6 +25,7 @@ import {
   DASHBOARD_SERVICE_KEY,
   MODULE_CAPSULES_KEY,
   LOGOUT_HANDLER_KEY,
+  ASSISTANT_SURFACE_KEY,
   defaultModuleCapsules,
   useAuthenticationStore,
 } from '@memoflow/app-vue/web-core';
@@ -83,7 +84,10 @@ const dataPortabilityService = createLazyService(async () => {
 
 const aiService = createLazyService(async () => {
   const { createAIHttpClient } = await import('@memoflow/ai/client');
-  return createAIHttpClient(resultHttpClient);
+  // Residual 351/Step D: dispatch first by default; host passes the policy
+  // explicitly (plan §3.2/§4.5). prefer_dispatch only falls back to legacy on
+  // definite dispatch-unavailable + zero observed events.
+  return createAIHttpClient(resultHttpClient, { dispatchPolicy: 'prefer_dispatch' });
 });
 
 const taskService = createLazyService(async () => {
@@ -113,6 +117,8 @@ export function installAppServices(app: App): void {
   app.provide(DASHBOARD_SERVICE_KEY, dashboardService);
   // V2 shell capsule navigation (UI_REDESIGN_V2_PLAN §2.2 / Brief §12-4)
   app.provide(MODULE_CAPSULES_KEY, defaultModuleCapsules);
+  // Residual 349: Web host advertises the 'web' assistant surface to shared Vue.
+  app.provide(ASSISTANT_SURFACE_KEY, 'web');
   app.provide(LOGOUT_HANDLER_KEY, async () => {
     const authStore = useAuthenticationStore();
     // Stop realtime sources first, then clear the identity cache (plan §3.1).

--- a/docs/architecture/adr/ADR-035-unified-assistant-agent-host.md
+++ b/docs/architecture/adr/ADR-035-unified-assistant-agent-host.md
@@ -8,7 +8,7 @@ tags:
   - plugin
 description: ADR-035 - 统一助手、Agent Host 与可插拔 Workflow、Turn Engine、Model Gateway 边界
 created: 2026-07-17T00:00:00
-updated: 2026-07-17T00:00:00
+updated: 2026-08-15T00:00:00
 ---
 
 # ADR-035: 统一助手与可插拔 Agent Host
@@ -199,6 +199,29 @@ ContextItem 携带来源、信任等级、敏感级别和 token 估算。Vault�
 - 本地/云端 fallback 不改变数据外传边界，不能静默发生。
 - 现有 LangGraph workflow 可以在不重写 Python graph 的前提下被 Host 包装。
 - 新增第二个 Turn Engine 后，无需修改 UI、业务模块或 Proposal/Executor contract。
+
+## 5.1 窄版本兼容例外（2026-08-15，plan §4.5 / Step D）
+
+产品 open-chat 的默认路径始终是 `dispatchAssistant`；legacy `streamMessage` 不是产品默认路径。
+唯一的窄版本兼容例外是 `AIClientService.dispatchAssistant` 内部的 version-compat adapter：
+
+- **允许条件（全部成立才 fallback 一次）**：command 为 `message` 且 profile 缺省或
+  `direct_turn`；dispatch 未产出任何 `AssistantEvent`（未收到 `run.started`）；错误码为稳定
+  `ASSISTANT_DISPATCH_UNAVAILABLE`（Web bootstrap 404/405/501；Desktop bridge/handler 在
+  START 接受前明确 `NOT_SUPPORTED/NOT_FOUND`）；`conversationId/content/providerId/model`
+  可无损映射。
+- **禁止条件（fail-closed）**：`pi_readonly`、proposal approve/revise/reject、`cancel_run`；
+  已收到任意事件；普通网络/timeout/abort/`STREAM_TERMINATED`；auth/validation/rate
+  limit/provider/Facade application error；protocol error（malformed frame、未知 event
+  type、done/result schema 错误）；Desktop START 接受后的 crash/sender destroy/stream error。
+- fallback 投影 `message.delta` / `message.completed`，保留 command runId 与持久化消息，
+  绝不伪造 `run.started`，不新增 fallback-specific 公共事件；命中只能通过内部 log/metric 观察。
+- `dispatchPolicy`（`prefer_dispatch` / `dispatch_only` / `legacy_only`）由 host composition
+  显式传入 client factory；生产缺省 `prefer_dispatch`，紧急回滚必须显式配置并记录 telemetry。
+- Vue 层不获得 `streamMessage` 依赖，不分支判断 transport，不展示 fallback-specific 产品事件。
+
+**移除条件**：旧 Server/Desktop host 全部升级到支持 dispatch 后，删除该 adapter 与
+`legacy_only` 开关；`streamMessage` 不长期作为双默认路径存在。
 
 ## 6. 相关资料
 

--- a/docs/architecture/ai-runtime-path-map.md
+++ b/docs/architecture/ai-runtime-path-map.md
@@ -12,16 +12,18 @@ updated: 2026-07-26T00:00:00
 # AI 运行路径地图
 
 > elegance plan **E4 / C1–C2**。产品 open-chat **不得**回退到 `streamMessage` 双路径。  
+> 唯一例外：`AIClientService` 内部的窄版本兼容 adapter（见下方 §① 例外），只对「dispatch 明确不可用 +
+> 零事件 + direct_turn message」生效。  
 > Dual 账本：[`../governance/dual-registry.md`](../governance/dual-registry.md)。  
 > 产品 plan：[`../plan/active/2026-07-17-unified-assistant-agent-host.md`](../plan/active/2026-07-17-unified-assistant-agent-host.md)（勿假绿 §20）。
 
 ## 三条路径（一眼）
 
-| # | 名称 | 主入口 | 持久化 / 事件 | 产品用途 |
-|---|------|--------|---------------|----------|
-| **①** | **Host open-chat** | `AIClientPort.dispatchAssistant` → HTTP SSE `/ai/assistant/dispatch/sse` 或 Desktop IPC | 会话消息 + Host 事件（`assistant-run-*` 绑定 **conversation**，**不是** 持久 `AgentRun` 行） | **产品默认聊天**（Web `useAIChatSession` / `useAssistantDispatch` / proposal lifecycle） |
-| **②** | **Workflow AgentRun** | `startAgentRun` / `resumeAgentRun` / `listAgentRuns` | 持久 `AgentRun`（可带 `conversationId` 过滤） | Goal/知识工作流、可恢复 run 列表 |
-| **③** | **Legacy message API** | `sendMessage` / `streamMessage` | 经典 chat message 流 | **遗留**；仅 adapter/Electron 桥与 **app-react** 工作区；**Vue 产品 open-chat 禁止作为默认发送** |
+| #     | 名称                   | 主入口                                                                                  | 持久化 / 事件                                                                                | 产品用途                                                                                                                                       |
+| ----- | ---------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **①** | **Host open-chat**     | `AIClientPort.dispatchAssistant` → HTTP SSE `/ai/assistant/dispatch/sse` 或 Desktop IPC | 会话消息 + Host 事件（`assistant-run-*` 绑定 **conversation**，**不是** 持久 `AgentRun` 行） | **产品默认聊天**（Web `useAIChatSession` / `useAssistantDispatch` / proposal lifecycle）                                                       |
+| **②** | **Workflow AgentRun**  | `startAgentRun` / `resumeAgentRun` / `listAgentRuns`                                    | 持久 `AgentRun`（可带 `conversationId` 过滤）                                                | Goal/知识工作流、可恢复 run 列表                                                                                                               |
+| **③** | **Legacy message API** | `sendMessage` / `streamMessage`                                                         | 经典 chat message 流                                                                         | **遗留**；仅 adapter/Electron 桥、**app-react** 工作区，以及 `AIClientService` 内的窄版本兼容 adapter；**Vue 产品 open-chat 禁止作为默认发送** |
 
 ## ① Host open-chat（主路径）
 
@@ -36,19 +38,47 @@ UI (app-vue)
 
 **允许调用方（生产）**
 
-| 位置 | 角色 |
-|------|------|
-| `packages/app-vue/.../useAIChatSession.ts` | open-chat 发送 / cancel / load |
-| `packages/app-vue/.../useAssistantDispatch.ts` | Host command 路由 |
-| `packages/app-vue/.../hostProposalLifecycle.ts` | approve/reject/cancel proposal |
-| `packages/app-vue/.../useAIKnowledgeNoteWorkflow.ts` | 知识笔记工作流可经 Host |
-| `packages/ai/src/electron/index.ts` | Desktop IPC 桥到 facade |
-| `packages/ai` adapters / controllers / module wiring | 传输与装配（非 UI） |
+| 位置                                                 | 角色                           |
+| ---------------------------------------------------- | ------------------------------ |
+| `packages/app-vue/.../useAIChatSession.ts`           | open-chat 发送 / cancel / load |
+| `packages/app-vue/.../useAssistantDispatch.ts`       | Host command 路由              |
+| `packages/app-vue/.../hostProposalLifecycle.ts`      | approve/reject/cancel proposal |
+| `packages/app-vue/.../useAIKnowledgeNoteWorkflow.ts` | 知识笔记工作流可经 Host        |
+| `packages/ai/src/electron/index.ts`                  | Desktop IPC 桥到 facade        |
+| `packages/ai` adapters / controllers / module wiring | 传输与装配（非 UI）            |
 
 **禁止**
 
-- 产品 open-chat 默认路径改回 `streamMessage` / `sendMessage`。
+- 产品 open-chat 默认路径改回 `streamMessage` / `sendMessage`；Vue 不分支判断 transport，
+  不展示 fallback-specific 产品事件。
 - 把 Host `assistant-run-*` 事件当成 `listAgentRuns` 持久行（见 N2 association surface）。
+
+**§① 窄版本兼容例外（plan §4.5 / ADR-035，2026-08-15）**
+
+`AIClientService.dispatchAssistant` 是唯一允许承担 legacy `streamMessage` 版本兼容的层，
+且仅当**全部**成立时才 fallback 一次：
+
+- command 是 `message`，`executionProfileId` 缺省或为 `direct_turn`；
+- dispatch 未产出任何 `AssistantEvent`（`sawEvent === false`，尤其未收到 `run.started`）；
+- 错误码是稳定的 `ASSISTANT_DISPATCH_UNAVAILABLE`（Web bootstrap 404/405/501；Desktop
+  bridge/handler 在 START 接受前明确 `NOT_SUPPORTED/NOT_FOUND`）；
+- 原 command 的 `conversationId/content/providerId/model` 可无损映射。
+
+**禁止 fallback（fail-closed）：**
+
+- `pi_readonly`、proposal approve/revise/reject、`cancel_run`；
+- 已收到任意事件（尤其是 `run.started`）；
+- 普通网络 / timeout / abort / `STREAM_TERMINATED`；
+- auth、validation、rate limit、provider/model、Facade application error；
+- malformed SSE/IPC frame、未知 event type、done/result schema error（protocol error）；
+- Desktop START 被接受后的 main crash、sender destroy 或 stream error。
+
+fallback 投影 `message.delta` / `message.completed`，保留 command runId 与持久化消息，
+**绝不伪造 `run.started`**，也不新增 fallback-specific 公共事件。命中只能通过内部
+log/metric 观察。`dispatchPolicy` 由 host composition 显式传入（`prefer_dispatch` /
+`dispatch_only` / `legacy_only`）；生产缺省 `prefer_dispatch`，紧急回滚必须显式配置并
+记录 telemetry。**移除条件**：旧 Server/Desktop host 全部升级到支持 dispatch 后，删除该
+adapter 与 `legacy_only` 开关，legacy 不长期作为双默认路径。
 
 ## ② Workflow AgentRun
 
@@ -62,12 +92,12 @@ UI / API
 
 **允许调用方（生产）**
 
-| 位置 | 角色 |
-|------|------|
-| `packages/app-vue/.../useAIChatView.ts` | `listAgentRuns({ limit })` 工作流侧栏/最近 run |
-| `packages/app-vue` goal/knowledge composables（经 `startAgentRun`/`resumeAgentRun`） | 工作流 |
-| `packages/ai/src/electron/index.ts` | IPC list/start/resume |
-| server controller + module | 装配 |
+| 位置                                                                                 | 角色                                           |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `packages/app-vue/.../useAIChatView.ts`                                              | `listAgentRuns({ limit })` 工作流侧栏/最近 run |
+| `packages/app-vue` goal/knowledge composables（经 `startAgentRun`/`resumeAgentRun`） | 工作流                                         |
+| `packages/ai/src/electron/index.ts`                                                  | IPC list/start/resume                          |
+| server controller + module                                                           | 装配                                           |
 
 **边界（N2）**：`listAgentRuns` ≠ Host open-chat 会话恢复列表；产品「按会话恢复 Host 列表」仍 open（AH-2）。
 
@@ -82,21 +112,22 @@ sendMessage / streamMessage
 
 **仍存在的生产调用方**
 
-| 位置 | 说明 |
-|------|------|
+| 位置                                             | 说明                                                |
+| ------------------------------------------------ | --------------------------------------------------- |
 | `packages/app-react/src/hooks/useAIWorkspace.ts` | React 工作区仍走 stream/send（**非** Vue 主产品壳） |
-| `packages/ai/src/electron/index.ts` | IPC 仍暴露 message 通道（兼容） |
-| `packages/ai` routes/controllers/adapters | 传输层保留 |
+| `packages/ai/src/electron/index.ts`              | IPC 仍暴露 message 通道（兼容）                     |
+| `packages/ai` routes/controllers/adapters        | 传输层保留                                          |
 
 **Vue `app-vue` 产品 open-chat**：不得新增对 `streamMessage`/`sendMessage` 的默认发送依赖。
+`AIClientService` 内部的窄版本兼容例外见 §①；该例外不改变「legacy 不是产品默认路径」的结论。
 
 ## 调用方审计快照（C2，2026-07-26）
 
-| API | 生产 UI 主用 | 遗留 / 桥 | 测试-only |
-|-----|--------------|-----------|-----------|
-| `dispatchAssistant` | app-vue Host composables | electron IPC、HTTP/IPC adapters | `*.test.ts` |
-| `listAgentRuns` | `useAIChatView`（workflow） | electron、HTTP/IPC | controller tests |
-| `sendMessage`/`streamMessage` | **app-react** workspace | electron message 通道、HTTP/IPC | message adapter tests |
+| API                           | 生产 UI 主用                | 遗留 / 桥                       | 测试-only             |
+| ----------------------------- | --------------------------- | ------------------------------- | --------------------- |
+| `dispatchAssistant`           | app-vue Host composables    | electron IPC、HTTP/IPC adapters | `*.test.ts`           |
+| `listAgentRuns`               | `useAIChatView`（workflow） | electron、HTTP/IPC              | controller tests      |
+| `sendMessage`/`streamMessage` | **app-react** workspace     | electron message 通道、HTTP/IPC | message adapter tests |
 
 死调用方本轮：**无额外 S 删除**（message API 仍被 React + Electron 使用；保留为 ③，不在本 PR 强制摘除）。
 

--- a/packages/ai/src/application-client/ai-client-service.dispatch-assistant.spec.ts
+++ b/packages/ai/src/application-client/ai-client-service.dispatch-assistant.spec.ts
@@ -1,0 +1,351 @@
+/**
+ * AIClientService.dispatchAssistant policy behavior (plan Step D §4.5 / §5.5).
+ *
+ * Host dispatch is the default; the legacy `streamMessage` fallback exists only
+ * inside the service as a narrow version-compatibility adapter. It fires exactly
+ * once and ONLY on a definite dispatch-unavailable + zero observed events.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { AIClientService } from './ai-client-service';
+import {
+  classifyAssistantDispatchFallback,
+  type AssistantDispatchPolicy,
+} from './assistant-dispatch-policy';
+import { createResultClientError } from '../infrastructure-client/adapters/result-client-error';
+import type { IAIAssistantApiClient, IAIMessageApiClient } from './ports/ai-api-client.port';
+import type { AssistantClientCommand, AssistantDispatchHandlers } from '@memoflow/contracts/ai';
+import { ASSISTANT_DISPATCH_UNAVAILABLE } from '@memoflow/contracts/ai';
+
+type MinimalApis = {
+  assistant: {
+    dispatchAssistant: ReturnType<typeof vi.fn>;
+  };
+  message: {
+    streamMessage: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createMinimalApis(): MinimalApis {
+  return {
+    assistant: {
+      dispatchAssistant: vi.fn(async () => {}),
+    },
+    message: {
+      streamMessage: vi.fn(async () => {}),
+    },
+  };
+}
+
+function createService(
+  apis: MinimalApis,
+  dispatchPolicy: AssistantDispatchPolicy = 'prefer_dispatch',
+) {
+  return new AIClientService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    apis.message as unknown as IAIMessageApiClient,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    apis.assistant as unknown as IAIAssistantApiClient,
+    dispatchPolicy,
+  );
+}
+
+function messageCommand(overrides: Partial<AssistantClientCommand> = {}): AssistantClientCommand {
+  return {
+    type: 'message',
+    conversationId: 'conv-1',
+    content: 'hello',
+    surface: 'web',
+    ...overrides,
+  } as AssistantClientCommand;
+}
+
+function makeHandlers(): AssistantDispatchHandlers & { events: unknown[]; done: unknown[] } {
+  const events: unknown[] = [];
+  const done: unknown[] = [];
+  return {
+    events,
+    done,
+    onEvent: (event) => events.push(event),
+    onDone: (result) => done.push(result),
+  };
+}
+
+describe('classifyAssistantDispatchFallback (pure §4.5 whitelist)', () => {
+  const unavailable = createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE);
+
+  it('eligible only for direct_turn message + unavailable + zero events', () => {
+    expect(
+      classifyAssistantDispatchFallback(unavailable, messageCommand(), { sawEvent: false }),
+    ).toBe(true);
+  });
+
+  it('fails closed for every non-message command and pi_readonly', () => {
+    const notMessage = {
+      type: 'cancel_run',
+      runId: 'r1',
+    } as AssistantClientCommand;
+    expect(classifyAssistantDispatchFallback(unavailable, notMessage, { sawEvent: false })).toBe(
+      false,
+    );
+
+    expect(
+      classifyAssistantDispatchFallback(
+        unavailable,
+        messageCommand({ executionProfileId: 'pi_readonly' }),
+        {
+          sawEvent: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('fails closed once any event is observed (run.started) and for all other errors', () => {
+    expect(
+      classifyAssistantDispatchFallback(unavailable, messageCommand(), { sawEvent: true }),
+    ).toBe(false);
+
+    const forbiddenErrors = [
+      new Error('network down'),
+      createResultClientError('timeout', 'TIMEOUT'),
+      createResultClientError('aborted', 'ABORTED'),
+      createResultClientError('terminated', 'STREAM_TERMINATED'),
+      createResultClientError('unauthorized', 'UNAUTHORIZED'),
+      createResultClientError('bad', 'VALIDATION_ERROR'),
+      createResultClientError('rate', 'RATE_LIMITED'),
+      createResultClientError('provider', 'PROVIDER_ERROR'),
+      createResultClientError('protocol', 'ASSISTANT_PROTOCOL_ERROR'),
+      undefined,
+    ];
+    for (const error of forbiddenErrors) {
+      expect(classifyAssistantDispatchFallback(error, messageCommand(), { sawEvent: false })).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe('AIClientService.dispatchAssistant (plan Step D)', () => {
+  it('forwards dispatch success untouched: delta/completed pass through, no legacy call', async () => {
+    const apis = createMinimalApis();
+    apis.assistant.dispatchAssistant.mockImplementation(async (_command, handlers) => {
+      handlers.onEvent?.({ type: 'message.delta', runId: 'run-1', content: 'hi' });
+      handlers.onEvent?.({ type: 'message.completed', runId: 'run-1', status: 'completed' });
+      handlers.onDone?.({ eventCount: 2 });
+    });
+    const service = createService(apis, 'prefer_dispatch');
+    const handlers = makeHandlers();
+
+    await service.dispatchAssistant(messageCommand(), handlers);
+
+    expect(apis.assistant.dispatchAssistant).toHaveBeenCalledTimes(1);
+    expect(apis.message.streamMessage).not.toHaveBeenCalled();
+    expect(handlers.events).toMatchObject([
+      { type: 'message.delta', runId: 'run-1' },
+      { type: 'message.completed', status: 'completed' },
+    ]);
+    expect(handlers.done).toEqual([{ eventCount: 2 }]);
+  });
+
+  it('falls back exactly once on definite unavailable + zero events, mapping conversation/content/provider/model', async () => {
+    const apis = createMinimalApis();
+    apis.assistant.dispatchAssistant.mockRejectedValue(
+      createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE),
+    );
+    apis.message.streamMessage.mockImplementation(async (request, streamHandlers) => {
+      streamHandlers.onChunk?.({ role: 'assistant', content: 'legacy' });
+      streamHandlers.onDone?.({
+        userMessage: { id: 'user-9', content: 'hello' },
+        assistantMessage: { id: 'assistant-9', content: 'legacy' },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        providerId: 'provider-1',
+        processingTimeMs: 1,
+      } as never);
+    });
+    const service = createService(apis, 'prefer_dispatch');
+    const handlers = makeHandlers();
+    const command = messageCommand({
+      runId: 'run-client-1',
+      providerId: 'provider-1',
+      model: 'model-1',
+    });
+
+    await service.dispatchAssistant(command, handlers);
+
+    expect(apis.assistant.dispatchAssistant).toHaveBeenCalledTimes(1);
+    expect(apis.message.streamMessage).toHaveBeenCalledTimes(1);
+    expect(apis.message.streamMessage.mock.calls[0][0]).toEqual({
+      conversationId: 'conv-1',
+      content: 'hello',
+      providerId: 'provider-1',
+      model: 'model-1',
+    });
+    expect(handlers.events).toMatchObject([
+      { type: 'message.delta', runId: 'run-client-1', content: 'legacy' },
+      {
+        type: 'message.completed',
+        runId: 'run-client-1',
+        status: 'completed',
+        content: 'legacy',
+        userMessage: { id: 'user-9', content: 'hello' },
+        assistantMessage: { id: 'assistant-9', content: 'legacy' },
+      },
+    ]);
+    // Fallback never fabricates run.started.
+    expect(
+      handlers.events.some((event) => (event as { type: string }).type === 'run.started'),
+    ).toBe(false);
+  });
+
+  it('preserves a generated runId when the command omitted one', async () => {
+    const apis = createMinimalApis();
+    apis.assistant.dispatchAssistant.mockRejectedValue(
+      createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE),
+    );
+    apis.message.streamMessage.mockImplementation(async (_request, streamHandlers) => {
+      streamHandlers.onChunk?.({ role: 'assistant', content: 'x' });
+    });
+    const service = createService(apis);
+    const handlers = makeHandlers();
+
+    await service.dispatchAssistant(messageCommand(), handlers);
+
+    const delta = handlers.events[0] as { type: string; runId: string };
+    expect(delta.type).toBe('message.delta');
+    expect(delta.runId).toMatch(/^legacy:/);
+  });
+
+  it('rejects fallback when run.started was observed, and for network/timeout/abort/protocol errors', async () => {
+    const cases: Array<[unknown, boolean]> = [
+      [createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE), true],
+      [createResultClientError('network', 'NETWORK_ERROR'), false],
+      [createResultClientError('timeout', 'TIMEOUT'), false],
+      [createResultClientError('aborted', 'ABORTED'), false],
+      [createResultClientError('terminated', 'STREAM_TERMINATED'), false],
+      [createResultClientError('auth', 'UNAUTHORIZED'), false],
+      [createResultClientError('validation', 'VALIDATION_ERROR'), false],
+      [createResultClientError('protocol', 'ASSISTANT_PROTOCOL_ERROR'), false],
+    ];
+
+    for (const [error, shouldFallback] of cases) {
+      const apis = createMinimalApis();
+      apis.assistant.dispatchAssistant.mockImplementation(async (_command, handlers) => {
+        if (shouldFallback) {
+          throw error;
+        }
+        handlers.onEvent?.({
+          type: 'run.started',
+          runId: 'r',
+          engineId: 'e',
+          profile: 'direct_turn',
+        });
+        throw error;
+      });
+      const service = createService(apis);
+      const handlers = makeHandlers();
+
+      if (shouldFallback) {
+        await expect(
+          service.dispatchAssistant(messageCommand(), handlers),
+        ).resolves.toBeUndefined();
+        expect(apis.message.streamMessage).toHaveBeenCalledTimes(1);
+      } else {
+        await expect(service.dispatchAssistant(messageCommand(), handlers)).rejects.toBe(error);
+        expect(apis.message.streamMessage).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it('pi_readonly, proposal and cancel commands never fall back', async () => {
+    const unavailable = createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE);
+    const commands: AssistantClientCommand[] = [
+      messageCommand({ executionProfileId: 'pi_readonly' }),
+      { type: 'approve_proposal', runId: 'r', proposalId: 'p', revision: 1 },
+      { type: 'revise_proposal', runId: 'r', proposalId: 'p', revision: 1, patch: {} },
+      { type: 'reject_proposal', runId: 'r', proposalId: 'p', revision: 1 },
+      { type: 'cancel_run', runId: 'r' },
+    ];
+
+    for (const command of commands) {
+      const apis = createMinimalApis();
+      apis.assistant.dispatchAssistant.mockRejectedValue(unavailable);
+      const service = createService(apis);
+      const handlers = makeHandlers();
+
+      await expect(service.dispatchAssistant(command, handlers)).rejects.toBe(unavailable);
+      expect(apis.message.streamMessage).not.toHaveBeenCalled();
+    }
+  });
+
+  it('dispatch_only never falls back even on definite unavailable', async () => {
+    const apis = createMinimalApis();
+    apis.assistant.dispatchAssistant.mockRejectedValue(
+      createResultClientError('route missing', ASSISTANT_DISPATCH_UNAVAILABLE),
+    );
+    const service = createService(apis, 'dispatch_only');
+    const handlers = makeHandlers();
+
+    await expect(service.dispatchAssistant(messageCommand(), handlers)).rejects.toMatchObject({
+      code: ASSISTANT_DISPATCH_UNAVAILABLE,
+    });
+    expect(apis.message.streamMessage).not.toHaveBeenCalled();
+  });
+
+  it('legacy_only runs streamMessage projection for direct_turn messages', async () => {
+    const apis = createMinimalApis();
+    apis.message.streamMessage.mockImplementation(async (_request, streamHandlers) => {
+      streamHandlers.onChunk?.({ role: 'assistant', content: 'legacy reply' });
+      streamHandlers.onDone?.({
+        userMessage: { id: 'u1', content: 'hello' },
+        assistantMessage: { id: 'a1', content: 'legacy reply' },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        providerId: 'provider-1',
+        processingTimeMs: 1,
+      } as never);
+    });
+    const service = createService(apis, 'legacy_only');
+    const handlers = makeHandlers();
+    const command = messageCommand({ runId: 'run-1' });
+
+    await service.dispatchAssistant(command, handlers);
+
+    expect(apis.assistant.dispatchAssistant).not.toHaveBeenCalled();
+    expect(apis.message.streamMessage).toHaveBeenCalledTimes(1);
+    expect(apis.message.streamMessage.mock.calls[0][0]).toEqual({
+      conversationId: 'conv-1',
+      content: 'hello',
+      providerId: undefined,
+      model: undefined,
+    });
+    expect(handlers.events).toMatchObject([
+      { type: 'message.delta', runId: 'run-1' },
+      { type: 'message.completed', runId: 'run-1', status: 'completed' },
+    ]);
+  });
+
+  it('legacy_only fails explicitly for pi_readonly and proposal/cancel (never sent to message endpoint)', async () => {
+    const commands: AssistantClientCommand[] = [
+      messageCommand({ executionProfileId: 'pi_readonly' }),
+      { type: 'approve_proposal', runId: 'r', proposalId: 'p', revision: 1 },
+      { type: 'cancel_run', runId: 'r' },
+    ];
+
+    for (const command of commands) {
+      const apis = createMinimalApis();
+      const service = createService(apis, 'legacy_only');
+      const handlers = makeHandlers();
+
+      await expect(service.dispatchAssistant(command, handlers)).rejects.toMatchObject({
+        code: 'ASSISTANT_DISPATCH_UNSUPPORTED',
+      });
+      expect(apis.message.streamMessage).not.toHaveBeenCalled();
+      expect(apis.assistant.dispatchAssistant).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/ai/src/application-client/ai-client-service.ts
+++ b/packages/ai/src/application-client/ai-client-service.ts
@@ -46,6 +46,13 @@ import type {
   AssistantClientCommand,
   AssistantDispatchHandlers,
 } from '@memoflow/contracts/ai';
+import {
+  classifyAssistantDispatchFallback,
+  DEFAULT_ASSISTANT_DISPATCH_POLICY,
+  type AssistantDispatchObservedState,
+  type AssistantDispatchPolicy,
+} from './assistant-dispatch-policy';
+import { createResultClientError } from '../infrastructure-client/adapters/result-client-error';
 
 /**
  * Thin facade over AI API client ports for UI consumption.
@@ -66,6 +73,7 @@ export class AIClientService implements AIClientPort {
     private readonly analyticsQueryApi: AIAnalyticsQueryApiClient,
     private readonly agentRuntimeApi: AIAgentRuntimeApiClient,
     private readonly assistantApi: IAIAssistantApiClient,
+    private readonly dispatchPolicy: AssistantDispatchPolicy = DEFAULT_ASSISTANT_DISPATCH_POLICY,
   ) {
     this.getCapabilities = this.getCapabilities.bind(this);
     this.getEvaluationOverview = this.getEvaluationOverview.bind(this);
@@ -132,7 +140,9 @@ export class AIClientService implements AIClientPort {
   }
 
   setDefaultProvider(providerId: string) {
-    const request: SetDefaultAIProviderReq = { providerId: providerId as SetDefaultAIProviderReq['providerId'] };
+    const request: SetDefaultAIProviderReq = {
+      providerId: providerId as SetDefaultAIProviderReq['providerId'],
+    };
     return this.providerApi.setDefaultProvider(request);
   }
 
@@ -225,11 +235,142 @@ export class AIClientService implements AIClientPort {
     handlers: AssistantDispatchHandlers,
     signal?: AbortSignal,
   ) {
-    return this.assistantApi.dispatchAssistant(command, handlers, signal);
+    return this.dispatchAssistantWithPolicy(command, handlers, signal);
+  }
+
+  /**
+   * Host dispatch is always the default (plan §4.5 / Step D). `legacy_only`
+   * bypasses dispatch for direct-turn messages only; every other command fails
+   * explicitly. `prefer_dispatch` falls back to `streamMessage` only when the
+   * dispatch attempt is definitely unavailable AND produced zero events.
+   *
+   * Host dispatch 始终是默认（计划 §4.5 / Step D）。`legacy_only` 仅对
+   * direct-turn message 绕过 dispatch；其余 command 明确失败。`prefer_dispatch`
+   * 仅在 dispatch 明确不可用且未产出任何事件时回退 `streamMessage`。
+   */
+  private async dispatchAssistantWithPolicy(
+    command: AssistantClientCommand,
+    handlers: AssistantDispatchHandlers,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (this.dispatchPolicy === 'legacy_only') {
+      this.assertLegacyEligible(command);
+      return this.dispatchLegacyProjection(command, handlers, signal);
+    }
+
+    const observed: AssistantDispatchObservedState = { sawEvent: false };
+    try {
+      await this.assistantApi.dispatchAssistant(
+        command,
+        {
+          onEvent: (event) => {
+            observed.sawEvent = true;
+            handlers.onEvent?.(event);
+          },
+          onDone: (result) => handlers.onDone?.(result),
+        },
+        signal,
+      );
+      return;
+    } catch (error) {
+      if (this.dispatchPolicy === 'dispatch_only') {
+        throw error;
+      }
+      if (classifyAssistantDispatchFallback(error, command, observed)) {
+        return this.dispatchLegacyProjection(command, handlers, signal);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * `legacy_only` accepts only direct-turn message commands. pi_readonly and
+   * proposal/cancel commands never reach the legacy message endpoint.
+   *
+   * `legacy_only` 只接受 direct-turn message command。pi_readonly 与
+   * proposal/cancel command 永远不进入 legacy message endpoint。
+   */
+  private assertLegacyEligible(command: AssistantClientCommand): void {
+    if (command.type !== 'message' || command.executionProfileId === 'pi_readonly') {
+      throw createResultClientError(
+        'Legacy-only host does not support this assistant command',
+        'ASSISTANT_DISPATCH_UNSUPPORTED',
+      );
+    }
+  }
+
+  /**
+   * Project a legacy `streamMessage` into the normalized dispatch event stream.
+   * Preserves the command runId (generating one when omitted) and the persisted
+   * message. NEVER fabricates a Host `run.started` — fallback visibility is
+   * internal log/metric only (plan §4.3).
+   *
+   * 把 legacy `streamMessage` 投影为归一化 dispatch 事件流。保留 command
+   * runId（缺省时生成一个）与持久化消息。绝不伪造 Host `run.started` ——
+   * fallback 仅能通过内部 log/metric 观察（计划 §4.3）。
+   */
+  private async dispatchLegacyProjection(
+    command: AssistantClientCommand,
+    handlers: AssistantDispatchHandlers,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (command.type !== 'message') {
+      throw createResultClientError(
+        'Legacy projection requires a message command',
+        'ASSISTANT_DISPATCH_UNSUPPORTED',
+      );
+    }
+    const runId = command.runId ?? createFallbackDispatchRunId();
+    const request: SendMessageReq = {
+      conversationId: command.conversationId as SendMessageReq['conversationId'],
+      content: command.content,
+      providerId: command.providerId as SendMessageReq['providerId'] | undefined,
+      model: command.model,
+    };
+
+    let eventCount = 0;
+    await this.messageApi.streamMessage(
+      request,
+      {
+        onChunk: (chunk) => {
+          eventCount += 1;
+          handlers.onEvent?.({
+            type: 'message.delta',
+            runId,
+            content: chunk.content,
+          });
+        },
+        onDone: (result) => {
+          eventCount += 1;
+          handlers.onEvent?.({
+            type: 'message.completed',
+            runId,
+            status: 'completed',
+            content: result.assistantMessage?.content,
+            userMessage: result.userMessage
+              ? { id: String(result.userMessage.id), content: result.userMessage.content }
+              : undefined,
+            assistantMessage: result.assistantMessage
+              ? {
+                  id: String(result.assistantMessage.id),
+                  content: result.assistantMessage.content,
+                }
+              : undefined,
+          });
+          handlers.onDone?.({ eventCount });
+        },
+      },
+      signal,
+    );
   }
 }
 
 // ===== Factory =====
+
+export interface CreateAIClientServiceOptions {
+  /** Assistant dispatch rollout policy (plan §4.5). Defaults to prefer_dispatch. */
+  dispatchPolicy?: AssistantDispatchPolicy;
+}
 
 export function createAIClientService(
   capabilitiesApi: IAICapabilitiesApiClient,
@@ -243,6 +384,7 @@ export function createAIClientService(
   analyticsQueryApi: AIAnalyticsQueryApiClient,
   agentRuntimeApi: AIAgentRuntimeApiClient,
   assistantApi: IAIAssistantApiClient,
+  options?: CreateAIClientServiceOptions,
 ): AIClientService {
   return new AIClientService(
     capabilitiesApi,
@@ -256,5 +398,22 @@ export function createAIClientService(
     analyticsQueryApi,
     agentRuntimeApi,
     assistantApi,
+    options?.dispatchPolicy,
   );
+}
+
+/**
+ * Client-owned fallback run id for legacy projections when the command did not
+ * carry a runId (plan §4.2 keeps runId optional for existing callers). Never
+ * persisted as a Host run; used only to correlate projected events.
+ *
+ * command 未携带 runId 时，legacy 投影使用的客户端 run id（计划 §4.2 对既有
+ * 调用方保持 runId 可选）。它不是持久 Host run，仅用于关联投影事件。
+ */
+function createFallbackDispatchRunId(): string {
+  const random =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+  return `legacy:${random}`;
 }

--- a/packages/ai/src/application-client/ai-http-service-factory.ts
+++ b/packages/ai/src/application-client/ai-http-service-factory.ts
@@ -1,9 +1,28 @@
 import type { IResultHttpClient } from '@memoflow/http-client';
 
 import { createAIHttpAdapters } from '../infrastructure-client';
-import { AIClientService, createAIClientService } from './ai-client-service';
+import {
+  AIClientService,
+  createAIClientService,
+  type CreateAIClientServiceOptions,
+} from './ai-client-service';
 
-export function createAIServiceFromHttpClient(httpClient: IResultHttpClient): AIClientService {
+export type AIServiceFromHttpClientOptions = CreateAIClientServiceOptions;
+
+/**
+ * Create the AI client service from an HTTP result client.
+ * 从 HTTP result client 创建 AI 客户端服务。
+ *
+ * `dispatchPolicy` is host-provided (plan §3.2 / §4.5); production default is
+ * `prefer_dispatch` and this factory never reads global environment variables.
+ *
+ * `dispatchPolicy` 由 host 显式传入（计划 §3.2 / §4.5）；生产缺省
+ * `prefer_dispatch`，本工厂从不读取全局环境变量。
+ */
+export function createAIServiceFromHttpClient(
+  httpClient: IResultHttpClient,
+  options?: AIServiceFromHttpClientOptions,
+): AIClientService {
   const adapters = createAIHttpAdapters(httpClient);
   return createAIClientService(
     adapters.capabilities,
@@ -17,5 +36,6 @@ export function createAIServiceFromHttpClient(httpClient: IResultHttpClient): AI
     adapters.analytics,
     adapters.agentRuntime,
     adapters.assistant,
+    options,
   );
 }

--- a/packages/ai/src/application-client/assistant-dispatch-policy.ts
+++ b/packages/ai/src/application-client/assistant-dispatch-policy.ts
@@ -1,0 +1,94 @@
+/**
+ * Assistant dispatch fallback policy (plan §4.5, residual 351).
+ * Assistant dispatch 回退策略（计划 §4.5，residual 351）。
+ *
+ * Host dispatch is ALWAYS the default; a legacy `streamMessage` fallback is a
+ * narrow version-compatibility adapter that lives only inside AIClientService.
+ * This module is the single pure decision point: unknown values fail closed.
+ *
+ * Host dispatch 始终是默认；legacy `streamMessage` 回退只是 AIClientService
+ * 内部的窄版本兼容 adapter。本模块是唯一的纯判定点：未知值一律 fail-closed。
+ */
+import type { AssistantClientCommand } from '@memoflow/contracts/ai';
+import { ASSISTANT_DISPATCH_UNAVAILABLE } from '@memoflow/contracts/ai';
+import { extractStructuredResultError } from '@memoflow/contracts/result';
+
+/**
+ * Host-provided rollout policy (plan §4.5 / §5.5 Step D).
+ * Host 提供的发布策略（计划 §4.5 / §5.5 Step D）。
+ *
+ * - `prefer_dispatch`: dispatch first; fallback to legacy only when dispatch is
+ *   definitely unavailable and produced zero events. Production default.
+ *   `prefer_dispatch`：先 dispatch；仅在 dispatch 明确不可用且未产生任何事件时
+ *   回退 legacy。生产默认。
+ * - `dispatch_only`: never fall back; diagnostic / forced-Host mode.
+ *   `dispatch_only`：永不回退；诊断 / 强制 Host 模式。
+ * - `legacy_only`: bypass dispatch; direct-turn messages only. pi_readonly and
+ *   proposal/cancel commands fail explicitly. Emergency rollback switch.
+ *   `legacy_only`：绕过 dispatch；仅 direct-turn message。pi_readonly 与
+ *   proposal/cancel 明确失败。紧急回滚开关。
+ */
+export type AssistantDispatchPolicy = 'prefer_dispatch' | 'dispatch_only' | 'legacy_only';
+
+/** Production default policy. 生产默认策略。 */
+export const DEFAULT_ASSISTANT_DISPATCH_POLICY: AssistantDispatchPolicy = 'prefer_dispatch';
+
+/**
+ * Observable state of a dispatch attempt used for fallback decisions.
+ * 用于回退判定的 dispatch 尝试观测状态。
+ */
+export interface AssistantDispatchObservedState {
+  /**
+   * Whether dispatch emitted at least one AssistantEvent before failing.
+   * Once an event is seen (especially `run.started`) the Host may have acted,
+   * so a legacy retry must never happen.
+   *
+   * 失败前 dispatch 是否至少产出过一个 AssistantEvent。只要看到事件
+   * （尤其是 `run.started`），Host 就可能已经执行，因此绝不能重试 legacy。
+   */
+  sawEvent: boolean;
+}
+
+/**
+ * Decide whether a failed dispatch may fall back to the legacy message stream.
+ * Implements ONLY the §4.5 whitelist; every unknown error / command / observed
+ * state fails closed (returns false).
+ *
+ * 判定一次失败的 dispatch 是否可以回退到 legacy message 流。只实现 §4.5
+ * 白名单；任何未知的错误 / command / 观测状态都 fail-closed（返回 false）。
+ *
+ * Eligible ONLY when:
+ * 仅当以下全部成立才 eligible：
+ * - command is `message` with `direct_turn` (or default) profile — proposal /
+ *   `cancel_run` / `pi_readonly` never fall back;
+ *   command 为 `message` 且 profile 为 `direct_turn`（或缺省）——proposal /
+ *   `cancel_run` / `pi_readonly` 永不回退；
+ * - dispatch produced zero AssistantEvent;
+ *   dispatch 未产出任何 AssistantEvent；
+ * - the error is the stable dispatch-unavailable code (bootstrap route absence
+ *   404/405/501, or Desktop bridge/handler absence before START acceptance).
+ *   错误是稳定的 dispatch-unavailable 码（bootstrap 路由缺失 404/405/501，或
+ *   Desktop bridge/handler 在 START 接受前缺失）。
+ */
+export function classifyAssistantDispatchFallback(
+  error: unknown,
+  command: AssistantClientCommand,
+  observed: AssistantDispatchObservedState,
+): boolean {
+  // Fail closed on any non-message command.
+  if (command.type !== 'message') return false;
+  // pi_readonly never maps to a legacy direct chat send.
+  if (command.executionProfileId === 'pi_readonly') return false;
+  // Any observed event — especially run.started — means the Host may have acted.
+  if (observed.sawEvent) return false;
+
+  const code = readErrorCode(error);
+  return code === ASSISTANT_DISPATCH_UNAVAILABLE;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  const structured = extractStructuredResultError(error);
+  return typeof structured?.code === 'string' && structured.code.length > 0
+    ? structured.code
+    : undefined;
+}

--- a/packages/ai/src/application-client/index.ts
+++ b/packages/ai/src/application-client/index.ts
@@ -15,4 +15,14 @@ export type { AIClientPort } from './ai-client.port';
 
 // ===== Client Service =====
 export { AIClientService, createAIClientService } from './ai-client-service';
+export type { CreateAIClientServiceOptions } from './ai-client-service';
 export { createAIServiceFromHttpClient } from './ai-http-service-factory';
+export type { AIServiceFromHttpClientOptions } from './ai-http-service-factory';
+export {
+  classifyAssistantDispatchFallback,
+  DEFAULT_ASSISTANT_DISPATCH_POLICY,
+} from './assistant-dispatch-policy';
+export type {
+  AssistantDispatchObservedState,
+  AssistantDispatchPolicy,
+} from './assistant-dispatch-policy';

--- a/packages/ai/src/client/index.ts
+++ b/packages/ai/src/client/index.ts
@@ -11,6 +11,7 @@ import {
   AIClientService,
   createAIClientService,
   type AIClientPort,
+  type AssistantDispatchPolicy,
 } from '../application-client';
 import {
   AICapabilitiesHttpAdapter,
@@ -76,7 +77,28 @@ export type {
   IResultIpcClient,
 };
 
-export function createAIHttpClient(httpClient: IResultHttpClient): AIClientPort {
+export type {
+  AssistantDispatchObservedState,
+  AssistantDispatchPolicy,
+  CreateAIClientServiceOptions,
+  AIServiceFromHttpClientOptions,
+} from '../application-client';
+
+/**
+ * Host-provided AI client options (plan §4.5). `dispatchPolicy` defaults to
+ * `prefer_dispatch` when omitted; hosts pass it explicitly per §3.2.
+ *
+ * Host 提供的 AI 客户端选项（计划 §4.5）。省略时 `dispatchPolicy` 缺省为
+ * `prefer_dispatch`；host 按 §3.2 显式传入。
+ */
+export interface AIClientFactoryOptions {
+  dispatchPolicy?: AssistantDispatchPolicy;
+}
+
+export function createAIHttpClient(
+  httpClient: IResultHttpClient,
+  options?: AIClientFactoryOptions,
+): AIClientPort {
   const adapters = createAIHttpAdapters(httpClient);
   return createAIClientService(
     adapters.capabilities,
@@ -90,10 +112,14 @@ export function createAIHttpClient(httpClient: IResultHttpClient): AIClientPort 
     adapters.analytics,
     adapters.agentRuntime,
     adapters.assistant,
+    options,
   );
 }
 
-export function createAIIpcClient(ipcClient: IResultIpcClient): AIClientPort {
+export function createAIIpcClient(
+  ipcClient: IResultIpcClient,
+  options?: AIClientFactoryOptions,
+): AIClientPort {
   const adapters = createAIIpcAdapters(ipcClient);
   return createAIClientService(
     adapters.capabilities,
@@ -107,6 +133,7 @@ export function createAIIpcClient(ipcClient: IResultIpcClient): AIClientPort {
     adapters.analytics,
     adapters.agentRuntime,
     adapters.assistant,
+    options,
   );
 }
 

--- a/packages/app-vue/src/di/keys.ts
+++ b/packages/app-vue/src/di/keys.ts
@@ -10,6 +10,7 @@ import type { InjectionKey, Ref, ShallowRef } from 'vue';
 import type { CloudAuthDesktopClientPort } from '@memoflow/contracts';
 import type { DesktopAccessSnapshot } from '@memoflow/contracts/electron';
 import type { ElectronBridge } from '@memoflow/ipc-client';
+import type { AssistantSurface } from '@memoflow/contracts/ai';
 import type { DesktopAuthApi } from '../shared/utils/desktop-auth-recovery';
 import type {
   IAccountService,
@@ -56,7 +57,8 @@ export const DASHBOARD_SERVICE_KEY: InjectionKey<IDashboardService> = Symbol('Da
 export const MODULE_CAPSULES_KEY: InjectionKey<ModuleCapsule[]> = Symbol('ModuleCapsules');
 export const USER_NAME_KEY: InjectionKey<string> = Symbol('UserName');
 export const LOGOUT_HANDLER_KEY: InjectionKey<() => void> = Symbol('LogoutHandler');
-export const PROFILE_LOCK_HANDLER_KEY: InjectionKey<() => Promise<void>> = Symbol('ProfileLockHandler');
+export const PROFILE_LOCK_HANDLER_KEY: InjectionKey<() => Promise<void>> =
+  Symbol('ProfileLockHandler');
 export const DESKTOP_ACCESS_SNAPSHOT_KEY: InjectionKey<Ref<DesktopAccessSnapshot | null>> =
   Symbol('DesktopAccessSnapshot');
 
@@ -82,3 +84,17 @@ export const SHELL_COMPOSER_DENSITY_KEY: InjectionKey<Ref<'comfortable' | 'compa
 /** Shell-owned workflow surface teleport mount. */
 export const SHELL_WORKFLOW_MOUNT_KEY: InjectionKey<ShallowRef<HTMLElement | null>> =
   Symbol('ShellWorkflowMount');
+
+/**
+ * Host-provided Assistant surface tag (ADR-035 / plan §4.2).
+ * Web provides `'web'`, Desktop renderer provides `'desktop'`; shared
+ * composables read this instead of sniffing `window`. The value travels
+ * unchanged on every assistant `message` command so the Host Turn Engine
+ * observes the real calling surface.
+ *
+ * Host 提供的 Assistant surface 标签（ADR-035 / 计划 §4.2）。Web 提供
+ * `'web'`，Desktop renderer 提供 `'desktop'`；共享 composable 通过该 key
+ * 读取，而不是嗅探 `window`。该值原样出现在每条 assistant `message`
+ * command 上，使 Host Turn Engine 观察到真实调用 surface。
+ */
+export const ASSISTANT_SURFACE_KEY: InjectionKey<AssistantSurface> = Symbol('AssistantSurface');

--- a/packages/app-vue/src/modules/ai/composables/use-ai-chat-host-dispatch.surface.spec.ts
+++ b/packages/app-vue/src/modules/ai/composables/use-ai-chat-host-dispatch.surface.spec.ts
@@ -4,23 +4,21 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Residual 351/369: open chat default send path goes through AssistantFacade
- * (dispatchAssistant), not streamMessage dual path. Residual 369 adds Host
- * multi-engine execution profile selection (direct_turn / pi_readonly).
+ * via the thin `useAssistantDispatch` entry (residual 349) — never a direct
+ * `loadService.dispatchAssistant` bypass and never streamMessage. Residual 369
+ * adds Host multi-engine execution profile selection (direct_turn / pi_readonly).
  * Residual 393: stopGenerating issues Host cancel_run with client-owned runId.
  */
 describe('useAIChatSession open chat Host dispatch surface', () => {
   const session = readFileSync(resolve(__dirname, 'useAIChatSession.ts'), 'utf8');
   const types = readFileSync(resolve(__dirname, 'types.ts'), 'utf8');
   const cancelHelper = readFileSync(resolve(__dirname, 'hostOpenChatCancel.ts'), 'utf8');
-  const composer = readFileSync(
-    resolve(__dirname, '../components/AIFooterComposer.vue'),
-    'utf8',
-  );
+  const composer = readFileSync(resolve(__dirname, '../components/AIFooterComposer.vue'), 'utf8');
   const chatView = readFileSync(resolve(__dirname, '../views/AIChatView.vue'), 'utf8');
 
-  it('routes handleSendChat via dispatchAssistant with model selection', () => {
-    expect(session).toContain('loadService.dispatchAssistant');
-    expect(session).toContain("type: 'message'");
+  it('routes handleSendChat via useAssistantDispatch.dispatchMessage with model selection', () => {
+    expect(session).toContain('useAssistantDispatch({');
+    expect(session).toContain('assistantDispatch.dispatchMessage({');
     expect(session).toContain('providerId: selectedModel.providerId');
     expect(session).toContain('model: selectedModel.modelId');
     // Residual 369: open chat multi-engine Host profile selection.
@@ -29,7 +27,10 @@ describe('useAIChatSession open chat Host dispatch surface', () => {
     expect(session).toContain('selectExecutionProfile');
     expect(session).toContain("event.type === 'message.delta'");
     expect(session).toContain("event.type === 'message.completed'");
+    // The session must NOT branch directly on the transport / call the legacy path.
+    expect(session).not.toMatch(/loadService\.dispatchAssistant\s*\(/);
     expect(session).not.toMatch(/loadService\.streamMessage\s*\(/);
+    expect(session).not.toMatch(/loadService\.sendMessage\s*\(/);
     expect(types).toContain("'dispatchAssistant'");
     expect(types).not.toMatch(/'\s*streamMessage\s*'/);
   });
@@ -70,5 +71,4 @@ describe('useAIChatSession open chat Host dispatch surface', () => {
     // session still must not call streamMessage on default send
     expect(session).not.toMatch(/loadService\.streamMessage\s*\(/);
   });
-
 });

--- a/packages/app-vue/src/modules/ai/composables/useAIChatSession.spec.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAIChatSession.spec.ts
@@ -1,0 +1,274 @@
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ok } from '@memoflow/contracts/result';
+import type { AssistantEvent } from '@memoflow/contracts/ai';
+import { useAIChatSession, type UseAIChatSessionOptions } from './useAIChatSession';
+import type { ChatModelOption } from './types';
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('vue-sonner', () => ({
+  toast: toastMocks,
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      common: { unknown: 'Unknown', operationFailed: 'Operation failed' },
+      aiAssistant: {
+        dialogs: {
+          chat: {
+            defaultConversationName: 'New chat',
+            deleted: 'Deleted',
+            loadFailed: 'Load failed',
+            deleteFailed: 'Delete failed',
+            sendFailed: 'Send failed',
+          },
+        },
+      },
+    },
+  },
+});
+
+const MODEL: ChatModelOption = {
+  key: 'provider-1::model-1',
+  providerId: 'provider-1',
+  providerName: 'Main provider',
+  modelId: 'model-1',
+  modelName: 'Model 1',
+};
+
+function createMessageEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+  return {
+    type: 'message.completed',
+    runId: 'server-run-1',
+    status: 'completed',
+    content: 'final content',
+    userMessage: { id: 'user-1', content: 'hello' },
+    assistantMessage: { id: 'assistant-1', content: 'final content' },
+    ...overrides,
+  } as AssistantEvent;
+}
+
+function createConversationDTO(id: string) {
+  return {
+    id,
+    identityId: 'identity-1',
+    name: 'New chat',
+    createdAt: 1,
+    updatedAt: 2,
+    messageCount: 0,
+    lastMessageAt: null,
+  };
+}
+
+type ServiceStub = {
+  createConversation: ReturnType<typeof vi.fn>;
+  listConversations: ReturnType<typeof vi.fn>;
+  dispatchAssistant: ReturnType<typeof vi.fn>;
+  listMessages: ReturnType<typeof vi.fn>;
+};
+
+function createServiceStub(overrides: Partial<ServiceStub> = {}): ServiceStub {
+  return {
+    createConversation: vi.fn(async () => ok(createConversationDTO('conv-1'))),
+    listConversations: vi.fn(async () =>
+      ok({ data: [{ id: 'conv-1', name: 'New chat' }], total: 1, page: 1, pageSize: 24 }),
+    ),
+    dispatchAssistant: vi.fn(async () => {}),
+    listMessages: vi.fn(async () => ok({ data: [], total: 0, page: 1, pageSize: 80 })),
+    ...overrides,
+  };
+}
+
+function mountComposable(service: ServiceStub, surface: 'web' | 'desktop' = 'web') {
+  let composable!: ReturnType<typeof useAIChatSession>;
+  const options: UseAIChatSessionOptions = {
+    service,
+    surface,
+    getDefaultConversationName: () => 'New chat',
+  };
+  mount(
+    defineComponent({
+      setup() {
+        composable = useAIChatSession(options);
+        return () => h('div');
+      },
+    }),
+    { global: { plugins: [i18n] } },
+  );
+  return composable;
+}
+
+function runDispatch(
+  composable: ReturnType<typeof useAIChatSession>,
+  service: ServiceStub,
+  events: AssistantEvent[],
+  dispatchImpl?: ServiceStub['dispatchAssistant'],
+) {
+  if (dispatchImpl) {
+    service.dispatchAssistant.mockImplementation(dispatchImpl);
+  } else {
+    service.dispatchAssistant.mockImplementation(async (_command, handlers) => {
+      for (const event of events) {
+        handlers.onEvent?.(event);
+      }
+    });
+  }
+  composable.chatMessage.value = 'hello';
+  return composable.handleSendChat(service as never, MODEL, 'New chat', () => {});
+}
+
+describe('useAIChatSession open chat Host dispatch (residual 349/351)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('creates a conversation then dispatches through the thin entry with model + surface', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(composable, service, []);
+
+    expect(service.createConversation).toHaveBeenCalledWith({ name: 'New chat' });
+    expect(service.dispatchAssistant).toHaveBeenCalledTimes(1);
+    const [command] = service.dispatchAssistant.mock.calls[0];
+    expect(command).toMatchObject({
+      type: 'message',
+      conversationId: 'conv-1',
+      content: 'hello',
+      surface: 'web',
+      executionProfileId: 'direct_turn',
+      providerId: 'provider-1',
+      model: 'model-1',
+    });
+    expect(command).toHaveProperty('runId');
+    expect(command.runId).toMatch(/^open-chat:/);
+    expect(command).not.toHaveProperty('identityId');
+    expect(composable.chatLoading.value).toBe(false);
+  });
+
+  it('desktop host option flows the desktop surface on the command', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'desktop');
+
+    await runDispatch(composable, service, []);
+
+    expect(service.dispatchAssistant.mock.calls[0][0]).toMatchObject({
+      type: 'message',
+      surface: 'desktop',
+    });
+  });
+
+  it('appends every message.delta to the current assistant draft', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(composable, service, [
+      {
+        type: 'run.started',
+        runId: 'server-run-1',
+        engineId: 'engine.direct_turn',
+        profile: 'direct_turn',
+        conversationId: 'conv-1',
+      },
+      { type: 'message.delta', runId: 'server-run-1', content: 'Hel' },
+      { type: 'message.delta', runId: 'server-run-1', content: 'lo' },
+      createMessageEvent(),
+    ]);
+
+    const assistant = composable.chatTimeline.value.find(
+      (item) => item.role === 'assistant' && item.id === 'assistant-1',
+    );
+    expect(assistant).toBeDefined();
+    expect(assistant?.content).toBe('final content');
+    expect(assistant?.status).toBe('success');
+
+    const user = composable.chatTimeline.value.find((item) => item.role === 'user');
+    expect(user?.id).toBe('user-1');
+    expect(user?.content).toBe('hello');
+  });
+
+  it('message.completed replaces both drafts with persisted ids and refreshes the list', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(composable, service, [createMessageEvent()]);
+
+    expect(service.listConversations).toHaveBeenCalled();
+    const ids = composable.chatTimeline.value.map((item) => item.id);
+    expect(ids).toContain('assistant-1');
+    expect(ids).toContain('user-1');
+    expect(composable.chatTimeline.value.some((item) => item.status === 'generating')).toBe(false);
+  });
+
+  it('server-rewritten runId is tracked and the pre-start client row is dropped', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(composable, service, [
+      {
+        type: 'run.started',
+        runId: 'server-run-9',
+        engineId: 'engine.direct_turn',
+        profile: 'direct_turn',
+      },
+      createMessageEvent({ runId: 'server-run-9' }),
+    ]);
+
+    const turns = composable.openChatHostTurns.value;
+    expect(turns.some((turn) => turn.runId === 'server-run-9')).toBe(true);
+    expect(turns.some((turn) => turn.runId === 'server-run-1')).toBe(false);
+  });
+
+  it('marks the assistant draft aborted on abort-like errors with no generating residue', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(
+      composable,
+      service,
+      [],
+      vi.fn(async () => {
+        throw new DOMException('The user aborted a request.', 'AbortError');
+      }),
+    );
+
+    const assistant = composable.chatTimeline.value.find((item) => item.role === 'assistant');
+    expect(assistant?.status).toBe('aborted');
+    expect(composable.chatLoading.value).toBe(false);
+    expect(composable.chatTimeline.value.some((item) => item.status === 'generating')).toBe(false);
+  });
+
+  it('marks the assistant draft error and toasts on a failed dispatch', async () => {
+    const service = createServiceStub();
+    const composable = mountComposable(service, 'web');
+
+    await runDispatch(
+      composable,
+      service,
+      [],
+      vi.fn(async () => {
+        throw new Error('provider unavailable');
+      }),
+    );
+
+    const assistant = composable.chatTimeline.value.find((item) => item.role === 'assistant');
+    expect(assistant?.status).toBe('error');
+    expect(assistant?.errorMessage).toBeDefined();
+    expect(toastMocks.error).toHaveBeenCalled();
+    expect(composable.chatLoading.value).toBe(false);
+  });
+});

--- a/packages/app-vue/src/modules/ai/composables/useAIChatSession.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAIChatSession.ts
@@ -1,7 +1,5 @@
 import { computed, nextTick, ref } from 'vue';
-import type {
-  AssistantEvent,
-} from '@memoflow/contracts/ai';
+import type { AssistantEvent, AssistantSurface } from '@memoflow/contracts/ai';
 import { useI18n } from 'vue-i18n';
 import { toast } from 'vue-sonner';
 import type {
@@ -13,6 +11,7 @@ import type {
 } from './types';
 import { unwrap } from '@memoflow/contracts/result';
 import { getAIErrorMessage } from './error';
+import { useAssistantDispatch } from './useAssistantDispatch';
 import {
   buildHostOpenChatStopCancelCommand,
   createHostOpenChatRunId,
@@ -32,6 +31,8 @@ type DeleteConversationId = Parameters<AIChatService['deleteConversation']>[0];
 
 export interface UseAIChatSessionOptions {
   service: AIChatService;
+  /** Host-provided Assistant surface tag (web / desktop / server). */
+  surface: AssistantSurface;
   getDefaultConversationName: (mode: string) => string;
   onConversationCreated?: (id: string) => void;
   restoreWorkflowState?: (id: string) => void;
@@ -39,6 +40,11 @@ export interface UseAIChatSessionOptions {
 
 export function useAIChatSession(options: UseAIChatSessionOptions) {
   const { t } = useI18n();
+
+  // Residual 349/351: open chat sends exclusively through the thin entry, never
+  // through streamMessage / sendMessage. surface is host-provided (DI), never
+  // guessed from window.
+  const assistantDispatch = useAssistantDispatch({ service: options.service });
 
   const chatMessage = ref('');
   const chatLoading = ref(false);
@@ -106,10 +112,7 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
     return 'assistant';
   }
 
-  function normalizeChatItem(
-    item: Partial<ConversationMessageSummary>,
-    index: number,
-  ): ChatItem {
+  function normalizeChatItem(item: Partial<ConversationMessageSummary>, index: number): ChatItem {
     return {
       id: item.id ? String(item.id) : `message-${index}`,
       role: normalizeChatRole(item.role),
@@ -213,8 +216,7 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
     // Residual 403: keep open-chat multi-engine badges across conversation switches.
     stashOpenChatHostTurnsForCurrentConversation();
     chatConversationId.value = item.id;
-    conversationTitle.value =
-      item.name || t('aiAssistant.dialogs.chat.defaultConversationName');
+    conversationTitle.value = item.name || t('aiAssistant.dialogs.chat.defaultConversationName');
     updateLastActiveConversation(String(item.id));
     syncModel(getConversationModelKey(String(item.id)));
     restoreOpenChatHostTurns(String(item.id));
@@ -241,10 +243,7 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
       onClearWorkflow(id);
       onClearModel(id);
       // Residual 403: drop session open-chat turn memory for deleted conversation.
-      openChatHostTurnMemory = forgetOpenChatHostTurnsForConversation(
-        openChatHostTurnMemory,
-        id,
-      );
+      openChatHostTurnMemory = forgetOpenChatHostTurnsForConversation(openChatHostTurnMemory, id);
       if (chatConversationId.value === id) {
         startNewConversation();
       }
@@ -258,10 +257,7 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
     }
   }
 
-  async function ensureConversationCreated(
-    loadService: AIChatService,
-    conversationName: string,
-  ) {
+  async function ensureConversationCreated(loadService: AIChatService, conversationName: string) {
     if (chatConversationId.value) return chatConversationId.value;
     const conversation = unwrap(
       await loadService.createConversation({
@@ -334,129 +330,129 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
       await nextTick();
       adjustComposerHeight();
 
-      // Residual 351: open chat default path via AssistantFacade Host dispatch.
+      // Residual 351: open chat default path via AssistantFacade Host dispatch,
+      // routed through the thin entry (residual 349). Never streamMessage.
       let sawCompleted = false;
-      await loadService.dispatchAssistant(
-        {
-          type: 'message',
-          conversationId,
-          content: pendingUserMessage,
-          surface: 'web',
-          runId: hostRunId,
-          // Residual 369: multi-engine Host profile selection for open chat.
-          executionProfileId: executionProfileId.value,
-          providerId: selectedModel.providerId,
-          model: selectedModel.modelId,
-        },
-        {
-          onEvent: (event: AssistantEvent) => {
-            if (event.type === 'run.started' && event.runId) {
-              activeHostRunId.value = event.runId;
-              const existing = openChatHostTurns.value.find((turn) => turn.runId === hostRunId);
-              upsertOpenChatHostTurn({
-                runId: event.runId,
-                executionProfileId:
-                  event.profile === 'pi_readonly'
-                    ? 'pi_readonly'
-                    : existing?.executionProfileId ?? profileForTurn,
-                status: 'generating',
-                title: existing?.title ?? pendingUserMessage,
-                summary: existing?.summary ?? '',
-                engineId: event.engineId,
-              });
-              // If server rewrote runId, drop the pre-start client id row.
-              if (event.runId !== hostRunId) {
-                openChatHostTurns.value = openChatHostTurns.value.filter(
-                  (turn) => turn.runId !== hostRunId,
-                );
-              }
-            }
-            if (isHostOpenChatCancelledEvent(event)) {
-              const target = chatTimeline.value.find((item) => item.id === assistantDraftId);
-              if (target && target.status === 'generating') {
-                target.status = 'aborted';
-                target.errorMessage = undefined;
-              }
-              const runKey = activeHostRunId.value ?? hostRunId;
-              const existing = openChatHostTurns.value.find((turn) => turn.runId === runKey);
-              if (existing) {
-                upsertOpenChatHostTurn({ ...existing, status: 'aborted' });
-              }
-            }
-            if (event.type === 'message.delta') {
-              const target = chatTimeline.value.find((item) => item.id === assistantDraftId);
-              if (target) {
-                target.content += event.content;
-                target.status = 'generating';
-                target.errorMessage = undefined;
-              }
-              return;
-            }
-
-            if (event.type === 'message.completed') {
-              sawCompleted = true;
-              const completedRunId = event.runId || activeHostRunId.value || hostRunId;
-              const existingTurn = openChatHostTurns.value.find(
-                (turn) => turn.runId === completedRunId || turn.runId === hostRunId,
+      await assistantDispatch.dispatchMessage({
+        conversationId,
+        content: pendingUserMessage,
+        surface: options.surface,
+        runId: hostRunId,
+        // Residual 369: multi-engine Host profile selection for open chat.
+        executionProfileId: executionProfileId.value,
+        providerId: selectedModel.providerId,
+        model: selectedModel.modelId,
+        signal: streamController.signal,
+        onEvent: (event: AssistantEvent) => {
+          if (event.type === 'run.started' && event.runId) {
+            activeHostRunId.value = event.runId;
+            const existing = openChatHostTurns.value.find((turn) => turn.runId === hostRunId);
+            upsertOpenChatHostTurn({
+              runId: event.runId,
+              executionProfileId:
+                event.profile === 'pi_readonly'
+                  ? 'pi_readonly'
+                  : (existing?.executionProfileId ?? profileForTurn),
+              status: 'generating',
+              title: existing?.title ?? pendingUserMessage,
+              summary: existing?.summary ?? '',
+              engineId: event.engineId,
+            });
+            // If server rewrote runId, drop the pre-start client id row.
+            if (event.runId !== hostRunId) {
+              openChatHostTurns.value = openChatHostTurns.value.filter(
+                (turn) => turn.runId !== hostRunId,
               );
-              if (existingTurn || completedRunId) {
-                const nextStatus =
+            }
+          }
+          if (isHostOpenChatCancelledEvent(event)) {
+            const target = chatTimeline.value.find((item) => item.id === assistantDraftId);
+            if (target && target.status === 'generating') {
+              target.status = 'aborted';
+              target.errorMessage = undefined;
+            }
+            const runKey = activeHostRunId.value ?? hostRunId;
+            const existing = openChatHostTurns.value.find((turn) => turn.runId === runKey);
+            if (existing) {
+              upsertOpenChatHostTurn({ ...existing, status: 'aborted' });
+            }
+          }
+          if (event.type === 'message.delta') {
+            const target = chatTimeline.value.find((item) => item.id === assistantDraftId);
+            if (target) {
+              target.content += event.content;
+              target.status = 'generating';
+              target.errorMessage = undefined;
+            }
+            return;
+          }
+
+          if (event.type === 'message.completed') {
+            sawCompleted = true;
+            const completedRunId = event.runId || activeHostRunId.value || hostRunId;
+            const existingTurn = openChatHostTurns.value.find(
+              (turn) => turn.runId === completedRunId || turn.runId === hostRunId,
+            );
+            if (existingTurn || completedRunId) {
+              const nextStatus =
+                event.status === 'aborted'
+                  ? 'aborted'
+                  : event.status === 'failed'
+                    ? 'failed'
+                    : 'completed';
+              upsertOpenChatHostTurn({
+                runId: completedRunId,
+                executionProfileId: existingTurn?.executionProfileId ?? profileForTurn,
+                status: nextStatus,
+                title: existingTurn?.title ?? pendingUserMessage,
+                summary: (event.content ?? '').trim().slice(0, 240) || existingTurn?.summary || '',
+                engineId: existingTurn?.engineId,
+              });
+            }
+            const assistantIndex = chatTimeline.value.findIndex(
+              (item) => item.id === assistantDraftId,
+            );
+            if (assistantIndex >= 0) {
+              chatTimeline.value[assistantIndex] = {
+                id: event.assistantMessage?.id
+                  ? String(event.assistantMessage.id)
+                  : assistantDraftId,
+                role: 'assistant',
+                content:
+                  event.assistantMessage?.content ??
+                  event.content ??
+                  chatTimeline.value[assistantIndex]?.content ??
+                  '',
+                status:
                   event.status === 'aborted'
                     ? 'aborted'
                     : event.status === 'failed'
-                      ? 'failed'
-                      : 'completed';
-                upsertOpenChatHostTurn({
-                  runId: completedRunId,
-                  executionProfileId: existingTurn?.executionProfileId ?? profileForTurn,
-                  status: nextStatus,
-                  title: existingTurn?.title ?? pendingUserMessage,
-                  summary:
-                    (event.content ?? '').trim().slice(0, 240) || existingTurn?.summary || '',
-                  engineId: existingTurn?.engineId,
-                });
-              }
-              const assistantIndex = chatTimeline.value.findIndex(
-                (item) => item.id === assistantDraftId,
-              );
-              if (assistantIndex >= 0) {
-                chatTimeline.value[assistantIndex] = {
-                  id: event.assistantMessage?.id
-                    ? String(event.assistantMessage.id)
-                    : assistantDraftId,
-                  role: 'assistant',
-                  content:
-                    event.assistantMessage?.content ??
-                    event.content ??
-                    chatTimeline.value[assistantIndex]?.content ??
-                    '',
-                  status: event.status === 'aborted' ? 'aborted' : event.status === 'failed' ? 'error' : 'success',
-                  errorMessage: event.error,
-                };
-              }
-              const userIndex = chatTimeline.value.findIndex((item) => item.id === userDraftId);
-              if (userIndex >= 0 && event.userMessage) {
-                chatTimeline.value[userIndex] = {
-                  id: String(event.userMessage.id),
-                  role: 'user',
-                  content: event.userMessage.content,
-                  status: 'success',
-                };
-              }
-              return;
+                      ? 'error'
+                      : 'success',
+                errorMessage: event.error,
+              };
             }
+            const userIndex = chatTimeline.value.findIndex((item) => item.id === userDraftId);
+            if (userIndex >= 0 && event.userMessage) {
+              chatTimeline.value[userIndex] = {
+                id: String(event.userMessage.id),
+                role: 'user',
+                content: event.userMessage.content,
+                status: 'success',
+              };
+            }
+            return;
+          }
 
-            if (event.type === 'error') {
-              const assistantDraft = chatTimeline.value.find((item) => item.id === assistantDraftId);
-              if (assistantDraft) {
-                assistantDraft.status = 'error';
-                assistantDraft.errorMessage = event.message;
-              }
+          if (event.type === 'error') {
+            const assistantDraft = chatTimeline.value.find((item) => item.id === assistantDraftId);
+            if (assistantDraft) {
+              assistantDraft.status = 'error';
+              assistantDraft.errorMessage = event.message;
             }
-          },
+          }
         },
-        streamController.signal,
-      );
+      });
       if (sawCompleted) {
         await loadConversationList(loadService);
       }

--- a/packages/app-vue/src/modules/ai/composables/useAIChatView.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAIChatView.ts
@@ -28,6 +28,8 @@ import {
   maybeRenameConversation,
 } from './chatViewHelpers';
 import { unwrap } from '@memoflow/contracts/result';
+import { useStrictInject } from '../../../shared/utils/useStrictInject';
+import { ASSISTANT_SURFACE_KEY } from '../../../di/keys';
 import type {
   AIWorkspaceRecentGoal,
   AIWorkspaceRecentKnowledgeNote,
@@ -44,6 +46,8 @@ export function useAIChatView(options: UseAIChatViewOptions) {
   const { t } = useI18n();
   const router = useRouter();
   const { service, providers, loadProviders } = useAI();
+  // Residual 349: host-provided surface tag; shared composables never sniff window.
+  const assistantSurface = useStrictInject(ASSISTANT_SURFACE_KEY, 'AssistantSurface');
   const { goals, fetchGoals, createGoal } = useGoal();
   const recentKnowledgeNotes = useRecentKnowledgeNotes();
   const formatters = useAIFormatters();
@@ -133,6 +137,7 @@ export function useAIChatView(options: UseAIChatViewOptions) {
   // 1. Chat session
   const chatSession = useAIChatSession({
     service,
+    surface: assistantSurface,
     getDefaultConversationName,
     onConversationCreated: (id) => _persistWorkflowAndModel?.(id),
   });

--- a/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.spec.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.spec.ts
@@ -85,4 +85,103 @@ describe('useAssistantDispatch', () => {
       revision: 1,
     });
   });
+
+  it.each([
+    { surface: 'web', label: 'web' },
+    { surface: 'desktop', label: 'desktop' },
+  ] as const)(
+    'carries the explicit $label surface on the command (no window sniffing)',
+    async ({ surface }) => {
+      const dispatchAssistant = vi.fn(async () => {});
+      const api = useAssistantDispatch({ service: { dispatchAssistant } });
+
+      await api.dispatchMessage({
+        conversationId: 'conv-1',
+        content: 'hello',
+        surface,
+        runId: 'run-1',
+        executionProfileId: 'direct_turn',
+        providerId: 'provider-1',
+        model: 'model-1',
+      });
+
+      expect(dispatchAssistant.mock.calls[0][0]).toMatchObject({
+        type: 'message',
+        conversationId: 'conv-1',
+        content: 'hello',
+        surface,
+        runId: 'run-1',
+        executionProfileId: 'direct_turn',
+        providerId: 'provider-1',
+        model: 'model-1',
+      });
+    },
+  );
+
+  it('resets dispatch state after a failed dispatch and never leaves lastEvents generating', async () => {
+    const dispatchAssistant = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const api = useAssistantDispatch({ service: { dispatchAssistant } });
+
+    await expect(
+      api.dispatchMessage({ conversationId: 'c', content: 'x', surface: 'web' }),
+    ).rejects.toThrow('boom');
+    expect(api.dispatching.value).toBe(false);
+    expect(api.lastError.value).toBe('boom');
+    expect(api.lastEvents.value).toEqual([]);
+  });
+
+  it('aborts an active dispatch via its own controller and via an external signal', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const dispatchAssistant = vi.fn((_command, _handlers, signal) => {
+      capturedSignal = signal;
+      return new Promise<void>((_resolve, reject) => {
+        const onAbort = () => reject(new Error('aborted'));
+        signal?.addEventListener('abort', onAbort, { once: true });
+      });
+    });
+    const api = useAssistantDispatch({ service: { dispatchAssistant } });
+
+    const run = api.dispatchMessage({
+      conversationId: 'c',
+      content: 'x',
+      surface: 'desktop',
+    });
+    await Promise.resolve();
+    expect(capturedSignal?.aborted).toBe(false);
+    api.abortActiveDispatch();
+    await expect(run).rejects.toThrow();
+    expect(api.dispatching.value).toBe(false);
+  });
+
+  it('propagates an external abort signal into the service call', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const pending = new Promise<void>(() => {});
+    const dispatchAssistant = vi.fn((_command, _handlers, signal) => {
+      capturedSignal = signal;
+      return new Promise<void>((resolve, reject) => {
+        const onAbort = () => reject(new Error('aborted'));
+        signal?.addEventListener('abort', onAbort, { once: true });
+        pending.then(() => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        });
+      });
+    });
+    const api = useAssistantDispatch({ service: { dispatchAssistant } });
+    const external = new AbortController();
+
+    const run = api.dispatchMessage({
+      conversationId: 'c',
+      content: 'x',
+      surface: 'web',
+      signal: external.signal,
+    });
+    await Promise.resolve();
+    external.abort();
+    await expect(run).rejects.toThrow();
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(api.dispatching.value).toBe(false);
+  });
 });

--- a/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.ts
@@ -1,9 +1,14 @@
 /**
  * useAssistantDispatch — residual 349 thin UI entry for AssistantFacade.
  *
- * Routes Host commands through AIClientPort.dispatchAssistant (Web HTTP/SSE).
- * Never places identityId in the command body. Does not switch the full chat
- * workbench yet; open chat default path remains the existing chat session until residual follow-up.
+ * Routes Host commands through AIChatService.dispatchAssistant (Web HTTP/SSE or
+ * Desktop IPC). Never places identityId in the command body, and the entry only
+ * exposes dispatchAssistant — it never calls streamMessage / sendMessage. The
+ * caller must provide an explicit `surface` (host-provided via DI); this shared
+ * composable does not sniff `window` to guess the platform.
+ *
+ * Open chat send flows through `useAIChatSession`, which uses
+ * `dispatchMessage()` from this entry (residual 349/351).
  */
 import { ref } from 'vue';
 import type { AssistantClientCommand, AssistantEvent } from '@memoflow/contracts/ai';
@@ -29,6 +34,7 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
     handlers?: {
       onEvent?: (event: AssistantEvent) => void;
     },
+    externalSignal?: AbortSignal,
   ): Promise<AssistantEvent[]> {
     if ('identityId' in (command as object)) {
       throw new Error('identityId must not be included in AssistantClientCommand');
@@ -41,6 +47,13 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
     lastError.value = null;
     const collected: AssistantEvent[] = [];
     lastEvents.value = collected;
+
+    const onExternalAbort = () => controller.abort();
+    if (externalSignal?.aborted) {
+      controller.abort();
+    } else {
+      externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+    }
 
     try {
       await options.service.dispatchAssistant(
@@ -59,6 +72,7 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
       lastError.value = error instanceof Error ? error.message : 'Assistant dispatch failed';
       throw error;
     } finally {
+      externalSignal?.removeEventListener('abort', onExternalAbort);
       if (activeAbortController.value === controller) {
         activeAbortController.value = null;
       }
@@ -69,11 +83,12 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
   async function dispatchMessage(input: {
     conversationId: string;
     content: string;
-    surface?: 'web' | 'desktop' | 'server';
+    surface: 'web' | 'desktop' | 'server';
     runId?: string;
     executionProfileId?: 'direct_turn' | 'pi_readonly';
     providerId?: string;
     model?: string;
+    signal?: AbortSignal;
     onEvent?: (event: AssistantEvent) => void;
   }) {
     return dispatch(
@@ -81,13 +96,14 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
         type: 'message',
         conversationId: input.conversationId,
         content: input.content,
-        surface: input.surface ?? 'web',
+        surface: input.surface,
         runId: input.runId,
         executionProfileId: input.executionProfileId,
         providerId: input.providerId,
         model: input.model,
       },
       { onEvent: input.onEvent },
+      input.signal,
     );
   }
 
@@ -152,10 +168,7 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
     );
   }
 
-  async function cancelRun(input: {
-    runId: string;
-    onEvent?: (event: AssistantEvent) => void;
-  }) {
+  async function cancelRun(input: { runId: string; onEvent?: (event: AssistantEvent) => void }) {
     return dispatch(
       {
         type: 'cancel_run',

--- a/packages/app-vue/src/modules/ai/views/AIChatView.spec.ts
+++ b/packages/app-vue/src/modules/ai/views/AIChatView.spec.ts
@@ -44,7 +44,7 @@ vi.mock('../../setting/composables/useUserSetting', () => ({
 }));
 
 import AIChatView from './AIChatView.vue';
-import { DASHBOARD_SERVICE_KEY, TASK_SERVICE_KEY } from '../../../di/keys';
+import { ASSISTANT_SURFACE_KEY, DASHBOARD_SERVICE_KEY, TASK_SERVICE_KEY } from '../../../di/keys';
 import { VueQueryPlugin } from '@tanstack/vue-query';
 import {
   createTestServerStateRuntime,
@@ -1219,6 +1219,7 @@ function mountView() {
         [DASHBOARD_SERVICE_KEY as symbol]: dashboardServiceFake,
         // Residual 1332: AIChatView mounts useTaskTemplateMutations() for Host task.create settlement.
         [TASK_SERVICE_KEY as symbol]: taskServiceFake,
+        [ASSISTANT_SURFACE_KEY as symbol]: 'web',
         [SERVER_STATE_RUNTIME_KEY]: runtime,
         [SERVER_STATE_IDENTITY_SCOPE_KEY]: () => 'identity-1',
       },

--- a/packages/app-vue/src/web-core.ts
+++ b/packages/app-vue/src/web-core.ts
@@ -14,6 +14,7 @@ export {
   DASHBOARD_SERVICE_KEY,
   MODULE_CAPSULES_KEY,
   LOGOUT_HANDLER_KEY,
+  ASSISTANT_SURFACE_KEY,
 } from './di/keys';
 
 export { defaultModuleCapsules } from './di/navigation';

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -2047,6 +2047,16 @@
       ]
     },
     {
+      "path": "packages/ai/src/application-client/ai-client-service.dispatch-assistant.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/ai/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/ai/vitest.config.ts"
+      ]
+    },
+    {
       "path": "packages/ai/src/electron/ai-electron.surface.spec.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -3578,6 +3588,14 @@
     },
     {
       "path": "packages/app-vue/src/modules/ai/composables/useAI.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/app-vue/vitest.config.ts"
+      ],
+      "measurementCollectors": []
+    },
+    {
+      "path": "packages/app-vue/src/modules/ai/composables/useAIChatSession.spec.ts",
       "primarySuite": "unit",
       "collectors": [
         "packages/app-vue/vitest.config.ts"
@@ -10157,21 +10175,21 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 122
+      "fileCount": 123
     },
     {
       "id": "packages/ai/vitest.config.ts",
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 122
+      "fileCount": 123
     },
     {
       "id": "packages/app-vue/vitest.config.ts",
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 186
+      "fileCount": 187
     },
     {
       "id": "packages/app-vue/vitest.store-coverage.config.ts",
@@ -10714,6 +10732,7 @@
       "packages/ai/src/api/routes/ai-langgraph-checkpoint.routes.test.ts",
       "packages/ai/src/api/routes/ai-void-success-envelope.surface.spec.ts",
       "packages/ai/src/application-client/ai-client-port-facade-dual.surface.spec.ts",
+      "packages/ai/src/application-client/ai-client-service.dispatch-assistant.spec.ts",
       "packages/ai/src/electron/ai-electron.surface.spec.ts",
       "packages/ai/src/electron/assistant-dispatch-lifecycle.spec.ts",
       "packages/ai/src/electron/index-lifecycle.spec.ts",
@@ -11217,7 +11236,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 960,
+    "unit": 962,
     "integration": 25,
     "smoke": 3,
     "boundary-ipc": 9,


### PR DESCRIPTION
Completes residual 349/351 per docs/plan/active/2026-08-15-agent-host-open-chat-dispatch.md.

Step C: AssistantSurface injection (web/desktop, no window sniffing); useAIChatSession via useAssistantDispatch().dispatchMessage; runId/executionProfileId/surface/model carried in command; delta/completed draft semantics; per-conversation model selection.
Step D: assistant-dispatch-policy.ts classifyAssistantDispatchFallback (§4.5 whitelist, fail-closed); dispatchAssistantWithPolicy (dispatch first, observed-event tracking); prefer_dispatch/dispatch_only/legacy_only flags; legacy_only rejects pi_readonly/proposal/cancel; ADR-035 + path-map updated.

Tests: app-vue 1024 / ai 865; typecheck/lint/prettier/gates/inventory green.