### PR TITLE
docs(architecture): define application failure contract refactor

### DIFF
--- a/docs/analysis/2026-08-17-failure-contract-library-and-open-source-study.md
+++ b/docs/analysis/2026-08-17-failure-contract-library-and-open-source-study.md
@@ -1,0 +1,1055 @@
+---
+tags:
+  - analysis
+  - architecture
+  - contracts
+  - error-handling
+  - libraries
+  - open-source
+description: MemoFlow failure/outcome 重构前的 TypeScript 库、协议标准与开源实现研究及设计修订
+created: 2026-08-17T00:00:00+09:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
+# Failure Contract Library and Open-Source Study / 失败契约库与开源实现研究
+
+## 1. 文档定位
+
+本文是 ADR-049 与全应用架构重构计划的**前置设计验证材料**。
+
+第一版审计已经确认 MemoFlow 存在 provider error 泄漏、message 作为隐式协议、DomainError 混合
+HTTP/diagnostic、正常流程状态被建模成 error、contracts 绝对中心化等系统性问题。但在修改生产代码前，
+还需要回答三个问题：
+
+1. TypeScript 生态中是否已有值得直接复用的 Result、pattern matching、state machine、effect/runtime
+   或 error contract 库；
+2. 成熟开源项目和协议标准如何划分 code、message、details、retry、recovery、provider cause 与
+   transport status；
+3. MemoFlow 应该采用、借鉴、延后还是明确拒绝哪些方案，避免重复造轮子，也避免为“统一错误”
+   引入一个新的全局框架。
+
+本文只更新设计与计划，不引入 npm 依赖，不修改生产代码，不宣称 ADR-049 已被实施。
+
+## 2. 当前 MemoFlow 技术基线
+
+### 2.1 已有能力
+
+MemoFlow 已经拥有：
+
+- 自有 `Result<T>`、`HttpResponse<T>`、`IpcResult<T>`；
+- Zod 4 schema 与 Zod-to-OpenAPI；
+- HTTP/IPC adapter-owned validation 与 parity fixtures；
+- Vue 3、TanStack Vue Query；
+- TypeScript strict mode；
+- host runtime composer、feature package、consumer-owned Port 的部分实践；
+- reliable operation receipt、lease、retry/dead-letter、timeline/replay；
+- OpenTelemetry opt-in 与结构化日志；
+- AST-based governance 和 architecture surface mutation tests。
+
+因此，候选库必须证明它解决的是 MemoFlow **尚未解决的问题**，而不是重新实现已有基础设施。
+
+### 2.2 当前依赖事实
+
+仓库当前未安装：
+
+- `ts-pattern`；
+- `neverthrow`；
+- `effect`；
+- `xstate`；
+- `@xstate/vue`；
+- `fp-ts`；
+- `true-myth`；
+- `oxide.ts`。
+
+已经广泛安装：
+
+- `zod@4.4.x`；
+- `@tanstack/vue-query@5.101.x`（app-vue）；
+- TypeScript 6.x；
+- RxJS 7.x（但不是当前 operation Result 的所有者）。
+
+这意味着任何新库都会新增认知、依赖、构建和治理成本，不能以“社区流行”作为采用理由。
+
+## 3. 评估标准
+
+所有候选方案按以下标准评估：
+
+| 维度            | 问题                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------- |
+| 语义适配        | 是否支持 Domain Fault、Outcome、Public Failure、Provider ACL 的分层，而不是只提供 Error class？ |
+| 增量采用        | 能否在一个 operation 或一个 feature 中试点，而不要求全仓重写？                                  |
+| 现有契约保护    | 是否能保持当前 Result/HTTP/IPC wire envelope？                                                  |
+| 类型穷尽        | 新增 union member/code 后，遗漏 mapping 是否能编译失败或测试失败？                              |
+| 运行时安全      | 是否支持 Zod/schema、JSON-safe payload、unknown/provider input validation？                     |
+| 状态机适配      | 是否适合 Auth、AI HITL、Cloud Connection 等复杂流程，而不是把简单 CRUD 复杂化？                 |
+| 重试正确性      | 是否区分 failure hint、operation idempotency、transaction/workflow-level retry？                |
+| 可观测性        | 是否能区分 expected outcome 与 true failure，避免重复记录 exception？                           |
+| 包体与编译成本  | 对 Web bundle、TypeScript 检查和 CI 时间有什么影响？                                            |
+| 锁定风险        | 是否会把 MemoFlow 的 architecture semantics 绑定到库的 runtime/model？                          |
+| AI/Agent 可读性 | 类型、registry、mapper 与状态图是否容易被人和 Agent 正确修改？                                  |
+| 维护成熟度      | 官方文档、许可证、版本演进、生态和长期维护是否足够可信？                                        |
+
+## 4. 决策摘要
+
+### 4.1 总结表
+
+| 候选                                           | 决策                                     | 用途                                                                | 不用于                                            |
+| ---------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------- |
+| TypeScript discriminated union + `assertNever` | **采用，基础能力**                       | Domain Fault、Outcome、Failure union、mapper 穷尽                   | 不单独承担 runtime validation                     |
+| Zod                                            | **继续采用，唯一 wire runtime schema**   | provider input、public failure details、HTTP/IPC/durable validation | 不放进纯 Domain invariant 内部                    |
+| `ts-pattern`                                   | **延期，本轮不引入依赖**                 | 未来 bounded mapper benchmark 候选                                  | 不替代默认 `switch + assertNever`                 |
+| `neverthrow`                                   | **不替换核心；借鉴 API 与 lint 思想**    | `mapErr`/`andThen`/Result consumption 设计参考                      | 不重建现有 Result/envelope                        |
+| `eslint-plugin-neverthrow`                     | **不直接采用**                           | “Result 必须消费”理念参考                                           | 不在未采用 neverthrow 时绑定插件                  |
+| XState                                         | **延期；Auth 不采用**                    | 未来 nested/parallel/invoked actor workflow 的独立 ADR 候选         | 不替代 typed reducer、Pinia 或 durable state      |
+| Effect                                         | **本轮不采用；未来隔离实验**             | 未来可能用于独立 AI/worker runtime 的 structured concurrency        | 不作为全仓 failure foundation                     |
+| RFC 9457                                       | **语义参考，暂不替换 envelope**          | HTTP problem projection、type/detail/security 设计                  | 不破坏当前 HTTP/IPC parity                        |
+| Google AIP-193                                 | **采用设计原则**                         | stable reason + typed metadata；message 不可解析                    | 不采用 server-side localized message 作为 UI 真值 |
+| Google AIP-194                                 | **采用重试原则**                         | retry 由 code + idempotency + operation policy 共同决定             | 不允许 failure 自己单方面决定自动重试             |
+| Connect errors                                 | **采用抽象原则，暂不换 transport**       | 小型公共 category、typed details、protocol-neutral code             | 不迁移到 Connect/gRPC 作为本轮目标                |
+| Temporal Retry Policy                          | **借鉴，不引入平台**                     | activity/workflow retry 分层、declarative policy                    | 不替换现有 reliable messaging/runtime             |
+| Lark CLI error contract                        | **主要治理参考**                         | closed category、stable subtype、cause 不出 wire、CI lint           | 不照搬 CLI exit code 模型                         |
+| Ardan Labs `errs`                              | **参考 public/internal separation**      | safe client message、internal-only diagnostic                       | 不照搬 HTTP status 进入 Domain Error              |
+| Memos                                          | **参考认证安全与 single-flight refresh** | code-driven auth、账号枚举保护、一次 retry                          | 不复制过粗的公共 taxonomy                         |
+| Vendure ErrorResult                            | **参考 expected result union**           | 正常但非成功的 operation branch 进入 schema                         | 不引入 GraphQL                                    |
+
+### 4.2 推荐技术组合
+
+本轮目标组合是：
+
+```text
+MemoFlow-owned Result<T, E>
+  + TypeScript discriminated unions
+  + Zod schemas at boundaries
+  + optional ts-pattern at exhaustive mapping hotspots
+  + optional XState for explicitly approved complex workflows
+  + AST/governance registry checks
+```
+
+不是：
+
+```text
+Effect everywhere
+neverthrow everywhere
+XState everywhere
+one global Error framework
+```
+
+## 5. TypeScript 库评估
+
+## 5.1 TypeScript discriminated unions + `assertNever`
+
+### 能解决什么
+
+TypeScript 原生 discriminated union 足以表达：
+
+```ts
+type SignInOutcome =
+  | { kind: 'authenticated'; session: SessionSnapshot }
+  | { kind: 'email_verification_required'; email: string };
+
+type AuthFailure =
+  | { code: 'AUTH_INVALID_CREDENTIALS'; category: 'unauthenticated' }
+  | { code: 'AUTH_PROVIDER_UNAVAILABLE'; category: 'unavailable' };
+```
+
+配合：
+
+```ts
+function assertNever(value: never, message?: string): never {
+  throw new Error(message ?? `Unexpected value: ${String(value)}`);
+}
+```
+
+可以在 `switch` 中完成编译期穷尽检查。
+
+### 优势
+
+- 零依赖；
+- 不改变运行时；
+- 与现有 Result、Zod、HTTP/IPC 完全兼容；
+- Agent 和开发者容易理解；
+- 可以逐 operation 迁移。
+
+### 局限
+
+- 嵌套 state/event、双 union 匹配会出现大量嵌套 `switch`；
+- `assertNever` 容易忘记写；
+- 不能直接验证网络/provider 输入。
+
+### 决策
+
+作为**默认基础**。任何库都只能增强该模型，不能取代 MemoFlow-owned union 和 contract ownership。
+
+## 5.2 Zod
+
+### 当前价值
+
+MemoFlow 已经使用 Zod 4，且 ADR-048 已将 runtime validation 和 OpenAPI schema 绑定到相同对象。
+因此不应再引入 Effect Schema、ArkType 或第二套 wire schema 作为本轮 failure contract 基础。
+
+Zod 应负责：
+
+- provider response 的最小安全解析；
+- Public Failure params/details；
+- HTTP/IPC/SSE/durable payload；
+- registry 的 machine-readable validation；
+- versioned compatibility parsing。
+
+Zod 不应负责：
+
+- 聚合内部所有不变量；
+- Domain Fault 控制流；
+- UI state machine；
+- retry policy 执行。
+
+### 决策
+
+继续作为**唯一 runtime boundary schema**。这可以减少依赖和 schema 双轨。
+
+## 5.3 `ts-pattern`
+
+官方项目定位是 TypeScript 的 exhaustive pattern matching，支持 discriminated union、嵌套对象、tuple、
+state/event reducer 与 `.exhaustive()`。它适合 MemoFlow 的两个高价值热点：
+
+1. Domain Fault / Provider Failure → Outcome/Public Failure；
+2. complex operation state × event → next state。
+
+示例：
+
+```ts
+return match<[AuthState, AuthEvent]>([state, event])
+  .with([{ status: 'submitting' }, { type: 'verified' }], ([, e]) => ({
+    status: 'authenticated',
+    session: e.session,
+  }))
+  .with([{ status: 'submitting' }, { type: 'verification_required' }], ([, e]) => ({
+    status: 'awaiting_verification',
+    email: e.email,
+  }))
+  .otherwise(() => state);
+```
+
+### 优点
+
+- `.exhaustive()` 可将新增 union member 变成编译错误；
+- 对嵌套 union 和 state/event pair 比手写嵌套 switch 更清晰；
+- 运行时包体较小；
+- 只需在热点使用，可增量采用。
+
+### 风险
+
+- 官方明确说明 exhaustive type checking 会增加 TypeScript 编译工作；
+- 大型 union 与深层模式可能让类型错误难读；
+- 如果到处使用，会形成 DSL 依赖并降低普通 TypeScript 可读性；
+- `.otherwise()` 会吞掉新增分支，不能无条件使用。
+
+### Spike 结果
+
+ACR-R02 以同一十成员 provider union 比较 native `switch + assertNever` 与 `ts-pattern`：两者都能在
+新增 union member 后编译失败；`ts-pattern` 减少了行数，但 isolated median typecheck 为 0.9409 秒，
+native switch 为 0.6515 秒。诊断质量均可接受，native 方案不增加依赖且更符合现有代码风格。
+
+### 决策
+
+**延期，本轮不引入依赖**。默认使用 native `switch + assertNever`。未来只有 bounded mapper 的独立
+benchmark 证明显著可读性收益且 affected typecheck 成本可接受时，才允许另行提出。
+
+官方来源：<https://github.com/gvergnaud/ts-pattern>
+
+## 5.4 `neverthrow`
+
+`neverthrow` 提供 `Result`、`ResultAsync`、`mapErr`、`andThen`、`fromPromise`、`fromThrowable` 和
+`safeTry`。它还提供 lint 思路：Result 必须通过 `match`、`unwrapOr` 或 unsafe unwrap 被消费。
+
+### 与 MemoFlow 的重叠
+
+MemoFlow 已经拥有：
+
+- 自有 `Result<T>`；
+- HTTP/IPC envelope；
+- client adapters；
+- Result-to-transport converters；
+- reliable receipt；
+- 大量 consumer code。
+
+直接换成 neverthrow 会产生：
+
+```text
+Neverthrow Result
+  -> MemoFlow Result
+  -> HttpResponse/IpcResult
+```
+
+或者迫使整个 contracts、client 和 transport 重写。这是另一条长期双轨。
+
+### 值得借鉴的部分
+
+- `map` / `mapErr` / `andThen` 的组合器 API；
+- Promise/throw boundary 必须显式 `fromPromise` / `fromThrowable`；
+- Result 必须被消费的 lint/gate；
+- async pipeline 不在中间重新抛 generic Error。
+
+### 可能的 MemoFlow 实现
+
+在自有 Result 上增加少量函数式 helper：
+
+```ts
+mapResult;
+mapResultError;
+andThenResult;
+fromPromiseResult;
+fromThrowableResult;
+matchResult;
+```
+
+并用自有 governance 检查：
+
+- 未消费的 Result；
+- Result → generic Error rethrow；
+- unchecked `.data` / `.error`；
+- operation boundary 未提供 failure generic。
+
+### 决策
+
+**不替换核心 Result**。借鉴 API 与治理，micro-spike 只验证其 ergonomics，不把它加入生产依赖。
+
+官方来源：<https://github.com/supermacro/neverthrow>
+
+## 5.5 Effect
+
+Effect 提供完整 runtime：
+
+```text
+Effect<Success, Error, Requirements>
+```
+
+以及 typed errors、dependency injection、structured concurrency、scheduling/retry、tracing、metrics、
+schema 和资源管理。
+
+### 优点
+
+- error、dependency、concurrency 在类型中显式；
+- structured concurrency 和 interruption 对 AI/worker 有价值；
+- retry/backoff、resource scope、observability 一体化；
+- 可以渐进地从 Promise 包装进入 Effect。
+
+### 与 MemoFlow 的高重叠
+
+MemoFlow 已经有：
+
+- Result；
+- DI/host composer；
+- Zod schema；
+- reliable messaging、lease、retry/dead-letter；
+- OpenTelemetry；
+- RxJS；
+- TanStack Query；
+- AI Agent runtime、checkpoint、approval、SSE。
+
+引入 Effect 作为底座会同时改变：
+
+- use case signature；
+- dependency injection；
+- retry；
+- resource lifecycle；
+- observability；
+- async mental model；
+- testing；
+- AI/Agent-generated code conventions。
+
+这已经不是错误契约重构，而是 runtime/platform 迁移。
+
+### 版本与迁移风险
+
+Effect 官方正在推进下一代版本演进。即使当前稳定版本可用于生产，本轮也不应在 MemoFlow 大重构
+中同时承担 Effect runtime 迁移风险。
+
+### 未来可能的试点
+
+若后续 AI worker 或独立服务出现以下问题，可以另立实验：
+
+- orphan async task；
+- cancellation/resource scope 难以保证；
+- provider fan-out 与限流复杂；
+- retry/timeout/parallelism 组合代码重复；
+- 单独 deployable service，不要求 Web/Desktop 全仓迁移。
+
+实验必须通过普通 Promise/Port 暴露边界，不能让 Effect type 穿透全部 feature contracts。
+
+### 决策
+
+**本轮不采用**。未来仅允许隔离、可撤销的 AI/worker spike。
+
+官方来源：<https://www.effect.website/>
+
+## 5.6 XState
+
+XState 使用 state machine、statechart 和 actor model 管理复杂状态和异步 actor 生命周期。
+官方支持 Vue，并可检查 actor 生命周期、事件、snapshot 和 transition microstep。
+
+### 真正适合的场景
+
+- Auth：password / GitHub / device code / email verification / reset / retry / cancel；
+- Desktop Cloud Connection：guest/profile/authorization/adoption/reauth；
+- AI HITL：streaming → waiting approval → approved/revised/rejected → executing → receipt；
+- 长生命周期导入/导出或 account closure workflow。
+
+这些流程具备：
+
+- 明确的有限状态；
+- 事件驱动；
+- 并发/取消；
+- invoked async work；
+- 非法 transition；
+- 需要可视化/检查。
+
+### 不适合的场景
+
+- 单个 CRUD mutation 的 idle/loading/success/failure；
+- TanStack Query 已经拥有的 server-state；
+- 简单表单；
+- 仅为统一风格替代 Pinia；
+- durable workflow 的数据库真值（XState actor 不是 durable ledger）。
+
+### 复杂度准入规则
+
+只有满足至少三项才允许提出 XState：
+
+1. 5 个以上业务状态；
+2. 事件在不同状态下有不同合法性；
+3. 有取消、超时、retry 或并行子流程；
+4. 有 invoked actor 生命周期；
+5. 有 Web/Desktop host 差异但共享语义；
+6. 状态图能够明显改善 review 和测试；
+7. 状态需要持久化/恢复的明确定义。
+
+### 与 durable state 的边界
+
+XState 可以拥有内存中的 orchestration state，但：
+
+- session、receipt、approval、operation status 的 durable fact 仍在 DB/ledger；
+- actor snapshot 不能替代 reliable operation receipt；
+- restart/replay 必须从 durable fact 重建；
+- provider adapter 仍输出 MemoFlow outcome/failure。
+
+### Spike 结果与决策
+
+ACR-R02 中 typed reducer 与 XState machine 源码规模相近；XState isolated median typecheck 为 1.0628
+秒，typed reducer 为 0.6530 秒。Auth 流程没有展示出足以抵消第二套 actor/snapshot lifecycle 的收益。
+
+**延期；Auth 不采用**。Auth 使用 feature-owned typed reducer。未来只有 nested/parallel state、invoked
+actors、durable resume 等更复杂 workflow 才可通过独立 ADR/spike 提出，且 actor snapshot 不得成为
+durable fact。
+
+官方来源：
+
+- <https://stately.ai/docs/xstate>
+- <https://stately.ai/docs/actors>
+- <https://stately.ai/docs/invoke>
+- <https://stately.ai/docs/inspection>
+
+## 6. 协议与行业标准
+
+## 6.1 RFC 9457 Problem Details
+
+RFC 9457 定义 HTTP API 的 machine-readable problem details，核心成员包括：
+
+```text
+type
+status
+title
+detail
+instance
+extension members
+```
+
+对 MemoFlow 最有价值的原则：
+
+- HTTP status 无法表达全部业务原因；
+- machine identity 应使用稳定 `type`，不是解析 `detail`；
+- `detail` 是 human-readable，消费者不应解析；
+- extension fields 应被明确设计；
+- problem details 不是暴露 stack/provider internals 的调试工具；
+- 如果应用已有合适格式，不要求强行替换。
+
+### 是否采用
+
+MemoFlow 当前有受保护的 Result/HttpResponse/IpcResult envelope，并要求 HTTP/IPC parity。
+因此不应立即替换成 `application/problem+json`。
+
+建议：
+
+1. 将 ADR-049 的 Public Failure 设计与 RFC 9457 语义对齐；
+2. 为未来外部 HTTP API v2 或 content negotiation 保留 problem-details projection；
+3. 当前内部 Web/Desktop API 继续使用兼容 envelope；
+4. `type` 可由 MemoFlow feature code 文档 URI 推导，但不作为本轮前置条件。
+
+官方来源：<https://www.rfc-editor.org/rfc/rfc9457.html>
+
+## 6.2 Google AIP-193 Errors
+
+AIP-193 的关键设计：
+
+- canonical status code 只提供大类；
+- `ErrorInfo.reason + domain` 是 machine-readable identity；
+  -动态信息放在 typed/defined metadata；
+- message 是开发者可读文本；
+- 任何 message 中的动态事实也必须出现在 metadata，避免客户端解析字符串；
+- metadata key 一旦公开，需要稳定演进；
+  -权限和资源存在性的检查顺序具有安全含义。
+
+### 对 MemoFlow 的直接影响
+
+1. `FailureCategory` 对应大类；
+2. feature failure code 对应 reason；
+3. feature/operation 对应 domain/namespace；
+4. `params` 必须 per-code schema，不能是 arbitrary context；
+5. raw message 不可成为行为协议；
+6. 登录错误必须继续合并不存在账号和密码错误；
+7. UI 本地化继续由客户端完成，才能支持 locale live retranslation。
+
+官方来源：<https://google.aip.dev/193>
+
+## 6.3 Google AIP-194 Automatic Retry
+
+AIP-194 强调：
+
+- 是否自动 retry 不仅由错误码决定；
+- 重复执行不能造成意外状态变化；
+- transaction 不应只 retry 单个请求，而应在更高层重跑完整 transaction；
+- `ABORTED`/concurrency failure 往往需要上层 retry；
+- unauthenticated、permission、not-found、already-exists 等一般不能盲目自动 retry。
+
+这说明第一版 `RetryDirective` 设计混合了三个不同概念，必须拆开。
+
+### 修订后的模型
+
+```ts
+export type FailureRetryHint =
+  { kind: 'not_retryable' } | { kind: 'transient' } | { kind: 'after'; afterMs: number };
+
+export interface OperationRetryPolicy {
+  readonly mode: 'never' | 'safe_read' | 'idempotent_write' | 'transaction' | 'workflow_step';
+  readonly maxAttempts: number;
+  readonly backoff: BackoffPolicy;
+  readonly requiresIdempotencyKey: boolean;
+}
+
+export type RecoveryAction =
+  | { kind: 'none' }
+  | { kind: 'reauthenticate' }
+  | { kind: 'verify_email'; email: string }
+  | { kind: 'correct_input'; fields?: readonly string[] }
+  | { kind: 'resolve_conflict'; resource: string }
+  | { kind: 'retry_manually' };
+```
+
+最终自动 retry 条件：
+
+```text
+failure hint
+  ∩ operation retry policy
+  ∩ idempotency/transaction state
+  ∩ attempt budget/deadline
+  ∩ cancellation state
+```
+
+Public Failure 可以携带服务端事实 `retryAfterMs`，但不能单方面命令客户端重试一个非幂等写入。
+
+官方来源：<https://google.aip.dev/194>
+
+## 6.4 Connect Error Model
+
+Connect 在不同协议间提供同一套 error code API，并支持 typed error details；不同协议再投影成不同 HTTP
+表示。Web client 暴露 code、message/rawMessage、metadata 和 schema-decoded details。
+
+可借鉴：
+
+- 小型全局 category/code set；
+- typed details，不使用 arbitrary context；
+- protocol-neutral application semantics；
+- HTTP representation 是投影，不是核心错误本身；
+- details 应限制为组织内小型、稳定的类型集合；
+- retry/backoff 信息可以作为 typed detail。
+
+不采用：
+
+- 本轮不迁移 Connect/gRPC transport；
+- 不把 16 个 Connect code 当成足够的 feature semantics；
+- 不把 backend raw message 当作 UI 文案。
+
+官方来源：
+
+- <https://connectrpc.com/docs/web/errors/>
+- <https://connectrpc.com/docs/go/errors/>
+
+## 6.5 OpenTelemetry Error Recording
+
+OpenTelemetry semantic conventions 对 MemoFlow 有两个关键约束：
+
+1. 已经被 retry/handle 且 operation 最终正常完成的错误，不应计入该 operation 的 error span/metric；
+2. 同一个 exception 不应在每层重复记录。
+
+因此：
+
+- `email_verification_required`、`waiting_approval`、`already_exists` 幂等 outcome 不应成为 error rate；
+- provider exception 应在最终负责的 instrumentation boundary 记录一次；
+- `error.type` 必须低基数、可预测，不能使用 raw message；
+- public failure code 与 internal provider code 应使用不同 attribute；
+- application 成功处理 provider/transient error 后，不应重复把整个 operation 标成失败。
+
+建议 attributes：
+
+```text
+memoflow.feature
+memoflow.operation
+memoflow.outcome.kind
+memoflow.failure.code
+memoflow.failure.category
+memoflow.provider
+memoflow.provider.code
+```
+
+其中 provider attributes 仅内部 telemetry，不出 public wire。
+
+官方来源：<https://opentelemetry.io/docs/specs/semconv/general/recording-errors/>
+
+## 6.6 Temporal Retry Policy
+
+Temporal 将 Workflow 和 Activity 区分：外部、易失败、非确定性的工作放在 Activity，Activity 有声明式 retry；
+Workflow 本身默认不自动 retry，而是通过 durable history/replay 保持确定性。
+
+MemoFlow 不需要为了错误契约引入 Temporal，但应借鉴：
+
+- retry policy 属于 execution boundary，不属于领域错误对象；
+- provider API、LLM、email、GitHub 等外部动作是 activity-like step；
+- workflow-level retry 和 step-level retry 不相同；
+- retry 必须结合幂等键；
+- durable receipt 记录每个 attempt，而不是只保留最终 message；
+- permanent/non-retryable failure 要显式分类。
+
+MemoFlow 已有 lease、receipt、retry/dead-letter 和 replay，因此当前决策是借鉴模型，不引入平台。
+
+官方来源：<https://docs.temporal.io/encyclopedia/retry-policies>
+
+## 7. 开源项目实现研究
+
+## 7.1 Lark CLI：最值得借鉴的治理模型
+
+Lark CLI 的 error contract 明确区分：
+
+- closed Category；
+- declared stable Subtype；
+- upstream numeric Code；
+- informational Message；
+- actionable Hint；
+- non-serialized Cause；
+- declared per-subtype extension fields；
+- CI 检查未声明 subtype、缺失 required fields 和错误结构。
+
+其核心不变量包括：
+
+```text
+Category + Subtype = wire-stable
+Message = informational
+Cause = internal only
+Unknown fields = forward-compatible
+Undeclared subtype = CI failure
+```
+
+### MemoFlow 应借鉴
+
+1. feature code 和 category 的稳定性等级；
+2. message、recovery hint、cause 分离；
+3. provider code 独立字段，只在内部/特定 wire policy 中存在；
+4. per-code typed extension fields；
+5. mutation/lint 证明 contract gate 有效；
+6. AI Agent 和脚本只根据 stable fields 分支；
+7. compatibility/deprecation policy。
+
+### MemoFlow 不照搬
+
+- CLI exit code；
+  -所有错误必须是 Go typed struct；
+- CLI `hint` 直接出 wire 的统一做法。
+
+MemoFlow 的 recovery 应由 application/presentation policy 结合 host/context 决定，不能把 UI action 固化为服务端字符串。
+
+官方来源：<https://github.com/larksuite/cli/blob/main/errs/ERROR_CONTRACT.md>
+
+## 7.2 Ardan Labs Service：public 与 internal 的分离
+
+Ardan Labs `errs` package 提供稳定 ErrCode、HTTP status mapping、FieldErrors，并有 `InternalOnlyLog`：
+内部错误 message 不发送给客户端。其 Error 中的函数名/文件名也不会进入 JSON。
+
+### 值得借鉴
+
+- safe public error 与 internal diagnostic 明确分开；
+- code → transport status 在统一 adapter 中处理；
+- unknown/internal 不泄漏真实 message；
+- validation field errors 有明确结构。
+
+### 不应照搬
+
+Ardan 的 error package 是 web/service 边界模型，并不意味着 MemoFlow Domain Fault 应携带 HTTP status。
+MemoFlow 的目标比该模板更进一步：Domain Fault 与 public web error 是两层不同类型。
+
+官方来源：
+<https://pkg.go.dev/github.com/ardanlabs/service/app/sdk/errs>
+
+## 7.3 Memos：认证安全与客户端 code-driven behavior
+
+Memos 的密码登录对以下两种内部原因返回同一公开错误：
+
+```text
+user not found
+password mismatch
+  -> same public invalid-credentials response
+```
+
+这可以防止登录账号枚举。
+
+其 Web Connect interceptor：
+
+- 只根据 `ConnectError.code === Code.Unauthenticated` 判断 refresh；
+- retry attempt 只允许一次；
+- 使用 token refresh manager 合并并发 refresh；
+- refresh transport 不挂同一 auth interceptor，避免递归。
+
+### MemoFlow 应借鉴
+
+- 登录不存在与错误密码必须继续统一；
+- code 驱动行为，不匹配 message；
+- single-flight refresh；
+- bounded retry；
+- refresh path 和普通 auth interceptor 分离。
+
+### 不应照搬
+
+Memos 的 `InvalidArgument` 对 MemoFlow 来说过粗。MemoFlow 有 email verification、device authorization、
+account closure、profile binding 等更复杂的 outcome，需要 feature-owned semantics。
+
+官方来源：
+
+- <https://github.com/usememos/memos/blob/main/server/router/api/v1/auth_service.go>
+- <https://github.com/usememos/memos/blob/main/web/src/connect.ts>
+
+## 7.4 Vendure：Expected Error 进入 schema union
+
+Vendure 把可预期 mutation error 编码进 GraphQL schema union。客户端通过 `__typename` 区分正常实体结果
+和具体 ErrorResult，而 unexpected error 仍走异常路径。
+
+### MemoFlow 应借鉴
+
+- expected alternate result 是 operation schema 的一部分；
+  -客户端可以穷尽处理；
+- operation-specific fields 随具体结果携带；
+  -不把所有非成功结果都压成 generic exception。
+
+这支持 ADR-049 的判断：
+
+```text
+email verification required
+waiting approval
+conflict resolution required
+```
+
+应优先成为 outcome union。
+
+### 不应照搬
+
+不需要为了该模型引入 GraphQL；TypeScript union + Zod + Result envelope 已足够。
+
+官方来源：<https://docs.vendure.io/guides/developer-guide/error-handling/>
+
+## 7.5 Connect：协议无关 code 与 typed details
+
+Connect 最值得学的是：应用层 code/details 保持协议无关，而 gRPC、gRPC-Web、Connect protocol 各自采用不同
+HTTP 表达。这验证了 MemoFlow 的目标：
+
+```text
+Public Failure / Outcome
+  -> HTTP projection
+  -> IPC projection
+  -> SSE projection
+```
+
+而不是 Domain Error 自己携带 HTTP status。
+
+## 8. 对 ADR-049 的关键修订
+
+## 8.1 从六层模型扩展为“六层语义 + 三类政策”
+
+六层语义继续成立：
+
+1. Domain Fault；
+2. Operation Outcome；
+3. Public Failure；
+4. Provider/Infrastructure Failure；
+5. Transport Projection；
+6. Diagnostic Failure。
+
+但第一版把 retry/recovery 混进 Public Failure，需要拆成三个政策：
+
+### Failure Retry Hint
+
+表达服务端观察到的事实：
+
+```ts
+not_retryable;
+transient;
+after(delay);
+```
+
+它不是自动执行命令。
+
+### Operation Retry Policy
+
+由调用 operation/executor 拥有：
+
+```text
+read/write/transaction/workflow step
+idempotent or not
+idempotency key
+attempt budget
+deadline
+backoff/jitter
+```
+
+### Recovery Action
+
+由 application/presentation 拥有：
+
+```text
+reauthenticate
+verify email
+correct input
+resolve conflict
+retry manually
+contact support
+```
+
+它不能使用可翻译 message 表达，也不应简单作为 provider hint 透传。
+
+## 8.2 Public Failure 目标形状修订
+
+```ts
+export interface PublicFailure<
+  Code extends string,
+  Category extends FailureCategory,
+  Details = never,
+> {
+  readonly code: Code;
+  readonly category: Category;
+  readonly details?: Details;
+  readonly retryHint?: FailureRetryHint;
+  readonly reference?: FailureReference;
+}
+```
+
+### `details` 而不是 arbitrary `params`
+
+每个 code 必须绑定具体 Zod schema：
+
+```ts
+const TaskVersionConflictDetailsSchema = z.object({
+  expectedVersion: z.number().int().nonnegative(),
+  actualVersion: z.number().int().nonnegative(),
+});
+```
+
+不允许公共：
+
+```ts
+Record<string, unknown>;
+```
+
+### `reference`
+
+只允许安全追踪引用：
+
+```ts
+interface FailureReference {
+  requestId?: string;
+  traceId?: string;
+}
+```
+
+具体是否出 wire 由 transport policy 决定。
+
+## 8.3 Registry 应从同一对象推导，不维护多套清单
+
+目标 registry：
+
+```ts
+export const AuthFailures = defineFailureRegistry({
+  AUTH_INVALID_CREDENTIALS: {
+    category: 'unauthenticated',
+    details: z.never().optional(),
+    retryHint: { kind: 'not_retryable' },
+    i18nKey: 'auth.errors.invalidCredentials',
+    http: { status: 401 },
+  },
+  AUTH_PROVIDER_UNAVAILABLE: {
+    category: 'unavailable',
+    details: z.object({ retryAfterMs: z.number().int().positive().optional() }),
+    retryHint: { kind: 'transient' },
+    i18nKey: 'auth.errors.providerUnavailable',
+    http: { status: 503 },
+  },
+});
+```
+
+从该定义推导：
+
+- code union；
+- Zod failure schema；
+- HTTP policy completeness；
+- i18n key completeness；
+- telemetry mapping；
+- docs table；
+- mutation/gate inventory。
+
+不能再单独手写五份平行 map。
+
+## 8.4 库使用必须服从 architecture ownership
+
+即使采用 `ts-pattern` 或 XState：
+
+- Domain Fault/Outcome/Public Failure 仍是 MemoFlow contract；
+- library type 不进入 wire；
+- provider mapping ownership 不变；
+- durable fact 不由内存 actor 代替；
+- transport parity 不变；
+- library 可以替换，contract 不受影响。
+
+## 9. 推荐 North-Star 设计
+
+```text
+Provider / DB / SDK
+        |
+        v
+Infrastructure ACL + Zod parse
+        |
+        +---- DiagnosticIncident -> observer once
+        |
+        v
+Feature Application Port
+        |
+        +---- DomainFault -> operation mapper
+        |
+        v
+Result<OperationOutcome, PublicFailure>
+        |
+        +---- OperationRetryPolicy evaluates retryHint + idempotency + attempts
+        |
+        +---- RecoveryPolicy derives host/user next action
+        |
+        v
+Contracts schema / registry
+        |
+   +----+-----------+-------------+
+   |                |             |
+ HTTP projection   IPC          SSE/durable
+   |                |             |
+   +----------------+-------------+
+                    |
+          presentation operation state
+                    |
+         code/outcome -> i18n + recovery UI
+```
+
+## 10. 已执行的设计 Spike
+
+ACR-R02 已在 `/tmp/memoflow-failure-spikes` 完成，详细数据、源码规模、TypeScript timing、mutation
+diagnostic、Zod 安全负向测试与 retry-policy fixture 见：
+
+- [Failure Contract Spike Evidence and Design Gate](./2026-08-17-failure-contract-spike-evidence.md)。
+
+实验使用与仓库一致的 TypeScript 6.0.3 和 Zod 4.4.3，并比较：
+
+1. native `switch + assertNever`、`ts-pattern`、neverthrow mapper；
+2. typed reducer 与 XState v5 Auth state model；
+3. TypeScript + Zod 单源 registry 与 retry-policy intersection。
+
+主要结果：
+
+| 项目                                   | 结果                                          |
+| -------------------------------------- | --------------------------------------------- |
+| mapper fixture                         | 10/10 三版输出完全一致                        |
+| native mapper median typecheck         | 0.6515 s                                      |
+| `ts-pattern` median typecheck          | 0.9409 s                                      |
+| neverthrow median typecheck            | 0.7036 s                                      |
+| typed reducer median typecheck         | 0.6530 s                                      |
+| XState median typecheck                | 1.0628 s                                      |
+| exhaustiveness mutation                | native / ts-pattern / neverthrow 全部编译失败 |
+| registry unknown code                  | fail closed                                   |
+| strict details secret field            | fail closed                                   |
+| retry without required idempotency key | denied                                        |
+
+Spike 同时发现两个必须进入规范的安全约束：
+
+- 不依赖 Zod 未导出的内部 union option 类型；registry builder 只依赖 Zod 公共 API；
+- Zod object 默认剥离未知字段，public failure details 必须使用 strict schema，并有 token/provider-body
+  negative tests。
+
+## 11. ACR-R03 设计 Gate 结论
+
+设计 Gate 已于 2026-08-17 通过。生产重构从 ACR-001 起解锁。
+
+### 11.1 Adopt
+
+1. MemoFlow-owned `Result<T, E>`；
+2. TypeScript discriminated union；
+3. native `switch + assertNever` 作为默认穷尽映射；
+4. Zod 4 public API 与 strict details schema；
+5. one-source feature failure registry；
+6. provider anti-corruption layer；
+7. expected outcome union；
+8. public/diagnostic separation；
+9. `FailureRetryHint`、`OperationRetryPolicy`、`RecoveryAction` 三分；
+10. mutation-based governance。
+
+### 11.2 Borrow
+
+- neverthrow 的组合器与“Result 必须消费”思想，但不引入 neverthrow runtime；
+- RFC 9457、Connect、AIP-193/194 的稳定 code、typed details、retry 原则；
+- Temporal 的 operation/activity retry 与 durable workflow retry 分层；
+- Lark CLI、Ardan Labs、Memos、Vendure 的 public/internal、expected outcome 和治理模式。
+
+### 11.3 Defer
+
+- `ts-pattern`：本轮不加入依赖。只有独立 bounded mapper benchmark 显示显著可读性收益且 affected
+  typecheck 成本可接受时，才允许单独提出；
+- XState：Auth 不采用。未来只有 nested/parallel state、invoked actors、durable resume 等复杂流程才可
+  通过新 ADR/spike 提出；actor snapshot 不得成为 durable fact。
+
+### 11.4 Reject for this program
+
+1. 全仓 Effect 迁移；
+2. neverthrow 替换 MemoFlow Result；
+3. XState 取代普通 store/composable；
+4. Connect/gRPC transport 迁移；
+5. Temporal 平台迁移；
+6. 新建全局 Error class hierarchy；
+7. 同时维持多个 Result/schema/runtime。
+
+## 12. 最终建议
+
+MemoFlow 不需要先引入一个“更强的错误库”。经过源码研究和隔离实验后，最优方案是使用已有的
+TypeScript、Zod、Result、HTTP/IPC parity、ExecutionContext、observer 和 governance 地基，在正确的
+ownership boundary 上增加极少量自有 primitive 与 builder。
+
+这意味着后续生产实现必须坚持：
+
+```text
+Domain owns business faults
+Application owns outcome and operation policy
+Contracts own stable public data
+Infrastructure owns provider translation
+Transport owns protocol projection
+Presentation owns recovery projection
+Observer owns diagnostics
+```
+
+库只能是可替换实现细节，不能成为 code identity、wire schema、durable fact 或业务状态的所有者。

--- a/docs/analysis/2026-08-17-failure-contract-spike-evidence.md
+++ b/docs/analysis/2026-08-17-failure-contract-spike-evidence.md
@@ -1,0 +1,318 @@
+---
+tags:
+  - analysis
+  - architecture
+  - contracts
+  - error-handling
+  - spike
+  - xstate
+  - typescript
+description: ACR-R02 isolated spike evidence and ACR-R03 library/design gate decision
+created: 2026-08-17T00:00:00+09:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
+# Failure Contract Spike Evidence and Design Gate
+
+## 1. Purpose
+
+This document records the executed evidence for:
+
+- **ACR-R02** — isolated mapper, state-model, registry, and retry-policy spikes;
+- **ACR-R03** — final library-adoption and ADR-049 implementation gate.
+
+The spikes ran outside the repository in `/tmp/memoflow-failure-spikes`. They did not modify production code, workspace dependencies, the lockfile, Docker configuration, or database schemas.
+
+The repository baseline was:
+
+```text
+repository: /home/ubuntu/projects/memoflow
+branch: docs/failure-contract-architecture
+base revision: 8258d415e93afb9bb79e161f4f13d0bcdc8a3519
+TypeScript: 6.0.3
+Zod: 4.4.3
+```
+
+Candidate versions resolved from npm on 2026-08-17:
+
+```text
+ts-pattern 5.9.0
+neverthrow 8.2.0
+xstate 5.32.5
+zod 4.4.3
+typescript 6.0.3
+```
+
+## 2. Spike A — Exhaustive provider mapper
+
+### 2.1 Scope
+
+A ten-member `ProviderFailure` union was mapped into MemoFlow-owned `AuthOutcome | AuthFailure` using three implementations:
+
+1. native TypeScript `switch` plus `assertNever`;
+2. `ts-pattern` with `.exhaustive()`;
+3. neverthrow `Result` plus an exhaustive native switch.
+
+The fixture matrix covered:
+
+- invalid credentials;
+- email verification required;
+- duplicate account;
+- rate limiting;
+- provider unavailable;
+- network timeout;
+- account closed;
+- invalid verification token;
+- expired verification token;
+- unknown provider failure.
+
+All three implementations produced byte-for-byte equivalent JavaScript objects for all ten fixtures.
+
+### 2.2 Source size
+
+| Implementation                | Lines | Source bytes |
+| ----------------------------- | ----: | -----------: |
+| native switch + `assertNever` |    29 |        1,864 |
+| `ts-pattern`                  |    16 |        1,783 |
+| neverthrow + native switch    |    19 |        1,610 |
+
+The line-count advantage of `ts-pattern` was real, but the source-byte difference was small because fluent matcher expressions are dense.
+
+### 2.3 Isolated TypeScript check timing
+
+Seven no-emit checks were executed for each isolated configuration.
+
+| Implementation |   Median |     Mean |
+| -------------- | -------: | -------: |
+| native switch  | 0.6515 s | 0.6591 s |
+| `ts-pattern`   | 0.9409 s | 0.9384 s |
+| neverthrow     | 0.7036 s | 0.7019 s |
+
+In this small experiment, `ts-pattern` increased median type-check time by approximately 44% compared with the native switch. The absolute difference is small, but MemoFlow already has a large contracts graph and extensive type-level governance; adding matcher-heavy types globally would increase risk without changing architecture ownership.
+
+### 2.4 Exhaustiveness mutation
+
+A new provider variant was injected without updating the mappers:
+
+```ts
+{
+  kind: 'mfa_required';
+  challengeId: string;
+}
+```
+
+All three implementations failed compilation.
+
+Native switch diagnostic:
+
+```text
+Argument of type '{ kind: "mfa_required"; challengeId: string; }'
+is not assignable to parameter of type 'never'.
+```
+
+`ts-pattern` diagnostic:
+
+```text
+Type 'NonExhaustiveError<{ kind: "mfa_required"; challengeId: string; }>'
+has no call signatures.
+```
+
+The native diagnostic is direct and already compatible with MemoFlow's TypeScript conventions. `ts-pattern` does not provide a correctness capability that MemoFlow cannot obtain with a small shared `assertNever` helper.
+
+### 2.5 Decision
+
+- **Adopt:** native discriminated unions, `switch`, and `assertNever` as the default mapper pattern.
+- **Defer:** `ts-pattern`; it may be reconsidered for a narrowly bounded mapper only when a separate benchmark shows a material readability benefit and no meaningful affected type-check regression.
+- **Reject for this program:** neverthrow as a runtime dependency. MemoFlow retains its existing `Result<T, E>` and may implement small local combinators without adding a second Result abstraction.
+
+## 3. Spike B — Auth state model
+
+### 3.1 Scope
+
+The same Auth state graph was implemented twice:
+
+- a pure typed reducer;
+- an XState v5 machine.
+
+The graph contained:
+
+```text
+idle
+submitting
+invalid_credentials
+awaiting_email_verification
+verification_sending
+verification_sent
+provider_unavailable
+authenticated
+canceled
+```
+
+Events covered submit, invalid credentials, verification required, send verification, verification sent, provider unavailable, authenticated, retry, cancel, and reset.
+
+Both implementations passed the same behavior sequence and ignored an illegal `AUTHENTICATED` event after `verification_sent`.
+
+### 3.2 Size and type-check cost
+
+| Implementation | Lines | Source bytes | Median type-check | Mean type-check |
+| -------------- | ----: | -----------: | ----------------: | --------------: |
+| typed reducer  |    53 |        2,530 |          0.6530 s |        0.6546 s |
+| XState v5      |    52 |        2,194 |          1.0628 s |        1.0667 s |
+
+Installed package footprint in the isolated experiment:
+
+```text
+xstate: 2.6 MiB
+ts-pattern: 584 KiB
+neverthrow: 132 KiB
+zod: 6.4 MiB
+```
+
+The XState source was not substantially smaller than the reducer for this Auth flow, while the isolated type-check median was approximately 63% higher. XState would also introduce a second actor/snapshot lifecycle that must remain subordinate to MemoFlow's existing durable receipts, Pinia/application state, and Web/Desktop host boundaries.
+
+### 3.3 Decision
+
+- **Adopt for Auth:** a pure feature-owned typed reducer/state transition function, with effects invoked by the application service/composable boundary.
+- **Do not adopt for Auth:** XState.
+- **Defer XState generally:** it may be reconsidered for a workflow that has invoked actors, nested/parallel states, durable resume, and a statechart that is materially easier to review than a reducer. XState actor snapshots must never become the durable source of truth.
+
+## 4. Spike C — Single-source failure registry and retry policy
+
+### 4.1 Scope
+
+A registry was implemented using TypeScript and Zod only. One descriptor object owned:
+
+- public code;
+- category;
+- strict details schema;
+- retry hint;
+- HTTP projection metadata;
+- i18n key;
+- telemetry label.
+
+The experiment derived the public failure union and runtime schema from the same descriptor object. It also evaluated retry as the intersection of a failure hint and operation policy.
+
+### 4.2 Findings
+
+#### Zod public API boundary
+
+The first implementation attempted to depend on an internal discriminated-union option type. Zod 4 did not export that type as a supported public API. The corrected design hides the minimum audited tuple cast inside a MemoFlow-owned registry builder and exposes only a typed `z.ZodType<PublicFailure>`.
+
+MemoFlow must not import Zod internal types or make them part of a public contract.
+
+#### Strict object schemas are mandatory
+
+Zod object schemas strip unknown keys by default. A negative test containing a secret-like field initially passed parsing:
+
+```ts
+{
+  code: 'AUTH_RATE_LIMITED',
+  category: 'rate_limited',
+  details: {
+    retryAfterMs: 1,
+    token: 'secret'
+  }
+}
+```
+
+Adding `.strict()` to every public details object made the negative test fail as required.
+
+Therefore:
+
+- all public failure detail objects must be strict;
+- the registry builder must reject non-strict schemas or wrap a safe strict-object constructor;
+- secret/provider-body negative tests are mandatory.
+
+#### Unknown codes fail closed
+
+A provider-shaped code such as `BETTER_AUTH_X` was rejected by the derived schema. Provider vocabulary therefore cannot enter public failure data through the compatibility serializer.
+
+#### Retry policy must remain operation-owned
+
+A rate-limited failure with a transient retry hint was not retried when the write operation required an idempotency key and none was present. It was retried only when:
+
+```text
+failure hint permits retry
+AND operation policy permits retry
+AND required idempotency key exists
+AND attempt budget remains
+```
+
+### 4.3 Decision
+
+- **Adopt:** a MemoFlow-owned registry builder based on TypeScript and Zod 4 public APIs.
+- **Adopt:** strict details schemas and negative secret/provider-field tests.
+- **Adopt:** `FailureRetryHint`, `OperationRetryPolicy`, and `RecoveryAction` as separate types with separate owners.
+- **Reject:** a single `RetryDirective` that mixes transient facts, automatic retry execution, and UI recovery.
+
+## 5. ACR-R03 design gate
+
+### 5.1 Library decision matrix
+
+| Candidate                       | Decision                | Allowed use                                                              |
+| ------------------------------- | ----------------------- | ------------------------------------------------------------------------ |
+| TypeScript discriminated unions | Adopt                   | Domain faults, outcomes, failures, reducers, mapper exhaustiveness       |
+| Zod 4                           | Adopt                   | Wire/runtime schema and strict public details validation                 |
+| native `switch` + `assertNever` | Adopt                   | Default exhaustive mapping and state reducers                            |
+| `ts-pattern`                    | Defer                   | No dependency in this program; reconsider only with a bounded benchmark  |
+| neverthrow                      | Reject                  | Do not add a second Result runtime; borrow combinator ideas only         |
+| XState                          | Defer                   | Not used for Auth; future complex workflow requires a separate ADR/spike |
+| Effect                          | Reject for this program | No global runtime/DI/Result migration                                    |
+| Connect / RFC 9457              | Borrow                  | Error-code/detail principles; do not replace existing HTTP/IPC envelopes |
+| Temporal                        | Borrow                  | Retry/transaction semantics; do not introduce a workflow engine here     |
+
+### 5.2 Frozen foundation types
+
+The implementation foundation is approved as:
+
+```ts
+type PublicFailure<Code extends string, Details = never> = {
+  readonly code: Code;
+  readonly category: FailureCategory;
+  readonly details?: Details;
+  readonly retryHint?: FailureRetryHint;
+  readonly reference?: FailureReference;
+};
+```
+
+The following remain separate:
+
+```text
+FailureRetryHint     -> failure classification
+OperationRetryPolicy -> application/executor policy
+RecoveryAction       -> presentation/application guidance
+DiagnosticFailure    -> observer-only cause/provider detail
+```
+
+### 5.3 Implementation authorization
+
+ADR-049 is approved for implementation with the decisions above. Production implementation may proceed from ACR-001 onward, subject to the protected contracts and per-PR review/repair loop in the active plan.
+
+## 6. Executed commands and evidence
+
+The isolated project executed:
+
+```bash
+npm install
+npm run typecheck
+npm run run
+./node_modules/.bin/tsc -p tsconfig.native.json --noEmit
+./node_modules/.bin/tsc -p tsconfig.pattern.json --noEmit
+./node_modules/.bin/tsc -p tsconfig.neverthrow.json --noEmit
+./node_modules/.bin/tsc -p tsconfig.reducer.json --noEmit
+./node_modules/.bin/tsc -p tsconfig.xstate.json --noEmit
+```
+
+Behavior result:
+
+```json
+{
+  "fixtures": 10,
+  "reducerFinal": "verification_sent",
+  "xstateFinal": "verificationSent",
+  "registryCodes": 6,
+  "status": "PASS"
+}
+```
+
+The temporary spike remains outside version control and is not a production dependency.

--- a/docs/architecture/adr/ADR-010-standard-centralized-contracts.md
+++ b/docs/architecture/adr/ADR-010-standard-centralized-contracts.md
@@ -1,35 +1,47 @@
 # ADR-010: Standard - Centralized Contracts
 
 ## Status
-Accepted
+
+Accepted — Amended by ADR-049
 
 ## Date
+
 2026-01-15
 
 ## Implementation note (Residual 617 / 2026-07-22)
+
 Shared operation outcomes live under `@memoflow/contracts/result` as `Result<T>`
 (and IPC/HTTP envelopes). The retired `ActionResult` / `CountResult` dual-track
 helpers must not be reintroduced.
 
+## 2026-08-17 amendment
+
+ADR-049 narrows “centralized contracts” to cross-boundary/public contracts. Domain entities, domain faults, provider types, repository-private types and implementation helpers stay with their owning feature and are connected to contracts through explicit mappers.
+
 ## Context
+
 Code duplication of types (e.g., `User`, `TaskDTO`) across Frontend, Backend, and Desktop processes leads to synchronization bugs. If the API changes but the frontend type isn't updated, the app crashes at runtime. Ad-hoc/inline type definitions make refactoring dangerous.
 
 ## Decision
+
 All shared types must be defined in the unique source of truth: `packages/contracts`.
 
 ### 1. "Single Source of Truth" Rule
-*   Any type used by more than one package (e.g., API <-> UI, or Domain <-> Infra) MUST reside in `contracts`.
-*   **Forbidden:** Inline definitions in `application-*` or `infrastructure-*`.
+
+- Any type used by more than one package (e.g., API <-> UI, or Domain <-> Infra) MUST reside in `contracts`.
+- **Forbidden:** Inline definitions in `application-*` or `infrastructure-*`.
 
 ### 2. What goes into Contracts?
-*   **Entities:** Core business objects (`Task`, `User`).
-*   **DTOs:** API Request/Response shapes (`CreateTaskRequest`, `TaskResponse`).
-*   **Results:** Operation result wrappers (`Result<T>`, `IpcResult<T>`, `HttpResponse<T>`).
-*   **Enums:** Shared state indicators (`TaskStatus`, `Priority`).
-*   **Interfaces:** Service contracts (`IRepository`, `ILogger`).
-*   **Constants:** Shared business rules/magic numbers.
+
+- **Entities:** Core business objects (`Task`, `User`).
+- **DTOs:** API Request/Response shapes (`CreateTaskRequest`, `TaskResponse`).
+- **Results:** Operation result wrappers (`Result<T>`, `IpcResult<T>`, `HttpResponse<T>`).
+- **Enums:** Shared state indicators (`TaskStatus`, `Priority`).
+- **Interfaces:** Service contracts (`IRepository`, `ILogger`).
+- **Constants:** Shared business rules/magic numbers.
 
 ### 3. Usage
+
 ```typescript
 // Correct
 import type { Task, CreateTaskRequest } from '@memoflow/contracts';
@@ -39,5 +51,6 @@ export interface MyLocalTask { id: string... } // ❌ Don't redefine
 ```
 
 ## Consequences
-*   **Positive:** "Change once, update everywhere"; Compiler errors catch integration mismatches immediately; Zero circular dependencies.
-*   **Negative:** Developers must run the build/watch process for `contracts` when adding new fields.
+
+- **Positive:** "Change once, update everywhere"; Compiler errors catch integration mismatches immediately; Zero circular dependencies.
+- **Negative:** Developers must run the build/watch process for `contracts` when adding new fields.

--- a/docs/architecture/adr/ADR-012-standard-error-handling.md
+++ b/docs/architecture/adr/ADR-012-standard-error-handling.md
@@ -1,51 +1,66 @@
 # ADR-012: Standard - Error Handling
 
 ## Status
-Accepted
+
+Accepted — Amended by ADR-049
 
 ## Date
+
 2026-01-15
 
 ## Implementation note (Residual 617 / 2026-07-22)
+
 Boundary layers convert thrown/structured errors into `Result<T>` failures
 (`fail` / `error`), then map to `IpcResult` or `HttpResponse` at the transport edge.
 Do not convert to retired `ActionResult` helpers.
 
+## 2026-08-17 amendment
+
+ADR-049 replaces the single AppError/DomainError-with-HTTP model with separate Domain Fault, Operation Outcome, Public Failure, Provider Failure, Transport Projection and Diagnostic Failure ownership. Existing structured Result boundaries remain protected during migration.
+
 ## Context
+
 Random error throwing (strings, generic Errors) and inconsistent catching make debugging impossible. A unified error strategy is needed for reliable operation.
 
 ## Decision
+
 We adopt a typed classification of errors and a structured handling pattern.
 
 ### 1. Custom Error Types
+
 Use specific error classes extending a base `AppError`.
-*   `NotFoundError`: Resource missing (404).
-*   `ValidationError`: Bad input (422).
-*   `AppError`: Generic application base.
+
+- `NotFoundError`: Resource missing (404).
+- `ValidationError`: Bad input (422).
+- `AppError`: Generic application base.
 
 ### 2. Error Codes
+
 Errors must carry a machine-readable `code` (e.g., `AUTH_TOKEN_EXPIRED`, `TASK_NOT_FOUND`) to allow frontend localization and logic.
 
 ### 3. Try/Catch & Result Pattern
-*   **Service Layer:** Throw specific errors (`throw new NotFoundError()`) to abort logic flow.
-*   **Boundary Layer (Controller/IPC):** Catch exceptions and convert them to `Result<T>`.
-    ```typescript
-    import { ok, fail } from '@memoflow/contracts/result';
 
-    try {
-       await service.doIt();
-       return ok(null);
-    } catch (e) {
-       // Convert exception to serializable Result failure
-       return fail({ code: 'INTERNAL_ERROR', message: 'Operation failed' });
-    }
-    ```
+- **Service Layer:** Throw specific errors (`throw new NotFoundError()`) to abort logic flow.
+- **Boundary Layer (Controller/IPC):** Catch exceptions and convert them to `Result<T>`.
+  ```typescript
+  import { ok, fail } from '@memoflow/contracts/result';
+
+  try {
+    await service.doIt();
+    return ok(null);
+  } catch (e) {
+    // Convert exception to serializable Result failure
+    return fail({ code: 'INTERNAL_ERROR', message: 'Operation failed' });
+  }
+  ```
 
 ### 4. Forbidden
-*   ❌ `throw "string"`
-*   ❌ Silent `catch (e) { }` (swallowing errors).
-*   ❌ Returning generic "Error" without codes.
+
+- ❌ `throw "string"`
+- ❌ Silent `catch (e) { }` (swallowing errors).
+- ❌ Returning generic "Error" without codes.
 
 ## Consequences
-*   **Positive:** Frontend can react to specific errors (e.g., show login modal on `AUTH_EXPIRED`); Logs are meaningful.
-*   **Negative:** Requires wrapping external library errors (e.g., catching Prisma errors and re-throwing AppErrors).
+
+- **Positive:** Frontend can react to specific errors (e.g., show login modal on `AUTH_EXPIRED`); Logs are meaningful.
+- **Negative:** Requires wrapping external library errors (e.g., catching Prisma errors and re-throwing AppErrors).

--- a/docs/architecture/adr/ADR-017-centralized-types.md
+++ b/docs/architecture/adr/ADR-017-centralized-types.md
@@ -1,39 +1,50 @@
 # ADR-017: Absolute Type Centralization in Contracts
 
 ## Status
-Accepted
+
+Superseded by ADR-049
+
+## Supersession note
+
+Absolute type centralization is no longer the target architecture. ADR-049 adopts boundary-first contracts: stable wire/public/durable types remain in `@memoflow/contracts`, while domain models and implementation-specific types remain in the owning feature.
 
 ## Context
+
 Type definitions (Interfaces, DTOs, Enums) are currently scattered across `apps/`, `packages/domain`, and `packages/contracts`. This causes duplication, inconsistency, and confusion about the "Source of Truth".
 
 ## Decision
+
 We enforce **Absolute Type Centralization**.
 
 ### The Rule
+
 **All public data types, business entities, DTOs, and shared enumerations MUST reside in `@memoflow/contracts`.**
 
 ### Scope
+
 - **MUST be in Contracts**:
-    - Domain Entities Interfaces (`interface Task`).
-    - API Request/Response DTOs (`interface CreateTaskDTO`).
-    - Database Model interfaces (if shared).
-    - Enums (`enum TaskStatus`).
-    - React Component Prop Interfaces (if using domain objects).
+  - Domain Entities Interfaces (`interface Task`).
+  - API Request/Response DTOs (`interface CreateTaskDTO`).
+  - Database Model interfaces (if shared).
+  - Enums (`enum TaskStatus`).
+  - React Component Prop Interfaces (if using domain objects).
 - **ALLOWED in other packages**:
-    - Private helper types (not exported).
-    - Implementation-specific types (e.g., specific Prisma raw result types that never leave the repo).
-    - Unit test mock types.
+  - Private helper types (not exported).
+  - Implementation-specific types (e.g., specific Prisma raw result types that never leave the repo).
+  - Unit test mock types.
 
 ### Implementation
+
 - `packages/contracts` becomes the **Type Registry** of the system.
 - Other packages import types: `import type { Task } from '@memoflow/contracts/task';`.
 - It is **FORBIDDEN** to `export interface` a domain object from `packages/domain-*`. Domain classes should `implements` the interface from Contracts.
 
 ## Consequences
+
 - **Positive**:
-    - Single source of truth.
-    - Zero ambiguity for AI Agents on where to find types.
-    - API and Frontend always in sync.
+  - Single source of truth.
+  - Zero ambiguity for AI Agents on where to find types.
+  - API and Frontend always in sync.
 - **Negative**:
-    - `packages/contracts` will grow large (must use submodule folders).
-    - Making a change to a model requires editing `contracts` first, then the implementation.
+  - `packages/contracts` will grow large (must use submodule folders).
+  - Making a change to a model requires editing `contracts` first, then the implementation.

--- a/docs/architecture/adr/ADR-030-standard-result-pattern.md
+++ b/docs/architecture/adr/ADR-030-standard-result-pattern.md
@@ -1,36 +1,49 @@
 # ADR-030: Unifying API Responses with Result Pattern
 
 ## Status
-Accepted
+
+Accepted — Amended by ADR-049
 
 ## Date
+
 2026-01-16
 
 ## Implementation note (Residual 615 / Residual 617 / 2026-07-22)
+
 - `@memoflow/contracts/response` is removed (stage-6).
 - Zero-consumer `ActionResult` / `actionOk` dual-track helpers are removed from
   `@memoflow/contracts/result` (Residual 615).
 - Canonical surface: `Result<T>` + `IpcResult<T>` + `HttpResponse<T>` only.
 
+## 2026-08-17 amendment
+
+`Result<T, E>` remains the standard application/client/transport boundary. ADR-049 clarifies that normal alternate states use typed outcomes, public failures are operation-specific and JSON-safe, and domain/provider/diagnostic control flow is not forced into one untyped global `ResultError`.
+
 ## Context
+
 Currently, the codebase suffers from "Type Schizophrenia":
+
 - `contracts/src/result`: A modern, Rust-inspired `Result<T, E>` pattern (`ok: boolean`).
 - `contracts/src/response`: A legacy, HTTP-coupled pattern (`success: boolean`).
 - `utils/src/response`: Tools that mix both, confusing developers and AI agents.
 
 This duality causes:
+
 1. Inconsistent error handling (some return objects, some throw).
 2. Confusion on which type to use in new features.
 3. Leaking HTTP concerns (status codes) into the Domain layer types.
 
 ## Decision
+
 We will **unify all operation results** using the **Result Pattern** defined in `@memoflow/contracts/result`.
 
 ### 1. The Single Source of Truth
+
 - **Module**: `@memoflow/contracts/result` is the **ONLY** legal way to return outcomes from Application-facing boundaries and external APIs.
 - **Legacy**: `@memoflow/contracts/response` is **removed** (stage-6); do not reintroduce.
 
 ### 2. Standard Schema
+
 All internal operations (Functions, Services) and External APIs (HTTP REST) must conform to:
 
 ```typescript
@@ -53,22 +66,25 @@ interface Failure {
 ```
 
 ### 3. Separation of Concerns
+
 - **Domain Layer**: May return domain-specific `Result<T>` for validation/business-rule operations, but repositories and low-level persistence ports are allowed to throw structured exceptions.
 - **Application Layer / Module API**: Returns `Result<T>` to callers and is the preferred boundary for converting thrown exceptions into failures.
 - **Infrastructure (Web) Layer**: Maps `Result.code` to HTTP Status.
-    - `ResultCode.NOT_FOUND` -> 404
-    - `ResultCode.PERMISSION_DENIED` -> 403
-    - `ResultCode.SUCCESS` -> 200
+  - `ResultCode.NOT_FOUND` -> 404
+  - `ResultCode.PERMISSION_DENIED` -> 403
+  - `ResultCode.SUCCESS` -> 200
 
 ## Consequences
+
 - **Positive**:
-    - "Thinking in Results" becomes the universal language.
-    - AI Agents can reliably generate correct return types.
-    - Frontend data fetching becomes predictable (`if (!res.ok) handle(res.error)`).
+  - "Thinking in Results" becomes the universal language.
+  - AI Agents can reliably generate correct return types.
+  - Frontend data fetching becomes predictable (`if (!res.ok) handle(res.error)`).
 - **Negative**:
-    - Requires refactoring existing code using `ResponseBuilder` or `success: boolean`.
+  - Requires refactoring existing code using `ResponseBuilder` or `success: boolean`.
 
 ## Migration Strategy
+
 1. Update transport adapters to consume `Result<T>` instead of legacy types.
 2. Keep persistence interfaces free to throw structured errors where that keeps use cases simpler.
 3. ~~Mark `contracts/src/response` as `@deprecated`.~~ **Done — package removed.**

--- a/docs/architecture/adr/ADR-049-domain-outcome-and-failure-contracts.md
+++ b/docs/architecture/adr/ADR-049-domain-outcome-and-failure-contracts.md
@@ -1,0 +1,553 @@
+---
+tags:
+  - adr
+  - architecture
+  - contracts
+  - domain
+  - error-handling
+  - outcomes
+description: 领域故障、应用结果、公开失败契约、provider 适配和传输映射的所有权决策
+created: 2026-08-17
+updated: 2026-08-17
+---
+
+# ADR-049: Domain Outcomes and Failure Contracts / 领域结果与失败契约
+
+**状态**：已采纳（ACR-R03 设计 Gate 通过，实施中）
+
+**日期**：2026-08-17
+
+**研究依据**：[失败契约库与开源实现研究](../../analysis/2026-08-17-failure-contract-library-and-open-source-study.md)
+
+**实验依据**：[Failure Contract Spike Evidence and Design Gate](../../analysis/2026-08-17-failure-contract-spike-evidence.md)
+
+## 1. 背景
+
+MemoFlow 已采用 `Result<T>`、`HttpResponse<T>`、`IpcResult<T>`、ExecutionContext、
+HTTP/IPC adapter parity 和 feature package 分层，但现有错误模型仍把多个层级混在一起：
+
+- `ResultError.code` 是 `ResultCode | string`，feature/provider/transport code 可任意进入；
+- `ResultError` 同时允许 public `message/details/context` 和 internal `cause`；
+- `DomainError` 同时携带领域 code、HTTP status、timestamp、operationId、step、原始异常、
+  API JSON 和日志格式；
+- `packages/contracts/src/result/http.ts` 在 shared contracts 内维护 HTTP status 映射；
+- UI 和 E2E 部分路径依赖 raw `message`；
+- provider code/status 在 Auth、Repository、AI 等 application/presentation 路径中被直接判断；
+- “需要邮箱验证”“等待审批”等正常下一步被建模为 error；
+- ADR-010/017 要求绝对类型中心化，使 contracts 同时承担 wire DTO、领域实体接口、协议、
+  schema 和内部业务类型。
+
+Auth 登录错误映射回归证明：保留 provider code 可以避免信息损失，但如果没有 MemoFlow-owned
+anti-corruption mapping，provider vocabulary 会直接泄漏到 UI、i18n 和测试。
+
+本 ADR 决定整个应用的 fault、outcome、failure、transport 和 diagnostic ownership，而不是只修 Auth。
+
+在形成第一版草案后，本项目又完成了 TypeScript 库、RFC/AIP、Connect、OpenTelemetry、Temporal
+以及 Lark CLI、Ardan Labs、Memos、Vendure 的设计研究。研究结论是：MemoFlow 不应引入一个新的
+全局 Error runtime，而应保留自有 Result/Zod/envelope，只在穷尽 mapper 和复杂状态机热点选择性使用库。
+同时，第一版把 retry 与 recovery 混合在一个 directive 中是不正确的，必须拆分。
+
+## 2. 决策
+
+### 2.1 采用六层语义模型与三类独立政策
+
+MemoFlow 将失败相关语义拆分为六类：
+
+| 层级                            | 责任                                              | 稳定性                  |
+| ------------------------------- | ------------------------------------------------- | ----------------------- |
+| Domain Fault                    | 表达领域不变量或状态转移拒绝                      | feature 内部稳定        |
+| Application Outcome             | 表达用例成功及正常替代分支                        | operation contract 稳定 |
+| Public Failure                  | 表达跨边界可处理的失败                            | wire/API 稳定           |
+| Provider/Infrastructure Failure | 表达 SDK、DB、网络和第三方实现细节                | adapter 私有            |
+| Transport Projection            | 将 public failure 映射为 HTTP/IPC/SSE             | transport-local         |
+| Diagnostic Failure              | 保存 cause、stack、provider body、内部 attributes | 仅日志/trace            |
+
+任何类型不得同时承担全部层级。六层语义之外，重试与恢复再拆成三类独立政策：
+
+1. `FailureRetryHint`：服务端/adapter 对失败暂态性的事实描述；
+2. `OperationRetryPolicy`：由调用 operation/executor 根据幂等性、transaction、attempt budget 和 deadline 决定；
+3. `RecoveryAction`：由 application/presentation 根据 host 与用户上下文推导下一步。
+
+Public Failure 不得单方面命令客户端自动重试一个非幂等写操作，也不得把 UI action 固化成 provider hint。
+
+### 2.2 Domain Fault 归 owning feature domain
+
+领域故障定义在：
+
+```text
+packages/<feature>/src/server/domain/faults/**
+```
+
+或同等 feature-owned domain 目录。
+
+推荐使用 discriminated union、小型 value object 或 feature-specific typed exception。禁止要求所有
+领域故障继承一个包含 HTTP/日志能力的全局 `DomainError`。
+
+Domain Fault：
+
+- 可以携带 domain value object 和不变量上下文；
+- 不携带 HTTP status、i18n key、provider code、requestId、traceId、timestamp 或 stack payload；
+- 默认不属于 public contract；
+- 由 application mapper 决定是否、如何公开；
+- 不因为跨包复用而自动移动到 `@memoflow/contracts`。
+
+示例：
+
+```ts
+export type TaskDomainFault =
+  | { readonly kind: 'TaskAlreadyCompleted'; readonly taskId: TaskId }
+  | { readonly kind: 'TaskArchived'; readonly taskId: TaskId }
+  | { readonly kind: 'TaskHierarchyCycle'; readonly parentId: TaskId };
+```
+
+### 2.3 Application Outcome 归 owning feature application/public contract
+
+Application use case 必须明确区分：
+
+1. 完成的成功结果；
+2. 需要调用方采取下一步的正常结果；
+3. 失败。
+
+正常替代结果使用 discriminated union，不使用 generic error code：
+
+```ts
+export type SignInOutcome =
+  | {
+      readonly kind: 'authenticated';
+      readonly account: CloudAccountSummary;
+      readonly session: CloudSessionSummary;
+    }
+  | {
+      readonly kind: 'email_verification_required';
+      readonly email: string;
+    };
+```
+
+适用场景包括但不限于：
+
+- email verification required；
+- waiting approval / interrupted；
+- accepted for durable processing；
+- user confirmation required；
+- conflict resolution choice required；
+- device/OAuth flow waiting for user action。
+
+Application 层负责：
+
+- Domain Fault → operation outcome/public failure；
+- infrastructure port failure → public failure；
+- operation-specific retry policy 与 recovery semantics；
+- operation-specific state transition。
+
+### 2.4 Public Failure 归 feature contract，通用类别归 shared result contract
+
+跨边界稳定失败定义在：
+
+```text
+packages/contracts/src/modules/<feature>/failures.ts
+packages/contracts/src/modules/<feature>/outcomes.ts
+```
+
+或 feature contract 下等价的 operation-specific 文件。
+
+通用 JSON-safe primitive 定义在 `@memoflow/contracts/result`：
+
+```ts
+export type FailureCategory =
+  | 'validation'
+  | 'unauthenticated'
+  | 'permission'
+  | 'not_found'
+  | 'conflict'
+  | 'rate_limited'
+  | 'unavailable'
+  | 'timeout'
+  | 'canceled'
+  | 'internal';
+
+export type FailureRetryHint =
+  | { readonly kind: 'not_retryable' }
+  | { readonly kind: 'transient' }
+  | { readonly kind: 'after'; readonly afterMs: number };
+
+export interface FailureReference {
+  readonly requestId?: string;
+  readonly traceId?: string;
+}
+
+export interface PublicFailure<Code extends string = string, Details = never> {
+  readonly code: Code;
+  readonly category: FailureCategory;
+  readonly details?: Details;
+  readonly retryHint?: FailureRetryHint;
+  readonly reference?: FailureReference;
+}
+```
+
+每个 feature 拥有自己的 code union，例如：
+
+```ts
+export type AuthFailureCode =
+  | 'AUTH_INVALID_CREDENTIALS'
+  | 'AUTH_USER_ALREADY_EXISTS'
+  | 'AUTH_ACCOUNT_CLOSED'
+  | 'AUTH_RATE_LIMITED'
+  | 'AUTH_PROVIDER_UNAVAILABLE';
+```
+
+禁止建立一个包含所有 feature code 的全局巨型 enum。Shared result 只拥有 category 和 envelope primitive。
+
+每个 public code 的 `details` 必须绑定具体 Zod schema，不允许把
+`Record<string, unknown>`、provider body 或任意 context 作为公开扩展。Registry 应从一个定义推导
+code union、schema、HTTP policy、i18n、telemetry 和文档，禁止平行维护多份手工 map。
+
+### 2.5 Failure hint、operation retry policy 与 recovery action 分离
+
+```ts
+export interface OperationRetryPolicy {
+  readonly mode: 'never' | 'safe_read' | 'idempotent_write' | 'transaction' | 'workflow_step';
+  readonly maxAttempts: number;
+  readonly requiresIdempotencyKey: boolean;
+  readonly backoff: BackoffPolicy;
+}
+
+export type RecoveryAction =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'reauthenticate' }
+  | { readonly kind: 'verify_email'; readonly email: string }
+  | { readonly kind: 'correct_input'; readonly fields?: readonly string[] }
+  | { readonly kind: 'resolve_conflict'; readonly resource: string }
+  | { readonly kind: 'retry_manually' };
+```
+
+自动 retry 必须同时满足：failure retry hint、operation policy、幂等/transaction 状态、attempt budget、
+deadline 与 cancellation 状态。`Retry-After` 是 transport/server fact，不是非幂等 operation 的自动执行许可。
+
+### 2.6 Result 保持泛型，但 public error 必须可收窄
+
+`Result<T, E>` 继续作为 application/client/transport boundary 的标准结果：
+
+```ts
+export type Result<T, E extends PublicFailure = PublicFailure> =
+  | { readonly ok: true; readonly data: T; readonly meta?: ResultMeta }
+  | { readonly ok: false; readonly error: E; readonly meta?: ResultMeta };
+```
+
+迁移期保留当前 `ResultError` 和 envelope shape，但新 feature/新 operation 必须提供具体 failure generic。
+现有 `ResultError.code: string` 不再被视为目标设计。
+
+### 2.7 Public Failure 与 Diagnostic Failure 类型隔离
+
+Public Failure 必须：
+
+- JSON-safe；
+- 不含 `cause`、Error instance、stack、provider response、SQL、token 或任意未审计 context；
+- params/details 使用 operation schema allowlist；
+- 可通过 HTTP、IPC、durable receipt 安全传输。
+
+内部诊断信息使用独立对象或 observer API：
+
+```ts
+export interface DiagnosticFailure {
+  readonly operation: string;
+  readonly cause?: unknown;
+  readonly provider?: string;
+  readonly providerCode?: string;
+  readonly attributes?: Record<string, unknown>;
+}
+```
+
+`DiagnosticFailure` 不能成为 HTTP/IPC contract，也不能持久化到用户可读取的 receipt。
+requestId/traceId 继续由 `ResultMeta` / ExecutionContext / observer 管理，不进入 Domain Fault。
+
+### 2.8 Provider errors 必须止于 infrastructure anti-corruption layer
+
+BetterAuth、Prisma、GitHub、OpenAI-compatible provider、PowerSync、filesystem、Electron native API 等
+错误只能在 infrastructure adapter 中解析。
+
+Adapter 输出 MemoFlow-owned outcome/failure：
+
+```text
+BetterAuth EMAIL_NOT_VERIFIED
+  -> Auth SignInOutcome.email_verification_required
+
+BetterAuth INVALID_EMAIL_OR_PASSWORD
+  -> AUTH_INVALID_CREDENTIALS
+
+GitHub 404 in selected operation
+  -> REPOSITORY_NOT_FOUND
+
+Prisma P2002 in create operation
+  -> feature-specific conflict failure
+```
+
+Application、UI 和 E2E 不得 import provider error class、依赖 provider code、解析 provider message 或
+直接判断 provider HTTP status。
+
+### 2.9 HTTP status 归 HTTP adapter，不归 domain/contracts primitive
+
+`FailureCategory` 提供 transport-neutral default semantics。HTTP adapter 负责：
+
+- category → default status；
+- operation/code → explicit override；
+- `Retry-After`、authentication challenge、cache/header policy；
+- safe response serialization。
+
+IPC/SSE 使用自己的 projection。`@memoflow/contracts/result` 不再是 feature-specific HTTP status
+registry 的长期 owner。
+
+兼容期保留当前 `ResultCodeToHttpStatus`，但新增 feature public code 必须通过 feature HTTP registry 或
+category mapping，不再扩张全局 string map。
+
+### 2.10 UI 只根据 stable semantics 本地化和恢复
+
+Presentation state 可以保存：
+
+- outcome `kind`；
+- public failure `code/category/details/retryHint`；
+- operation-owned retry state；
+- application/presentation-derived recovery action；
+- safe request/trace reference。
+
+禁止保存或根据以下内容分支：
+
+- provider message；
+- arbitrary server message；
+- English substring；
+- HTTP status 单独推断业务原因。
+
+locale 改变时，UI 根据 code + typed details 重新计算文案。`message` 在兼容期只是安全 fallback，
+不是状态真值；recovery 也不得从 translated message 或 retry hint 推导。
+
+### 2.11 contracts 采用 Boundary-First，而非 Absolute Type Centralization
+
+以下内容必须在 contracts：
+
+- 跨 package/process/language 的 request/response schema；
+- public operation outcome/failure；
+- durable message/event schema；
+- HTTP/IPC canonical input/output；
+- external client/application port；
+- serialization-safe snapshot/primitive。
+
+以下内容默认不在 contracts：
+
+- domain aggregate/entity interface；
+- domain fault；
+- repository implementation/private port；
+- provider/Prisma row；
+- UI component props；
+- feature-internal helper types；
+- logger/trace/cause object。
+
+Domain model 是业务不变量的 source of truth，contracts 是边界投影。两者通过命名 mapper 连接，不要求
+Domain class `implements` wire DTO。
+
+### 2.12 组合根和跨 feature 依赖使用 Port/Contract
+
+跨 feature orchestration 必须依赖 consumer-owned port 或 feature public application port，由 apps/runtime
+composer 注入 adapter。禁止通过解析对方异常/message 获得业务语义。
+
+长期将 feature Nx tag 从误导性的 package-level `layer:domain` 调整为 vertical feature tag；包内
+source-layer 依赖由 AST governance 执行。
+
+### 2.13 库采用边界与设计验证结论
+
+ACR-R02 隔离实验和 ACR-R03 Gate 已完成。本 ADR 的 library 决策如下：
+
+| 方案                                 | 决策                                                              |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| TypeScript discriminated union + Zod | 采用；Zod details 必须 strict，只依赖公共 API                     |
+| native `switch + assertNever`        | 采用；作为 mapper 和 reducer 的默认穷尽模式                       |
+| `ts-pattern`                         | 延期；本轮不加入依赖，未来仅允许 bounded benchmark 后单独提出     |
+| `neverthrow`                         | 拒绝作为依赖；不替换 MemoFlow Result，只借鉴 combinator 思想      |
+| XState                               | Auth 不采用；复杂 nested/parallel/invoked workflow 需新 ADR/spike |
+| Effect                               | 本轮拒绝作为全仓底座                                              |
+| RFC 9457 / Connect / Temporal        | 借鉴语义与 retry/projection 模型，不替换 transport/runtime        |
+
+任何 library type 不得成为 MemoFlow wire contract、Domain Fault identity 或 durable fact 的 owner。
+生产实现从 ACR-001 起解锁；后续每批仍必须遵循 active plan 的 protected contracts、review 和 repair gate。
+
+## 3. 命名与位置规则
+
+### 3.1 命名
+
+| 概念                | 后缀/字段                                             |
+| ------------------- | ----------------------------------------------------- |
+| Domain fault union  | `*DomainFault`，discriminator `kind`                  |
+| Public failure code | `*FailureCode`，大写稳定 code                         |
+| Public failure type | `*Failure`                                            |
+| Normal outcome      | `*Outcome`，discriminator `kind`                      |
+| Provider mapper     | `map<Provider>Error` / `<provider>-failure.mapper.ts` |
+| Domain mapper       | `map<Feature>FaultToFailure`                          |
+| HTTP map            | `<feature>-failure-http.ts`                           |
+| UI localization     | `getLocalized<Feature>Failure` 或 registry            |
+
+### 3.2 推荐目录
+
+```text
+packages/task/src/server/domain/faults/
+packages/task/src/server/application/failures/
+packages/task/src/server/infrastructure/adapters/prisma/prisma-task-failure.mapper.ts
+packages/task/src/server/transport/http/task-failure-http.ts
+packages/contracts/src/modules/task/outcomes.ts
+packages/contracts/src/modules/task/failures.ts
+```
+
+目录名可按 feature 现有结构调整，但所有权不得改变。
+
+## 4. 兼容迁移
+
+### 4.1 兼容期 wire shape
+
+第一阶段不破坏：
+
+```ts
+{ ok: false, error: { code, message, details?, context? }, meta? }
+```
+
+但要求：
+
+- `code` 来自 MemoFlow registry；
+- `message` 是安全 fallback；
+- `context` 逐步替换为 per-code typed `details`；
+- `cause` 不进入 serializer；
+- client/UI 不再 branch on message。
+
+### 4.2 Auth 作为首个 vertical slice
+
+Auth 迁移顺序：
+
+1. BetterAuth code → adapter-private mapping；
+2. `EMAIL_NOT_VERIFIED` → `email_verification_required` outcome；
+3. invalid credentials → MemoFlow public failure；
+4. Web/Desktop consuming same outcome/failure；
+5. i18n by public code；
+6. E2E deterministic fixture；
+7. provider code leakage governance。
+
+### 4.3 `DomainError` 退役
+
+不得一次删除所有 subclass。迁移方式：
+
+1. 禁止新 feature subclass；
+2. 将 HTTP/diagnostic fields 标记 legacy；
+3. feature-by-feature 引入 domain fault + application mapper；
+4. transport 不再读取 `DomainError.httpStatus`；
+5. 清零引用后删除基类。
+
+### 4.4 contracts 收缩
+
+不执行一次性大搬家。每个 feature 在修改相关能力时分类：
+
+- wire/public contract：保留；
+- domain type：迁回 feature；
+- duplicated type：选择 owner 并用 mapper；
+- provider/infra type：迁回 adapter；
+- unused/legacy：删除。
+
+迁移期间通过 subpath compatibility alias 保持调用方可逐步更新；alias 必须有 retire date。
+
+## 5. Governance 要求
+
+必须新增机器门禁：
+
+1. single-source public failure registry/schema/HTTP/i18n coverage；
+2. provider code 只允许出现在 adapter/fixture allowlist；
+3. production `message.includes/match` failure branching 禁止；
+4. `throw new Error(result.error.message)` 禁止；
+5. UI public failure i18n coverage；
+6. HTTP/IPC projection coverage；
+7. public failure JSON-safety 与 per-code details schema；
+8. unknown code fail-closed diagnostics；
+9. compatibility alias owner/retire date；
+10. mutation fixture 证明删除 mapper/registry 会使 gate 失败；
+11. failure retry hint 不得绕过 operation idempotency/attempt policy；
+12. library adoption 必须符合本 ADR 的 approved scope。
+
+## 6. 被取代或修订的决策
+
+- **ADR-017 Absolute Type Centralization**：被本 ADR 取代。以后只集中边界契约，不集中所有领域类型。
+- **ADR-010 Centralized Contracts**：被修订。“共享”限定为跨边界/public contract，不包括 Domain ↔ Infra
+  只因跨层使用的内部类型。
+- **ADR-012 Error Handling**：被修订。取消全局 AppError/DomainError 携带 HTTP 的目标，改为六层模型。
+- **ADR-030 Result Pattern**：保留 Result 作为 application boundary，但不要求所有 domain/internal control
+  flow 都使用同一个 untyped `ResultError`。
+- **ADR-048 Transport Contract Parity**：继续有效；本 ADR 为 parity 增加 public failure/outcome 语义要求。
+
+## 7. 拒绝的方案
+
+### 7.1 一个全局 `ErrorCode` enum
+
+拒绝。它会成为跨 bounded context 的中央修改点，并混合 provider、domain、application 和 transport code。
+
+### 7.2 把所有错误 class 移到 contracts
+
+拒绝。Error instance、stack、cause 和继承层级不是稳定 wire contract。
+
+### 7.3 只增加 i18n key 覆盖 provider code
+
+拒绝。虽然能修复当前 UI，但会把 BetterAuth/GitHub/OpenAI vocabulary 固化成 MemoFlow public API。
+
+### 7.4 所有 domain method 统一返回 Result
+
+拒绝。Result 是边界语言；领域内部可以使用更贴近模型的 decision/fault。统一形状不等于统一语义。
+
+### 7.5 继续用 message 作为 fallback protocol
+
+拒绝。message 可以临时展示，但永远不能承担分支、retry、status 或 fixture 协议。
+
+### 7.6 将所有映射放入 `packages/utils/errors`
+
+拒绝。通用工具包不能拥有每个 feature 的 business semantics。Mapper 必须靠近 owning boundary。
+
+## 8. 影响
+
+### 正面
+
+- provider 升级只影响 adapter；
+- Web、Desktop、HTTP、IPC 使用同一业务语义；
+- locale 和文案变化不改变行为；
+- domain 不再依赖 HTTP/日志；
+- public failure 可进行 schema、security 和 compatibility 检查；
+- contracts 变化原因更单一；
+- feature code 不再默认掉入 500；
+- E2E 可按 outcome/state 测试，而不是猜 message；
+- governance 可以在合并前阻止同类问题。
+
+### 代价
+
+- 需要显式 mapper 和 registry；
+- 同一业务原因可能同时存在 domain fault identity 与 public failure code，但二者职责不同；
+- contracts 收缩和 `DomainError` 退役需要多阶段迁移；
+- 兼容期会短暂存在 legacy `message/context` 与新 `params/category`；
+- 每个 feature 必须维护自己的 failure vocabulary 和 transport projection tests。
+
+## 9. 研究与参考
+
+- [失败契约库与开源实现研究](../../analysis/2026-08-17-failure-contract-library-and-open-source-study.md)
+- RFC 9457: <https://www.rfc-editor.org/rfc/rfc9457.html>
+- Google AIP-193: <https://google.aip.dev/193>
+- Google AIP-194: <https://google.aip.dev/194>
+- Connect errors: <https://connectrpc.com/docs/web/errors/>
+- OpenTelemetry error recording: <https://opentelemetry.io/docs/specs/semconv/general/recording-errors/>
+- Temporal retry policies: <https://docs.temporal.io/encyclopedia/retry-policies>
+- Lark CLI error contract: <https://github.com/larksuite/cli/blob/main/errs/ERROR_CONTRACT.md>
+- Memos auth/client: <https://github.com/usememos/memos>
+- Vendure expected errors: <https://docs.vendure.io/guides/developer-guide/error-handling/>
+
+## 10. 验收标准
+
+本 ADR 被视为实施完成，必须满足：
+
+- [ ] 库/开源研究、三个 design spike 与 adopt/borrow/defer/reject 记录完成；
+- [ ] Auth vertical slice 不暴露 BetterAuth code/message；
+- [ ] 至少 Auth、Account、Repository、AI、Task 完成 typed public failure/outcome 迁移；
+- [ ] production message-based branch inventory 清零或全部有到期 allowlist；
+- [ ] UI 不直接展示任意 `result.error.message`；
+- [ ] `DomainError` 不再携带或决定 HTTP status；
+- [ ] feature public codes 有 registry、schema、i18n 和 HTTP/IPC coverage；
+- [ ] contracts 中 domain/interface inventory 有 owner 分类并持续下降；
+- [ ] provider code leakage、raw message rethrow 和 JSON-safety governance 接入主门禁；
+- [ ] current Result/HTTP/IPC protected contracts 有明确 migration/compatibility tests；
+- [ ] API/Desktop/local Docker build identity 与源码 revision 可验证一致。

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -4,7 +4,7 @@ tags:
   - index
 description: 架构决策记录索引
 created: 2025-11-23T15:00:00
-updated: 2026-08-04T00:00:00+08:00
+updated: 2026-08-17T00:00:00+09:00
 ---
 
 # ADR 索引
@@ -25,14 +25,14 @@ updated: 2026-08-04T00:00:00+08:00
 | [ADR-007](./ADR-007-api-consistency.md)                             | API 接口一致性规范                                       | 提议中 | 未注明     |
 | [ADR-008](./ADR-008-standard-api-response-format.md)                | API Response Format                                      | 已采纳 | 2026-01-15 |
 | [ADR-009](./ADR-009-standard-clean-architecture-layers.md)          | Clean Architecture Layers                                | 已采纳 | 2026-01-15 |
-| [ADR-010](./ADR-010-standard-centralized-contracts.md)              | Centralized Contracts                                    | 已采纳 | 2026-01-15 |
+| [ADR-010](./ADR-010-standard-centralized-contracts.md)              | Centralized Contracts                                    | 由 ADR-049 修订 | 2026-01-15 |
 | [ADR-011](./ADR-011-standard-naming-conventions.md)                 | Naming Conventions                                       | 已采纳 | 2026-01-15 |
-| [ADR-012](./ADR-012-standard-error-handling.md)                     | Error Handling                                           | 已采纳 | 2026-01-15 |
+| [ADR-012](./ADR-012-standard-error-handling.md)                     | Error Handling                                           | 由 ADR-049 修订 | 2026-01-15 |
 | [ADR-013](./ADR-013-standard-testing-strategy.md)                   | Testing Strategy                                         | 已采纳 | 2026-01-15 |
 | [ADR-014](./ADR-014-standard-typescript-guidelines.md)              | TypeScript Guidelines                                    | 已采纳 | 2026-01-15 |
 | [ADR-015](./ADR-015-dev-phase-simplicity-preference.md)             | Dev Phase Simplicity Preference                          | 已采纳 | 2026-01-16 |
 | [ADR-016](./ADR-016-apps-as-containers.md)                          | Apps as Containers                                       | 已采纳 | 未注明     |
-| [ADR-017](./ADR-017-centralized-types.md)                           | Absolute Type Centralization in Contracts                | 已采纳 | 未注明     |
+| [ADR-017](./ADR-017-centralized-types.md)                           | Absolute Type Centralization in Contracts                | 已被 ADR-049 取代 | 未注明     |
 | [ADR-018](./ADR-018-smart-container-application-service-pattern.md) | Smart Container + Application Service Pattern            | 已采纳 | 2026-01-18 |
 | [ADR-019](./ADR-019-module-extension-strategy.md)                   | 模块扩展策略                                             | 已采纳 | 2025-12-08 |
 | [ADR-020](./ADR-020-api-server-unified-extraction-strategy.md)      | API Server 统一提取策略                                  | 已采纳 | 2026-01-19 |
@@ -45,7 +45,7 @@ updated: 2026-08-04T00:00:00+08:00
 | [ADR-027](./ADR-027-zod-to-openapi-documentation.md)                | API Documentation with Zod-to-OpenAPI                    | 已采纳 | 2026-02-19 |
 | [ADR-028](./ADR-028-workspace-package-resolution-strategy.md)       | Workspace Package Resolution Strategy                    | 已采纳 | 2026-03-09 |
 | [ADR-029](./ADR-029-main-process-sqlite-access.md)                  | 主进程 SQLite 直接访问策略                               | 已过时 | 2025-12-06 |
-| [ADR-030](./ADR-030-standard-result-pattern.md)                     | Unifying API Responses with Result Pattern               | 已采纳 | 2026-01-16 |
+| [ADR-030](./ADR-030-standard-result-pattern.md)                     | Unifying API Responses with Result Pattern               | 由 ADR-049 修订 | 2026-01-16 |
 | [ADR-031](./ADR-031-server-feature-standard-shape.md)               | Server Feature Standard Shape                            | 已采纳 | 2026-08-13 |
 | [ADR-032](./ADR-032-support-package-import-conventions.md)          | Support Package Import Conventions                       | 已采纳 | 2026-05-25 |
 | [ADR-033](./ADR-033-cross-module-communication-patterns.md)         | Cross-Module Communication Patterns                      | 已采纳 | 2026-07-10 |
@@ -64,6 +64,7 @@ updated: 2026-08-04T00:00:00+08:00
 | [ADR-046](./ADR-046-query-cache-powersync-offline-policy.md) | Query Cache Pilot — Offline / Freshness / PowerSync 策略（试点范围：Desktop networkMode、freshness、reconnect ordering、profile isolation、拒绝 cache 持久化） | 已接受（试点范围） | 2026-08-15 |
 | [ADR-047](./ADR-047-api-observability-pipeline.md) | API 可观测性流水线与装配治理（single observer、有界 metrics、默认 noop / opt-in OpenTelemetry、transport-only 模块注册上下文） | 已采纳 | 2026-08-15 |
 | [ADR-048](./ADR-048-transport-contract-parity.md) | Transport Contract Parity — adapter-owned validation、HTTP/IPC parity fixture、mapper 边界与 direct Vitest 门禁（RefArch Phase 4） | 已采纳 | 2026-08-16 |
+| [ADR-049](./ADR-049-domain-outcome-and-failure-contracts.md) | Domain Outcomes and Failure Contracts — 领域故障、应用结果、公开失败、provider ACL 与传输投影 | 已采纳（实施中） | 2026-08-17 |
 
 ## 维护规则
 

--- a/docs/audit/2026-08-17-application-architecture-and-failure-contract-audit.md
+++ b/docs/audit/2026-08-17-application-architecture-and-failure-contract-audit.md
@@ -1,0 +1,907 @@
+---
+tags:
+  - audit
+  - architecture
+  - contracts
+  - error-handling
+  - refactor
+  - governance
+description: MemoFlow 全应用架构、领域/应用/传输契约与失败语义的系统审计
+created: 2026-08-17T00:00:00+09:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
+# MemoFlow 全应用架构与失败契约系统审计
+
+## 1. 文档定位
+
+本文不是 Auth PR 的复盘，也不是一份只讨论错误提示的编码规范。它以
+`/home/ubuntu/projects/memoflow` 当前 `main` 为基线，把 Auth 暴露出的缺陷扩展到整个
+MemoFlow，审查以下长期结构：
+
+1. 领域模型、应用结果、跨边界契约、传输协议和诊断信息分别由谁拥有；
+2. `packages/contracts`、feature package、`domain-shared`、`utils` 和 apps 的职责是否清晰；
+3. HTTP、IPC、Web、Desktop、PowerSync、第三方 provider 之间是否存在语义泄漏；
+4. 失败、正常分支、重试、用户恢复动作和可观测性是否使用稳定协议；
+5. 当前包边界、组合根、测试与治理是否能阻止同类问题再次扩散；
+6. 应采用怎样的目标架构和迁移顺序，才能一次治理整类问题而不是逐个补丁。
+
+本轮只修改架构文档、ADR、规范与实施计划，不修改生产代码，不宣称现有问题已修复。
+第一版审计完成后，又补充了 TypeScript 库、协议标准和开源实现研究；研究结论与设计修订见
+[失败契约库与开源实现研究](../analysis/2026-08-17-failure-contract-library-and-open-source-study.md)。
+ACR-R02 隔离实验与 ACR-R03 设计 Gate 已完成，生产实施从 ACR-001 起解锁；实验依据见 `docs/analysis/2026-08-17-failure-contract-spike-evidence.md`。
+
+## 2. 结论先行
+
+MemoFlow 已经建立了 Result envelope、HTTP/IPC adapter、ExecutionContext、host composer、
+package boundary audit、transport parity 和 architecture surface locks。这些是很好的地基。
+
+但当前仍存在一个贯穿全仓的根问题：
+
+> 系统把“发生了什么”“调用方应该怎么做”“怎么通过网络表达”“给用户显示什么”以及
+> “内部如何诊断”压进了同一个 `Error` / `ResultError` 对象。
+
+Auth 只是最先把它暴露出来。相同模式已经出现在 Account、AI、Goal、Task、Reminder、
+Schedule、Repository、Setting、Web、Desktop 和 API 中：
+
+- provider code 或 provider HTTP status 直接进入 application/UI；
+- application 通过 `message.includes(...)` 判断业务原因；
+- `ResultError.message` 被重新包装为普通 `Error`，机器语义和 trace 丢失；
+- UI 直接展示 `result.error.message`；
+- 领域错误类携带 HTTP status、timestamp、operationId 和原始异常；
+- feature-specific code 未登记在全局 HTTP map 时默认成为 500；
+- 正常但未完成的状态被建模成 error；
+- `packages/contracts` 同时保存 wire DTO、领域实体接口、聚合、协议、事件和 schema，
+  逐渐成为全局语义仓库；
+- feature package 在一个 Nx `layer:domain` 标签下同时包含 domain、application、transport、
+  infrastructure 和部分 composition，包级标签无法表达真实依赖方向。
+
+因此，真正需要重构的不是“错误工具函数”，而是以下五个所有权：
+
+```text
+领域事实       -> feature domain
+用例结果       -> feature application
+跨边界稳定契约 -> contracts/<feature>
+provider/技术异常 -> infrastructure adapter
+HTTP/IPC/UI/日志 -> 各自边界 adapter
+```
+
+## 3. 核心决策摘要
+
+### 3.1 错误码不应该只放一个地方
+
+“错误码放领域层还是 contracts”这个问题没有单一答案，因为当前所谓的错误码其实混合了
+不同语义。目标架构必须区分：
+
+| 类型            | 示例                                              | 所有者                              | 是否跨进程稳定   |
+| --------------- | ------------------------------------------------- | ----------------------------------- | ---------------- |
+| 领域故障标识    | `TaskAlreadyCompleted`、`GoalArchived`            | feature domain                      | 否，除非明确公开 |
+| 应用失败码      | `TASK_STATE_CONFLICT`、`GOAL_NOT_FOUND`           | feature application/public contract | 是               |
+| 正常结果分支    | `email_verification_required`、`waiting_approval` | operation outcome contract          | 是               |
+| provider 错误码 | `EMAIL_NOT_VERIFIED`、GitHub `422`                | infrastructure adapter 私有         | 否               |
+| 通用失败类别    | `validation`、`conflict`、`unavailable`           | shared contracts                    | 是               |
+| HTTP status     | `409`、`503`                                      | HTTP transport adapter              | 仅 HTTP          |
+| UI 文案 key     | `auth.errors.INVALID_CREDENTIALS`                 | presentation                        | 仅 UI            |
+| 诊断原因        | stack、cause、query、provider body                | observability/infrastructure        | 绝不出 wire      |
+
+### 3.2 contracts 只集中“边界”，不集中“整个世界”
+
+`@memoflow/contracts` 应继续作为跨包、跨进程、跨语言、持久化消息和公开 Port 的稳定契约源，
+但不应继续充当所有领域实体、内部 helper type、provider type 和实现接口的绝对注册中心。
+
+新的原则是：
+
+> Boundary-first contracts，而不是 absolute type centralization。
+
+领域模型先在 owning feature 中表达业务不变量；contracts 保存它在边界上的 command、query、
+outcome、event 和 snapshot 投影。领域类不再 `implements` 一份为了网络传输而设计的全局接口。
+
+### 3.3 Result 是边界语言，不是所有内部控制流的唯一语言
+
+`Result<T, E>` 继续作为 application-facing boundary、HTTP、IPC 和 client port 的标准结果。
+领域内部可以使用 feature-owned discriminated union、typed decision 或 feature-specific fault；
+基础设施可以抛出 adapter-private 异常。关键要求是每个边界只有一个显式 mapper。
+
+### 3.4 message 不能驱动行为
+
+所有行为分支必须基于 stable code、outcome kind 或 typed metadata。`message` 只能作为兼容期的
+安全 fallback，不能用于：
+
+- `includes` / regex 分类；
+- HTTP status 选择；
+- retry 决策；
+- UI scene 切换；
+- E2E fixture 准备；
+- provider error 识别。
+
+### 3.5 预期分支不是错误
+
+以下状态应优先建模为成功结果的 discriminated outcome，而不是 generic failure：
+
+- 邮箱需要验证；
+- AI 等待审批；
+- 用户需要选择冲突解决方案；
+- durable operation 已接受并等待处理；
+- OAuth/device flow 等待用户动作；
+- import dry-run 需要确认。
+
+### 3.6 库与开源研究修正了第一版方案
+
+研究结论不是“找一个更强的 Error 库”，而是：
+
+- 保留 MemoFlow-owned `Result<T, E>`、Zod 和现有 HTTP/IPC envelope；
+- TypeScript discriminated union + `assertNever` 是默认基础；
+- `ts-pattern` 经 spike 后延期，本轮默认使用 native `switch + assertNever`；
+- neverthrow 只借鉴 combinator 与 Result-consumption 治理，不替换现有 Result；
+- Auth 经 spike 后采用 typed reducer；XState 只可由未来复杂 workflow 的独立 ADR/spike 提出；
+- Effect、Connect、Temporal 不作为本轮全仓 runtime/transport 基础；
+- RFC 9457、Google AIP、Connect、OpenTelemetry、Temporal 主要用于修正 public details、retry、
+  transport projection 与 observability 语义；
+- Lark CLI、Ardan Labs、Memos、Vendure 用于验证 stable code、internal cause、认证安全和 expected outcome。
+
+更关键的设计修正是把原先笼统的 retry directive 拆成：
+
+1. `FailureRetryHint`：失败是否暂态的事实；
+2. `OperationRetryPolicy`：operation/executor 根据幂等、transaction、attempt budget 和 deadline 决定；
+3. `RecoveryAction`：application/presentation 推导用户或 host 下一步。
+
+三者不得互相代替。Public Failure 不能单方面授权重试一个非幂等写操作，也不能固化 UI action。
+
+## 4. 审计范围与方法
+
+### 4.1 检查范围
+
+- `apps/api`、`apps/web`、`apps/desktop`；
+- `packages/contracts`、`packages/utils`、`packages/http-client`、`packages/cloud-auth`；
+- Account、AI、Goal、Task、Reminder、Schedule、Notification、Repository、Setting、
+  Governance、Data Portability；
+- Nx tags、package dependencies、feature-to-feature imports；
+- HTTP/IPC result mapping、UI error translation、E2E auth helper；
+- governance scripts、architecture surface manifest、ADR 和 standards。
+
+### 4.2 证据方法
+
+本审计使用：
+
+1. 源码直接阅读；
+2. workspace package graph 与 Nx project tags；
+3. 针对 `throw new Error`、`message.includes`、`ResultError`、`fail/error`、
+   raw message rethrow 的启发式静态扫描；
+4. PR #229 的 GitHub Actions Web Flow 日志；
+5. 当前 Docker image OCI revision 与运行 compose metadata；
+6. 现有 ADR、架构规范和治理脚本；
+7. `ts-pattern`、neverthrow、Effect、XState 官方资料；
+8. RFC 9457、AIP-193/194、Connect、OpenTelemetry、Temporal；
+9. Lark CLI、Ardan Labs、Memos、Vendure 的公开源码/契约。
+
+静态数量是用于识别结构性密度的启发式指标，不等同于逐条已确认缺陷；严重级别只对本文列出的
+有源码证据的模式负责。
+
+## 5. 当前架构地图
+
+```text
+                          apps/api
+                             |
+                     host runtime composers
+                             |
+       +---------------------+----------------------+
+       |                     |                      |
+  feature package       feature package       feature package
+  domain/application    transport/infra       client/electron
+       |                     |                      |
+       +---------- @memoflow/contracts -------------+
+                             |
+                  HTTP / IPC / PowerSync wire
+                             |
+              Web / Desktop presentation state
+```
+
+在理想设计里，apps 只拥有装配和平台适配；feature package 内部依赖方向为：
+
+```text
+transport -> application -> domain
+infrastructure -> application/domain ports
+```
+
+当前现实有三个偏差：
+
+1. 一个 feature package 的 Nx tag 统一是 `layer:domain`，但包内同时包含 infra 和 transport；
+2. `layer:domain` 在 Nx 规则中被允许依赖 `layer:infra`，真实纯度依赖额外 repo audit；
+3. Data Portability、Schedule Orchestration、AI 等跨 feature 编排仍存在直接 feature 依赖或
+   app/feature 双重 composition ownership。
+
+## 6. 证据快照
+
+### 6.1 contracts 规模
+
+当前 `packages/contracts/src` 的生产 TypeScript 约为：
+
+- 551 个文件；
+- 23,548 行；
+- 325 个 `interface`；
+- 423 个 `z.object`；
+- 同时包含 AI、Goal、Task、Reminder、Notification、Schedule、Governance、Repository、
+  Data Portability、Result、Electron、shared primitives 等。
+
+按行数最大的模块：
+
+| 模块               | 文件 |  行数 |
+| ------------------ | ---: | ----: |
+| AI                 |   57 | 3,499 |
+| Goal               |   75 | 3,130 |
+| Task               |   65 | 2,298 |
+| Reminder           |   52 | 1,724 |
+| Notification       |   55 | 1,533 |
+| Schedule           |   47 | 1,509 |
+| Governance         |   36 | 1,437 |
+| Data Portability   |   28 | 1,258 |
+| Reliable Messaging |    6 | 1,177 |
+| Result             |    5 |   885 |
+
+规模本身不是问题；问题是这些文件同时承担 wire schema、领域接口、聚合/实体语义、事件、
+mock 和基础协议，修改原因不再单一。
+
+### 6.2 全仓错误处理启发式扫描
+
+排除主要生成目录后，扫描得到：
+
+| 模式                                    | 近似数量 | 风险                                    |
+| --------------------------------------- | -------: | --------------------------------------- |
+| `throw new Error(...)`                  |      953 | generic exception 大量承担业务/协议语义 |
+| `throw` 任意值/宽类型                   |      204 | 边界难以稳定归类                        |
+| `as unknown as`                         |      127 | 边界 shape 漂移被强转掩盖               |
+| message-based branch                    |       53 | 文案成为行为协议                        |
+| `throw new Error(result.error.message)` |       23 | code/meta/trace 丢失                    |
+| inline `fail({ ... })`                  |      273 | public code 无集中 registry/coverage    |
+| uppercase code literals                 |      336 | code taxonomy 分散且语义层级混合        |
+
+高密度区域包括 `apps/web`、`packages/ai`、`packages/goal`、
+`packages/notification`、`apps/desktop`、`packages/task` 和 `packages/schedule`。
+
+### 6.3 代表性证据
+
+- `packages/account/.../close-account.use-case.ts` 通过
+  `message.includes('Account not found')` 选择 `NOT_FOUND`；
+- AI observability/runtime 通过 `timeout`、`unauthorized`、固定 message 常量分类；
+- Repository application service 直接检查 provider `status === 401/403/404/413`；
+- API、Desktop、app-vue 多处把 `result.error.message` 重新抛成普通 `Error`；
+- Repository/Setting UI 多处直接将 `result.error.message` 写入页面状态；
+- AI turn engine 的 `{ status: 'failed', error?: string }` 中，`error` 有时是 code、
+  有时是 `CODE: message`、有时是 provider/raw message；
+- `packages/utils/src/errors/domain-error.ts` 的领域错误同时携带 HTTP status、timestamp、
+  operationId、step、originalError，并提供 API JSON 和 log formatting；
+- `packages/contracts/src/result/http.ts` 在 shared contracts 内维护 HTTP status map，
+  未登记的 feature code 默认映射 500；
+- `packages/http-client/src/result-error.ts` 在找不到 i18n code 后返回 raw `message`；
+- Auth E2E helper 通过页面文案判断“账号不存在”并自动注册，导致一个文案漂移扩散成多个
+  Dashboard Web Flow 失败；
+- 当前 local Docker images 标记为 `8258d...-dirty`，且构建早于待验证 Auth commit，
+  运行版本无法精确证明当前源码行为。
+
+## 7. Findings 总表
+
+| ID   | 严重度 | 根因                                                   | 主要影响                         |
+| ---- | ------ | ------------------------------------------------------ | -------------------------------- |
+| F-01 | P0     | 领域、应用、wire、transport、diagnostic 错误合一       | 泄漏、误分类、错误恢复           |
+| F-02 | P0     | provider error 没有 ACL                                | 第三方升级穿透全栈               |
+| F-03 | P0     | message/string 承担机器协议                            | i18n、测试、重试和安全不稳定     |
+| F-04 | P0     | `ResultError` 同时包含 public data 与 `cause/context`  | wire 安全和可序列化边界不清      |
+| F-05 | P1     | 正常分支被建模为 error                                 | UI 状态机充满特殊判断            |
+| F-06 | P1     | contracts 绝对中心化                                   | god registry、领域贫血、变更放大 |
+| F-07 | P1     | HTTP mapping 位于 shared contracts                     | 非 HTTP host 被 HTTP 语义污染    |
+| F-08 | P1     | feature package/Nx layer 与真实子层不一致              | 包边界可读性和治理不足           |
+| F-09 | P1     | composition/cross-feature ownership 分散               | 重复实例、直接依赖、宿主行为漂移 |
+| F-10 | P1     | Presentation state 和错误翻译无单一 owner              | Web/Desktop/scene/receipt 双轨   |
+| F-11 | P1     | E2E fixture 通过 UI 文案和副作用准备数据               | 非目标测试级联失败               |
+| F-12 | P1     | provider/infra status 在 application 中分支            | application 依赖技术细节         |
+| F-13 | P2     | 治理未覆盖 failure registry/provider leakage           | 同类问题持续新增                 |
+| F-14 | P2     | build/config provenance 不构成验收契约                 | 验证源码与运行物不一致           |
+| F-15 | P2     | 旧 ADR 同时宣称 absolute centralization                | 架构规则自相矛盾                 |
+| F-16 | P1     | retry hint、operation retry 与 UI recovery 混合        | 非幂等重试和错误 UX 风险         |
+| F-17 | P1     | 未经 spike 的库采用可能形成第二套 runtime/Result/state | 重构范围失控与长期锁定           |
+
+## 8. 详细诊断
+
+### F-01：一个 Error 对象承担了五层职责
+
+当前 `DomainError` 名称暗示它属于领域层，但其字段包含：
+
+- domain/application code；
+- HTTP status；
+- API JSON shape；
+- timestamp；
+- operationId / step；
+- originalError；
+- log formatter；
+- error chain traversal。
+
+这违反单一变化原因。领域规则改变、HTTP policy 改变、日志结构改变、trace policy 改变都会修改
+同一个基类。更严重的是，领域层因此知道 HTTP，并且 `context` 是否安全出网没有类型保证。
+
+目标不是创建一个更大的 `AppError`，而是拆开：
+
+```text
+DomainFault        只表达业务事实
+ApplicationFailure 只表达调用方可处理的失败
+TransportMapping   只表达协议投影
+DiagnosticRecord   只表达内部排障信息
+```
+
+### F-02：第三方 provider 语义进入 MemoFlow public contract
+
+Auth 的 `INVALID_EMAIL_OR_PASSWORD` / `EMAIL_NOT_VERIFIED` 是当前最明显例子；Repository 中
+GitHub status、AI provider message、Prisma code 也存在同类风险。
+
+正确边界是 Anti-Corruption Layer：
+
+```text
+provider response
+       |
+       v
+adapter-private parser
+       |
+       v
+MemoFlow-owned outcome/failure
+```
+
+provider code 可以保留在内部 diagnostic attributes 中，但不能成为 UI、application、E2E 或
+跨进程 schema 的依赖。
+
+### F-03：message 成为隐藏的第二套协议
+
+系统表面上使用 `ResultError.code`，实际又通过 message 完成：
+
+- not-found 分类；
+- abort/timeout/auth 判断；
+- UI 文案；
+- E2E fixture 决策；
+- AI runtime invariant 识别；
+- generic Error rethrow。
+
+因此仓库同时存在两套协议：显式 code 和隐式 English string。后者没有 schema、没有版本、没有
+编译检查，并会被 provider、i18n 和文案调整随时改变。
+
+必须把 message branching 视为架构违规；只有 adapter 内解析无法提供结构化信息的 legacy
+provider 时允许临时 allowlist，并要求 owner/retire date。
+
+### F-04：public failure 与 diagnostic cause 没有类型隔离
+
+`ResultError` 当前同时允许 `context` 和 `cause`，而同一个类型被 server、client、HTTP、IPC、
+store 和 UI 使用。虽然 HTTP serializer 当前不会主动序列化 `cause`，但类型层没有防止：
+
+- context 放入 token、query、provider response、PII；
+- client 误依赖 server-only cause；
+- durable receipt 持久化 raw message/context；
+- adapter 将 Error 对象塞入 wire data。
+
+目标 public failure 必须是 JSON-safe、allowlisted 和无 cause 的类型。内部诊断使用独立类型，
+由 observer/logger 绑定 traceId，不进入 Result payload。
+
+### F-05：正常状态与失败状态混合
+
+“密码正确但邮箱未验证”不是系统故障；“AI 等待审批”不是失败；“任务已进入 durable queue”
+也不是失败。这些状态都要求调用方执行明确下一步，应由 outcome union 表达。
+
+将它们建模为 error 会导致：
+
+- success/failure 统计失真；
+- retry policy 不清；
+- UI 用 error code 切 scene；
+- toast、error banner 与正常指引混用；
+- provider-specific error code 被迫成为 workflow state。
+
+### F-06：Absolute Type Centralization 使 contracts 成为语义仓库
+
+ADR-010/017 原意是消除 Web/API/Desktop DTO 漂移，但规则扩展为“所有 public data types、business
+entities、domain entity interfaces 都必须在 contracts”。结果是：
+
+1. domain class 需要实现 wire-oriented interface；
+2. feature 内部变化先修改中央包；
+3. contracts 同时知道多个 bounded context 的内部模型；
+4. 每个 feature 仍存在 domain-server/domain-client 类型，形成“中央接口 + 本地实现”双模型；
+5. package root 构建和依赖 fan-out 增大；
+6. AI agent 容易把“共享类型”误解为“所有语义都属于 shared”。
+
+正确规则应是：
+
+- 跨边界、跨语言、durable event、public port 类型集中在 contracts；
+- domain entities、domain faults、repository ports、application-internal types 留在 owning feature；
+- 真正跨领域且语义完全相同的值对象才进入 `domain-shared`；
+- wire DTO 是 domain snapshot/projection，不是 domain interface。
+
+### F-07：HTTP status mapping 不属于 contracts/result
+
+`ResultCodeToHttpStatus` 和 `errorCodeToHttpStatus` 当前位于 contracts。它让 shared result package
+知道 HTTP，并让所有 feature code 依赖一个中央 map。新 code 未登记时默认为 500，导致：
+
+- 业务冲突被错误报告为服务器故障；
+- HTTP map 成为中央修改点；
+- IPC/Desktop 继承并不需要的 HTTP 分类；
+- feature code 与 transport policy 无法独立演进。
+
+目标：shared contracts 只提供 failure category；HTTP adapter 按 category 提供默认 status，并允许
+feature HTTP registry 对 operation/code 做显式覆盖。IPC 使用自己的 envelope，不携带 HTTP status。
+
+### F-08：Nx `layer:domain` 无法表达单包多层现实
+
+Goal、Task 等 package 被标记为 `layer:domain`，但内部包含 domain、application、transport、
+infrastructure 和 host-facing factory。为了允许 composition，Nx 又允许 domain package 依赖 infra。
+实际纯度依赖 `package-internal-boundary-audit.mjs` 补救。
+
+这套设计可以运行，但命名误导：package 不是 domain library，而是 vertical feature slice。
+建议长期改为：
+
+```text
+type:feature / layer:feature
+```
+
+并把 domain/application/transport/infrastructure 依赖方向全部交给 AST-based in-package governance。
+Nx package graph 管 feature isolation，source audit 管 feature 内层次。
+
+### F-09：组合根和跨 feature 编排仍然分散
+
+当前 package graph 没有循环，这是优点；但仍有高 fan-out：
+
+- Schedule Orchestration 直接依赖 Goal、Task、Reminder、Notification、Schedule；
+- Data Portability infrastructure 直接依赖多个 feature implementation；
+- AI 直接依赖 Repository、Setting；
+- Goal/Task/Reminder 直接依赖 Schedule contracts/implementation surface；
+- API 与 Desktop 对部分业务执行各有一套 adapter/orchestrator。
+
+跨 feature application service 可以存在，但它应该依赖 consumer-owned ports/public contracts，
+由 host composer 注入 provider adapters，而不是把 feature package implementation graph固定下来。
+
+### F-10：Presentation 失败状态没有单一 owner
+
+Auth 同时存在 `useWebAuth`、app-vue auth composables、Pinia receipt、Web scene-local state；其他模块也
+同时使用 translator、raw message、local ref、query error 和 toast。结果是同一个失败可能被：
+
+- 翻译两次或不翻译；
+- 存为 code、message 或完整 ResultError；
+- 在 locale 变化后无法重新翻译；
+- 在 reload 后持久化不安全内容；
+- Web 和 Desktop 给出不同 recovery。
+
+目标 presentation state 保存 stable failure/outcome，不保存最终文案；文案是 computed projection。
+每个 operation 由一个 application state owner 管 loading/outcome/failure/retry receipt。
+
+### F-11：测试 fixture 依赖用户界面行为
+
+通用 login helper 在页面失败后查找具体文案，再决定是否自动注册。这使一个 Auth 文案问题导致
+Dashboard、deep-link、shell 等非 Auth 场景失败。
+
+测试层应严格分工：
+
+- global setup/API/DB fixture 确定性建立 verified user；
+- login helper 只登录；
+- signup/verification E2E 独立验证；
+- UI test 根据 data-testid 和 stable state 断言，不把文案当 fixture protocol；
+- locale test 专门验证 code 在语言切换后重新投影。
+
+### F-12：application 直接理解 provider status
+
+Repository application service 直接判断 GitHub/HTTP status，Auth application 判断 BetterAuth code，
+AI application 从 provider message 分类。这表明 adapter 没有完成技术语义到应用语义的翻译。
+
+所有 provider-specific status/body/header 应止于 infrastructure。Application port 返回 MemoFlow-owned
+result/outcome，application 不 import provider SDK error class。
+
+### F-13：现有 governance 很强，但缺一类核心规则
+
+仓库已有：
+
+- package internal boundary；
+- package export audit；
+- architecture surface locks；
+- raw event bus / mitt RPC / unflushed events；
+- transport parity；
+- public JSDoc；
+- target baseline。
+
+缺失的是 failure contract governance：
+
+1. public failure code registry；
+2. provider code leakage scan；
+3. message-based branch ban；
+4. raw Result message rethrow ban；
+5. i18n coverage；
+6. HTTP/IPC mapping coverage；
+7. JSON-safe public failure schema；
+8. code removal/versioning check。
+
+### F-14：源码、构建物和运行物没有成为同一验收事实
+
+Docker image 已带 OCI revision，这是良好基础；但当前 image revision 带 `-dirty`，且运行 stack 的构建
+时间早于待验证 commit。测试如果不先校验 build identity，就可能验证旧 UI/API。
+
+目标是 E2E 启动时 fail fast：
+
+```text
+expected source revision
+  == web build revision
+  == api build revision
+  == compose evidence revision
+```
+
+同时 `.env.local` / `.env.production.local` 应由 typed environment schema 说明 required/public/secret/
+forbidden，而不是只靠文件内容约定。
+
+### F-15：旧 ADR 与当前目标互相冲突
+
+ADR-010/017 的 absolute centralization、ADR-012 的 error class + HTTP status、ADR-030 的 Result
+描述与当前 RefArch/transport parity 已有明显张力。若不正式 supersede/amend，后续开发者和 Agent 会继续
+依据旧文档生成错误结构。
+
+本审计配套 ADR-049，用正式决策关闭该冲突。
+
+### F-16：失败暂态事实、自动重试策略和用户恢复动作混为一谈
+
+第一版 `RetryDirective` 同时包含 `never/immediate/after/reauthenticate/user_action`。这把三个不同 owner
+放进同一字段：provider/server 对失败性质的判断、operation 对幂等和副作用的判断，以及 UI 下一步。
+Google AIP-194、Temporal Activity/Workflow retry 模型和现有 reliable receipt 都说明：是否自动 retry 必须
+结合 operation policy、idempotency key、transaction/workflow 边界、attempt budget、deadline 和部分副作用。
+`Retry-After` 或 transient failure 只是输入事实，不是执行许可。
+
+目标拆分为：
+
+```text
+FailureRetryHint
+  ∩ OperationRetryPolicy
+  ∩ idempotency / durable receipt state
+  ∩ attempt budget / deadline / cancellation
+  -> retry decision
+
+PublicFailure + Outcome + host context
+  -> RecoveryAction
+```
+
+### F-17：大重构容易借机引入第二套平台
+
+MemoFlow 已有 Result、Zod、DI/composer、reliable messaging、retry/dead-letter、OpenTelemetry、TanStack Query
+和 AI runtime。直接引入 neverthrow、Effect、XState 或 Connect 作为全仓底座，会同时重写 Result、schema、
+DI、lifecycle、transport、state 和测试。
+
+目标不是拒绝所有库，而是规定准入：
+
+- `ts-pattern`：只在 exhaustive mapper/complex reducer 使用，先测 typecheck 与错误质量；
+- XState：只在满足复杂度阈值的长流程使用，actor snapshot 不替代 durable fact；
+- neverthrow：借鉴组合器和 Result-consumption lint；
+- Effect：未来只允许隔离 AI/worker 实验；
+- 所有 library type 不得进入 wire、Domain Fault identity 或 durable schema。
+
+## 9. “错误码放哪里”的完整答案
+
+### 9.1 Domain 层放什么
+
+Domain 层放 feature-owned fault identity，表达业务不变量和状态转移为什么被拒绝。例如：
+
+```ts
+type TaskDomainFault =
+  | { kind: 'TaskAlreadyCompleted'; taskId: TaskId }
+  | { kind: 'TaskHierarchyCycle'; parentId: TaskId }
+  | { kind: 'TaskArchived'; taskId: TaskId };
+```
+
+约束：
+
+- 不含 HTTP status；
+- 不含 i18n message；
+- 不含 provider code；
+- 不含 stack/trace/timestamp；
+- 不要求所有 fault 跨边界稳定；
+- domain 不 import `@memoflow/contracts/result` 只是为了生成 HTTP-friendly code。
+
+### 9.2 Application 层放什么
+
+Application 层拥有 operation semantics：成功、正常替代结果和公开失败的映射。
+
+```ts
+type CompleteTaskOutcome =
+  { kind: 'completed'; task: TaskSnapshot } | { kind: 'already_completed'; task: TaskSnapshot };
+
+type CompleteTaskFailureCode =
+  'TASK_NOT_FOUND' | 'TASK_VERSION_CONFLICT' | 'TASK_COMPLETION_REJECTED';
+```
+
+Application 将 domain fault、repository fault、policy decision 映射为调用方可以处理的稳定语义。
+
+### 9.3 contracts 放什么
+
+contracts 放跨边界稳定的：
+
+- command/query request schema；
+- response snapshot；
+- operation outcome union；
+- public failure code union + JSON schema；
+- HTTP/IPC 共用的 canonical input/output；
+- durable events/messages；
+- public client/application port。
+
+不要放：
+
+- domain entity interface 只为了让 class implements；
+- Prisma/provider types；
+- private repository row；
+- UI component props；
+- feature internal helper types；
+- stack/cause/logger context。
+
+### 9.4 Infrastructure 放什么
+
+- provider code parser；
+- Prisma/GitHub/BetterAuth/OpenAI/PowerSync error mapper；
+- network/SDK exception；
+- retry-after/header/body 解析；
+- internal diagnostic attributes。
+
+这些类型默认 private，只有 MemoFlow-owned result/outcome 可以离开 adapter。
+
+### 9.5 Transport 放什么
+
+HTTP adapter 决定 status/header/cache/retry-after；IPC adapter 决定 channel envelope；SSE adapter 决定
+terminal event。它们都消费同一个 public failure/outcome，但不能反向影响 domain model。
+
+### 9.6 Presentation 放什么
+
+UI 保存：
+
+```text
+outcome kind
+public failure code/category/typed details/retry hint
+operation retry state
+recovery action
+request/trace reference
+```
+
+UI 不保存 raw provider/server message，也不根据 message 分支。locale 变化时重新根据 code/typed details
+计算文案。RecoveryAction 根据 public semantics 和 host context 推导，不能从 translated message 或 retry hint 推导。
+
+## 10. 目标架构
+
+```text
++--------------------------- Owning Feature ---------------------------+
+|                                                                      |
+|  Domain Model                                                        |
+|  aggregate / value object / DomainFault                              |
+|          |                                                           |
+|          v                                                           |
+|  Application Use Case                                                |
+|  command/query + OperationOutcome + failure mapper                   |
+|  OperationRetryPolicy + RecoveryPolicy                               |
+|          |                                                           |
+|          +---------------- public feature port -------------------+   |
+|                                                                  |   |
++------------------------------------------------------------------|---+
+                                                                   |
+                          @memoflow/contracts/<feature>              |
+                  request / outcome / public failure / snapshot      |
+                                                                   |
+               +-------------------+-------------------+             |
+               |                   |                   |             |
+               v                   v                   v             |
+          HTTP adapter         IPC adapter        durable message    |
+          status/header        channel envelope   schema/version     |
+               |                   |                   |             |
+               +-------------------+-------------------+             |
+                                   |                                 |
+                              client adapter                           |
+                                   |                                 |
+                         presentation state machine                   |
+                                   |                                 |
+                         i18n(code, typed details)                   |
+
+Provider/DB/SDK errors -> infrastructure ACL -> domain/application semantics
+Internal cause/stack   -> observer/logger only -> never enters public contract
+```
+
+## 11. 目标 package ownership
+
+| Package/目录                                   | 目标职责                                                               |
+| ---------------------------------------------- | ---------------------------------------------------------------------- |
+| `packages/<feature>/src/server/domain`         | aggregate、VO、policy、domain fault、domain-owned port                 |
+| `packages/<feature>/src/server/application`    | use case、application port、outcome/failure mapper、orchestration      |
+| `packages/<feature>/src/server/infrastructure` | DB/provider adapter、ACL、technical retry、diagnostic enrichment       |
+| `packages/<feature>/src/server/transport`      | HTTP/IPC-independent controller input/output delegation                |
+| `packages/contracts/src/modules/<feature>`     | wire schema、public outcome/failure、snapshot、event、RPC map          |
+| `packages/contracts/src/result`                | generic Result、public failure category、JSON-safe primitives          |
+| `packages/domain-shared`                       | 真正跨 bounded context 且语义一致的 domain primitive                   |
+| `packages/utils`                               | 纯技术工具；不再拥有全局 DomainError 业务层级                          |
+| `packages/http-client`                         | MemoFlow envelope transport、network classification；不做 feature i18n |
+| `packages/app-vue`                             | presentation/application state adapter；只消费 stable public semantics |
+| `apps/*`                                       | composition root、platform adapter、runtime lifecycle、environment     |
+
+## 12. Public failure 目标形状
+
+推荐的目标结构：
+
+```ts
+type FailureCategory =
+  | 'validation'
+  | 'unauthenticated'
+  | 'permission'
+  | 'not_found'
+  | 'conflict'
+  | 'rate_limited'
+  | 'unavailable'
+  | 'timeout'
+  | 'canceled'
+  | 'internal';
+
+type FailureRetryHint =
+  { kind: 'not_retryable' } | { kind: 'transient' } | { kind: 'after'; afterMs: number };
+
+interface PublicFailure<Code extends string = string, Details = never> {
+  readonly code: Code;
+  readonly category: FailureCategory;
+  readonly details?: Details;
+  readonly retryHint?: FailureRetryHint;
+  readonly reference?: { requestId?: string; traceId?: string };
+}
+
+interface OperationRetryPolicy {
+  readonly mode: 'never' | 'safe_read' | 'idempotent_write' | 'transaction' | 'workflow_step';
+  readonly maxAttempts: number;
+  readonly requiresIdempotencyKey: boolean;
+  readonly backoff: BackoffPolicy;
+}
+
+// Application/presentation-owned, not provider-owned.
+type RecoveryAction =
+  | { kind: 'none' }
+  | { kind: 'reauthenticate' }
+  | { kind: 'verify_email'; email: string }
+  | { kind: 'correct_input'; fields?: readonly string[] }
+  | { kind: 'resolve_conflict'; resource: string }
+  | { kind: 'retry_manually' };
+```
+
+兼容迁移期可以保留 `message`，但必须满足：
+
+- 由 MemoFlow allowlist 生成；
+- 不包含 provider response、token、query 或 PII；
+- UI 不根据它分支；
+- UI 优先根据 code + typed details 本地化；
+- 最终考虑从 canonical contract 移除或改为 `fallbackMessage`。
+
+内部诊断另用：
+
+```ts
+interface DiagnosticFailure {
+  readonly cause?: unknown;
+  readonly provider?: string;
+  readonly providerCode?: string;
+  readonly operation: string;
+  readonly attributes?: Record<string, unknown>;
+}
+```
+
+该对象只送 observer/logger，不可作为 HTTP/IPC/durable payload。
+
+### 12.1 Registry 与库边界
+
+每个 feature failure registry 应从一个对象推导：code union、Zod details schema、HTTP policy、i18n key、
+telemetry mapping 和文档。禁止维护多份平行 map，也禁止使用 arbitrary `Record<string, unknown>` 作为公开 details。
+
+默认使用 TypeScript union、Zod strict schema 和 `switch + assertNever`。ACR-R03 已决定本轮不引入 `ts-pattern`、neverthrow、XState 或 Effect 作为 foundation；XState 仅可由未来复杂 workflow 的独立 ADR/spike 提出。
+
+## 13. Protected contracts
+
+大重构必须保护：
+
+1. 当前 `Result<T>`、`HttpResponse<T>`、`IpcResult<T>` wire shape，在显式版本迁移前不破坏；
+2. ADR-048 的 HTTP/IPC canonical fixture 与 adapter-owned validation；
+3. ADR-045 的 ExecutionContext、requestId、traceId、identity ordering；
+4. ADR-042/043 的 reliable operation receipt、timeline、replay 和审计；
+5. AI approval gate、proposal lifecycle 和 single mutation owner；
+6. PowerSync offline/profile isolation 和已有 transport routes/channels；
+7. public deep links、test selectors、auth routes；
+8. database uniqueness/idempotency/receipt invariants；
+9. current build/export subpath，直到迁移调用方完成；
+10. library type 不进入 public wire、Domain Fault identity 或 durable fact；
+11. production failure foundation 只能使用 ACR-R03 已批准的 TypeScript/Zod/Result 组合。
+
+## 14. 重构原则
+
+### 14.1 先研究和 spike，再建立兼容层
+
+不能因为目标是“大刀阔斧重构”就直接选定新 runtime。先完成 library/standard/open-source research、
+exhaustive mapper spike、Auth reducer/XState spike、single-source registry/retry-policy spike，再由 ACR-R03
+冻结采用范围。之后才建立 compatibility layer 和迁移 feature。
+
+不能一次删除 `ResultError.message` 或移动数百个 contracts 文件。先建立新 primitives、registry、mappers
+和 governance，然后以 Auth 为 vertical slice，之后按风险迁移。
+
+### 14.2 Retry hint、operation policy 与 recovery 分属不同 owner
+
+Public Failure 可携带 `retryHint`，但 executor 只有结合 operation idempotency、receipt、attempt budget、deadline
+和 cancellation 后才能自动重试。UI recovery 根据 code/outcome/details 与 host context 推导，不解析 message。
+
+### 14.3 每个 feature 只有一个 public failure vocabulary
+
+Web、Desktop、API、IPC、worker 对同一 operation 使用同一 public code/outcome。Provider、Prisma、
+HTTP status 和 UI key 都只是这个 vocabulary 的投影。
+
+### 14.4 每个 state transition 只有一个 owner
+
+Auth login、AI turn、Task completion、Reminder response、Repository sync 都必须有一个 application
+state owner。UI/composable/helper 不再复制业务状态机。
+
+### 14.5 Contracts 通过 mapper 与 domain 相连
+
+禁止 domain class 为了“共享类型”实现 wire DTO。使用显式：
+
+```text
+toTaskSnapshot(domain)
+fromCreateTaskCommand(contract)
+mapTaskFaultToFailure(fault)
+```
+
+### 14.6 所有临时兼容都必须可退役
+
+兼容 alias、旧 code、raw message、allowlist 必须有 owner、reason、target date 和测试。不得通过新增
+第二套 helper 永久共存。
+
+## 15. 建议的实施顺序
+
+1. 完成 library/standard/open-source study；
+2. 完成 exhaustive mapper、Auth state model、single-source registry/retry-policy 三组隔离 spike；
+3. 通过 ACR-R03 冻结 adopt/borrow/defer/reject 和基础类型；
+4. 建立 ADR-049、failure/outcome 标准和静态 inventory；
+5. 扩展 generic Result 为 typed public failure，同时保持 wire 兼容；
+6. Auth 作为第一条端到端 vertical slice：provider ACL → outcome → HTTP/IPC → UI → E2E；
+7. 新增 failure registry/i18n/transport/governance gates；
+8. 迁移 Account、Repository、AI 中 message/status/provider leakage；
+9. 迁移 Goal/Task/Reminder/Schedule 的 domain fault 与 operation-specific outcomes；
+10. 将 `DomainError` 退役，拆出 domain fault 和 diagnostics；
+11. 将 contracts 从 absolute type registry 收缩为 boundary contract package；
+12. 收敛 host composition 与跨 feature ports；
+13. 完成 UI state、test fixture、build provenance 和 env schema hardening。
+
+具体 ticket、依赖、验收命令和回滚策略见：
+
+- `docs/analysis/2026-08-17-failure-contract-library-and-open-source-study.md`；
+- `docs/plan/active/2026-08-17-application-contract-and-architecture-refactor.md`；
+- `docs/architecture/adr/ADR-049-domain-outcome-and-failure-contracts.md`；
+- `docs/standards/failure-and-outcome-contracts.md`。
+
+## 16. 非目标
+
+本轮方案不主张：
+
+- 创建一个新的全局 `errors` god package；
+- 为每个异常创建 class；
+- 把所有 domain method 都改成 Result；
+- 把 HTTP status 写入 domain/public code；
+- 为了“统一”强迫 Web、Desktop 和 server 使用同一个状态 store；
+- 一次性改完 551 个 contracts 文件；
+- 通过添加更多 fallback/alias 掩盖 provider leakage；
+- 在没有 migration/compatibility tests 时破坏现有 wire envelope；
+- 全仓迁移 Effect、neverthrow、XState、Connect 或 Temporal；
+- 未完成设计 Gate 就把 library type 写入 public contract 或 durable schema。
+
+## 17. 最终判断
+
+MemoFlow 当前的主要风险不是缺少抽象，而是抽象边界错位：
+
+- contracts 管得太多；
+- domain error 知道得太多；
+- provider adapter 翻译得太少；
+- application outcome 表达得太少；
+- UI 和测试依赖 message 太多；
+- governance 对失败协议约束得太少；
+- retry 暂态事实、执行安全和 UI recovery 混得太多；
+- 未经 spike 的库采用可能替代了原本要保护的 architecture ownership。
+
+目标不是得到一套更复杂的 Error class hierarchy，而是让每个层只拥有自己的语义：
+
+```text
+Domain 说明为什么业务拒绝
+Application 说明调用方下一步是什么
+Contracts 说明边界上稳定传什么
+Transport 说明协议如何表达
+Presentation 说明用户看到什么
+Observability 说明工程师如何排障
+```
+
+当这六件事不再由同一个对象承担时，Auth 这类问题才会从“修一次”变成“结构上不再发生”。
+库只能减少 mapper 或复杂状态机样板，不能成为领域语义、public contract、重试安全或 durable fact 的所有者。

--- a/docs/plan/active/2026-08-17-application-contract-and-architecture-refactor.md
+++ b/docs/plan/active/2026-08-17-application-contract-and-architecture-refactor.md
@@ -1,0 +1,1361 @@
+---
+tags:
+  - plan
+  - active
+  - architecture
+  - contracts
+  - error-handling
+  - refactor
+description: MemoFlow 全应用领域/应用/边界契约、失败语义、组合根与治理的大重构实施计划
+created: 2026-08-17T00:00:00+09:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
+# Application Contract and Architecture Refactor / 应用契约与架构大重构
+
+## 文档状态
+
+- **状态**：Active implementation program；ACR-R01/R02/R03 已完成，生产实施从 ACR-001 起解锁。
+- **基线**：oracle3 `/home/ubuntu/projects/memoflow`，`main` = `8258d415e`。
+- **触发事件**：Auth 登录错误映射回归与 PR #229 暴露 provider code、raw message、UI state、
+  E2E fixture 和运行版本验证的系统性缺口。
+- **依据**：
+  - `docs/audit/2026-08-17-application-architecture-and-failure-contract-audit.md`；
+  - `docs/analysis/2026-08-17-failure-contract-library-and-open-source-study.md`；
+  - `docs/analysis/2026-08-17-failure-contract-spike-evidence.md`；
+  - `docs/architecture/adr/ADR-049-domain-outcome-and-failure-contracts.md`；
+  - `docs/standards/failure-and-outcome-contracts.md`；
+  - ADR-045、ADR-048 和现有 architecture/governance surface locks。
+
+## 1. Executive Decision Summary
+
+本计划不以“统一 Error class”为目标，而是重建以下所有权：
+
+```text
+Domain Fault        -> owning feature domain
+Operation Outcome   -> owning feature application/public contract
+Public Failure      -> contracts/<feature>
+Provider Failure    -> infrastructure adapter private
+Transport Mapping   -> HTTP/IPC/SSE adapter
+Presentation        -> stable code/outcome -> i18n/recovery
+Diagnostics         -> observer/logger only
+```
+
+重构顺序采用“外部研究与设计 spike → 设计 Gate → 基础契约 → Auth 垂直切片 → 高风险模块迁移 →
+contracts 收缩 → 组合根收敛 → UI/测试/部署硬化 → 删除旧轨”的方式。禁止先做全仓机械替换，
+也禁止同时维持两套长期协议。`ts-pattern`、XState、neverthrow、Effect 等任何库都必须先经过
+adopt/borrow/defer/reject 决策，不能因为重构规模大就直接成为新底座。
+
+## 2. 目标结果与主要用户路径
+
+### 2.1 目标结果
+
+完成后，MemoFlow 对任何 operation 都能回答：
+
+1. 这是正常 outcome 还是 failure；
+2. failure 是哪个 feature 拥有的稳定语义；
+3. provider/DB 错误如何被转换；
+4. HTTP、IPC、Web、Desktop 如何得到一致行为；
+5. 用户应该重试、重新认证、修正输入还是执行下一步；
+6. UI 如何在 locale 变化后重新翻译；
+7. 工程师如何通过 trace 获取内部 cause，而用户看不到敏感信息；
+8. 新增 code/provider/transport 时，哪一个 CI gate 会证明覆盖完整；
+9. 哪些能力由 MemoFlow 自己拥有，哪些库只作为可替换实现细节。
+
+### 2.2 首个端到端路径：Auth Sign-in
+
+```text
+user submits credentials
+  -> BetterAuth adapter parses provider response
+  -> MemoFlow SignInOutcome/AuthFailure
+  -> Web/IPC client receives canonical semantics
+  -> one application state owner updates scene/failure
+  -> presentation translates code or renders outcome
+  -> E2E verifies invalid credentials, verification required, verified login
+  -> observer records internal provider code without exposing it
+```
+
+必须覆盖：
+
+- 错误密码；
+- 不存在邮箱；
+- 正确密码但未验证；
+- 验证链接有效/无效/过期；
+- 验证后登录；
+- 重复注册；
+- network/provider unavailable；
+- locale 切换；
+- repeated login 清除旧 state；
+- Web/Desktop/HTTP/IPC parity；
+- deterministic test user setup。
+
+## 3. 范围
+
+### 3.1 In scope
+
+- library/standard/open-source research 与隔离 design spikes；
+- shared Result/public failure primitives；
+- feature failure/outcome registries；
+- Auth、Account、Repository、AI、Goal、Task、Reminder、Schedule 的迁移；
+- provider ACL；
+- HTTP/IPC/SSE projection；
+- presentation state/i18n/recovery；
+- `DomainError` 退役；
+- contracts boundary-first 分类和迁移；
+- feature package layering/tag clarification；
+- cross-feature application ports/composition roots；
+- E2E fixture、build provenance、environment schema；
+- governance、inventory、mutation fixtures；
+- docs/ADR/standards 更新。
+
+### 3.2 Out of scope
+
+- 改变现有产品功能或新增业务模块；
+- 重写数据库/PowerSync schema，除非某个 failure/receipt contract 必需；
+- 改变 AI approval、安全权限、account closure、reliable messaging 的业务政策；
+- 一次性删除所有现有 `ResultError.message/context`；
+- 一次性移动 contracts 的 551 个文件；
+- 把所有 domain method 强制改成 Result；
+- 创建新的全局 error god package；
+- 在本计划中重做整个 UI shell、Agent runtime 或 CI/CD platform；
+- 全仓迁移 Effect、neverthrow、XState、Connect 或 Temporal；
+- 违反 ACR-R03 已冻结 library/ownership boundary 的 production foundation。
+
+## 4. 当前系统与 Gap
+
+| Gap                       | Observed                                                   | Desired                                       | Impact                |
+| ------------------------- | ---------------------------------------------------------- | --------------------------------------------- | --------------------- |
+| Provider leakage          | BetterAuth/GitHub/provider code/status 进入 application/UI | adapter 输出 MemoFlow semantics               | 第三方升级不穿透全栈  |
+| Raw message protocol      | message 分支、直接显示、rethrow                            | code/outcome/typed details                    | i18n、安全、测试稳定  |
+| Error object overload     | DomainError 含 HTTP/log/diagnostic                         | 六层类型分离                                  | 分层和序列化安全      |
+| Untyped Result            | `ResultError.code: string`                                 | operation-specific failure generic            | exhaustive handling   |
+| Outcome/error mixing      | verification/approval 作为 error                           | normal outcome union                          | 状态机和 metrics 正确 |
+| Retry/recovery conflation | failure 同时决定自动 retry 与 UI action                    | retry hint / operation policy / recovery 分离 | 幂等与 UX 正确        |
+| Library adoption risk     | 可因“大重构”引入第二套 Result/runtime/state machine        | spike + explicit adoption boundary            | 避免平台级重写        |
+| Contracts god registry    | domain/wire/internal 类型集中                              | boundary-first contracts                      | bounded context 清晰  |
+| HTTP in shared contracts  | 全局 code map                                              | transport-local policy                        | 非 HTTP host 解耦     |
+| Composition fan-out       | feature 直接依赖多 feature                                 | consumer-owned ports + host wiring            | 可测试、可替换        |
+| UI error ownership        | raw refs/store/composable 双轨                             | operation state owner                         | recovery 一致         |
+| Test fixture coupling     | UI 文案决定注册                                            | deterministic setup                           | 非目标 suite 不级联   |
+| Runtime provenance        | image revision dirty/old                                   | source=build=runtime                          | 验收可信              |
+| Governance gap            | 无 failure registry/leakage gate                           | fail-closed audit                             | 防止复发              |
+
+## 5. North-star Architecture
+
+```text
+                      +-------------------------+
+                      |     Feature Domain      |
+                      | state + DomainFault     |
+                      +------------+------------+
+                                   |
+                                   v
+                      +-------------------------+
+                      |  Feature Application    |
+                      | use case + Outcome      |
+                      | fault/failure mapping   |
+                      +------------+------------+
+                                   |
+                      public application port
+                                   |
+             FailureRetryHint + OperationRetryPolicy + RecoveryPolicy
+                                   |
+                 +-----------------+-----------------+
+                 | @memoflow/contracts/<feature>     |
+                 | schema + outcome + public failure |
+                 +-----------------+-----------------+
+                                   |
+              +--------------------+---------------------+
+              |                    |                     |
+              v                    v                     v
+         HTTP adapter          IPC adapter         durable adapter
+         status/header         envelope            event/receipt
+              |                    |                     |
+              +--------------------+---------------------+
+                                   |
+                           client/application state
+                                   |
+                         i18n + recovery projection
+
+provider/db/sdk -> infrastructure ACL -> application semantics
+cause/stack/raw detail -> observer only
+```
+
+## 6. Protected Contracts
+
+所有 ticket 必须声明并保护：
+
+1. 当前 `Result<T>`、`HttpResponse<T>`、`IpcResult<T>` wire envelope；
+2. ADR-048 adapter-owned validation 和 HTTP/IPC parity fixtures；
+3. ADR-045 ExecutionContext、requestId、traceId、principal ordering；
+4. public routes、IPC channels、SSE event ordering、deep links；
+5. AI approval/proposal lifecycle、finite retry、execution receipt；
+6. account closure、auth security、password reset enumeration policy；
+7. PowerSync offline/profile isolation；
+8. reliable operation receipt、timeline/replay/audit；
+9. existing test selectors 和 product journeys；
+10. database uniqueness、idempotency、transaction 和 migration invariants；
+11. package public subpaths，直到 compatibility migration 完成；
+12. Docker compose entry points 和 deployment environment names；
+13. library type 不进入 public wire、Domain Fault identity 或 durable fact；
+14. library/type 选择必须符合 ACR-R03 已冻结的 adopt/borrow/defer/reject 决策。
+
+## 7. Phased Roadmap
+
+### Phase -1 — Library, Standard and Open-Source Design Validation — Completed
+
+**目标**：在修改生产代码前，验证是否应采用 `ts-pattern`、XState 或其它库，并吸收 RFC/AIP、Connect、
+OpenTelemetry、Temporal 和成熟开源项目的设计原则。
+
+**为何先做**：第一版架构方向正确，但 retry/recovery 仍有混合，且未经证据选择 library 会把本轮重构
+扩大为新的 runtime/platform 迁移。
+
+**Deliverables**：
+
+- library/standard/open-source study（ACR-R01，已完成）；
+- native switch、`ts-pattern`、neverthrow ergonomics mapper spike；
+- typed reducer 与 XState Auth state-model spike；
+- Zod single-source registry + retry policy spike；
+- dependency、bundle、typecheck、test、Agent 修改体验证据；
+- adopt/borrow/defer/reject decision record；
+- ADR-049 与标准的最终设计修订。
+
+**Acceptance evidence**：
+
+- spike 在实验目录或隔离 worktree，不接产品入口；
+- wire envelope、routes、channels、receipt 无变化；
+- 明确 `ts-pattern`/XState 是否进入生产依赖；
+- 明确 neverthrow/Effect 不形成第二套基础设施；
+- retry hint、operation retry policy、recovery action 三分模型通过 fixtures；
+- ACR-R03 形成签字式 Gate 结论。
+
+**Evidence**：`docs/analysis/2026-08-17-failure-contract-spike-evidence.md`；native mapper/reducer 与 Zod strict registry 被采用，`ts-pattern`/XState 延期，neverthrow/Effect 拒绝作为本轮底座。
+
+**Rollback**：实验代码和临时依赖已保持在仓库外；研究与证据文档作为决策记录保留。
+
+### Phase 0 — Baseline and Stop-the-Bleeding
+
+**目标**：建立可重复 inventory，先阻止新增同类问题，并修复 PR #229 的正确抽象边界。
+
+**为何先做**：没有 baseline 和 gate，后续迁移过程中旧模式会继续增长；Auth 是已复现的 vertical slice。
+
+**Deliverables**：
+
+- failure/message/provider leakage inventory；
+- registry schema design；
+- Auth provider mapper compatibility patch；
+- PR #229 Web Flow 修复；
+- docs/ADR/standard/plan；
+- initial governance report-only mode。
+
+**Acceptance evidence**：
+
+- inventory 可在本地和 CI 重复生成；
+- Auth raw provider message 不进入 UI；
+- Web Flow shards 全绿；
+- docs/governance checks 通过；
+- no production code allowlist without owner/retire date。
+
+**Rollback**：Auth mapping 可单独回滚；report-only governance 不阻塞其它模块。
+
+### Phase 1 — Shared Failure/Outcome Foundation
+
+**目标**：建立 JSON-safe public failure、typed Result、failure retry hint、operation retry policy、recovery policy、diagnostic separation 和 single-source registry。
+
+**Dependencies**：Phase -1 ACR-R03 Gate 与 Phase 0 baseline。
+
+**Deliverables**：
+
+- `FailureCategory`、`PublicFailure`、`FailureRetryHint`；
+- `OperationRetryPolicy` 与 `RecoveryAction` boundary；
+- Result generic compatibility；
+- registry schema and validators；
+- HTTP/IPC projection helper；
+- safe compatibility serializer；
+- observer diagnostic API；
+- governance unit/mutation fixtures。
+
+**Acceptance evidence**：contracts/http-client/API adapter direct tests、typecheck、transport parity。
+
+**Rollback**：新 primitives 可与旧 `ResultError` 并存一个受控迁移周期；wire shape 不变。
+
+### Phase 2 — Auth Vertical Slice
+
+**目标**：从 BetterAuth 到 Web/Desktop/E2E 完整采用新模型。
+
+**Dependencies**：Phase 1 primitives。
+
+**Deliverables**：
+
+- BetterAuth ACL；
+- SignIn/SignUp outcomes；
+- Auth public failure registry；
+- one Auth application state owner；
+- safe i18n/recovery registry；
+- deterministic auth fixtures；
+- HTTP/IPC/Web parity；
+- provider leakage fail-closed gate。
+
+**Acceptance evidence**：Auth matrix、Web Flow、locale retranslation、secret-negative tests。
+
+**Rollback**：保留 current wire compatibility adapter；不恢复 provider code exposure。
+
+### Phase 3 — High-risk Failure Protocol Migration
+
+**目标**：清理最危险的 message/status/string protocol。
+
+**顺序**：Account/Repository → AI → Goal/Task → Reminder/Schedule → remaining UI。
+
+**Deliverables**：
+
+- Account closure 不再 message branch；
+- GitHub/provider status 止于 Repository adapter；
+- AI turn/stream failure 不再使用 `error?: string`；
+- Task/Goal domain fault + public failure pilots；
+- Reminder/Schedule typed outcome；
+- UI raw message inventory 清零或限期 allowlist。
+
+**Acceptance evidence**：每个 feature 的 mapper table tests、transport parity、UI i18n coverage。
+
+### Phase 4 — Contracts Boundary Refactor
+
+**目标**：将 `packages/contracts` 从绝对类型仓库收敛为边界契约包。
+
+**Dependencies**：至少两个 feature 完成新 failure/outcome 模式，证明 mapper 结构。
+
+**Deliverables**：
+
+- contracts ownership inventory；
+- domain/wire/internal/provider 分类；
+- Goal/Task 试点迁移；
+- root/subpath export 收敛；
+- compatibility aliases；
+- ADR-010/017 migration closure；
+- contracts size/fan-out trend report。
+
+**Acceptance evidence**：package export audits、consumer compilation、wire snapshot parity、no domain class implements wire DTO。
+
+### Phase 5 — Feature Boundary and Composition Refactor
+
+**目标**：让跨 feature 编排依赖 Port/Contract，host 拥有 composition。
+
+**Deliverables**：
+
+- Data Portability capability ports；
+- Schedule Orchestration consumer-owned ports；
+- AI host adapters 去重；
+- app/API/Desktop module identity tests；
+- feature tag strategy (`layer:feature`/`type:feature`)；
+- AST internal layering gate。
+
+**Acceptance evidence**：Nx graph no cycles、feature direct import inventory 降低、single module instance tests。
+
+### Phase 6 — Presentation, Test and Deployment Hardening
+
+**目标**：状态、测试和运行版本都基于稳定契约。
+
+**Deliverables**：
+
+- presentation failure/outcome state pattern；
+- shared recovery registry approach；
+- deterministic E2E fixture service；
+- source/build/runtime revision gate；
+- typed environment schema；
+- UI raw message/secret persistence negative tests；
+- operational metrics。
+
+**Acceptance evidence**：Web/Desktop product journeys、local Docker revision parity、env validation、locale tests。
+
+### Phase 7 — Legacy Removal and Hardening
+
+**目标**：删除旧轨、alias 和过期规则，完成架构闭合。
+
+**Deliverables**：
+
+- `DomainError` 删除；
+- `ResultError.cause` 从 public contract 分离；
+- legacy status map/aliases 删除；
+- message branching inventory 清零；
+- old ADR implementation notes 更新；
+- final mutation tests and architecture surface locks。
+
+**Acceptance evidence**：全仓 governance、typecheck/lint/tests、API/Web/Desktop/local Docker journeys。
+
+## 8. Ticket Dependency Order
+
+```text
+ACR-R01 -> ACR-R02 -> ACR-R03 -> ACR-001 -> ACR-002 -> ACR-010 -> ACR-011 -> ACR-012
+                                      |
+                                      v
+            ACR-020 -> ACR-021 -> ACR-022 -> ACR-023
+                                      |
+              +-----------------------+---------------------+
+              v                       v                     v
+          ACR-030                 ACR-031               ACR-032
+              |                       |                     |
+              +---------------+-------+---------------------+
+                              v
+                          ACR-040 -> ACR-041
+                              |
+                          ACR-050 -> ACR-051
+                              |
+                          ACR-060 -> ACR-061
+                              |
+                          ACR-070 -> ACR-071
+                              |
+                          ACR-080 -> ACR-081
+```
+
+## 9. Execution-ready Tickets
+
+## ACR-R01 — Research libraries, standards and open-source implementations
+
+**Status:** Completed as design evidence on 2026-08-17.
+
+**Goal:** 在生产重构前比较可复用 TypeScript 库、协议标准和优雅开源实现，修正第一版方案。
+
+**Why now:** 避免重复造轮子，也避免把错误契约重构误变成 Effect/XState/Result runtime 迁移。
+
+**Scope:** `ts-pattern`、neverthrow、Effect、XState、Zod；RFC 9457、AIP-193/194、Connect、
+OpenTelemetry、Temporal；Lark CLI、Ardan Labs、Memos、Vendure。
+
+**Out of scope:** 不安装生产依赖，不修改产品入口。
+
+**Protected contracts:** 当前 Result/HTTP/IPC envelope、ADR-048 parity、reliable receipt、Auth routes/state behavior。
+
+**Implementation:**
+
+1. 盘点现有依赖与重叠能力；
+2. 建立评估标准；
+3. 对每个候选做 adopt/borrow/defer/reject 分析；
+4. 对开源项目追踪真实 source/contract；
+5. 修订 retry/recovery 模型；
+6. 形成研究文档和 spike 建议。
+
+**Tests:** 文档链接、docs-check、governance-check。
+
+**Acceptance:** 研究文档明确推荐组合、拒绝的全局 runtime 和待验证 spike。
+
+**Dependencies:** 无。
+
+**Risks:** 只看 API 文档忽略真实集成成本；由 ACR-R02 用本仓库 spike 补证据。
+
+## ACR-R02 — Run isolated mapper, state-machine and registry spikes
+
+**Status:** Completed on 2026-08-17. Evidence: `docs/analysis/2026-08-17-failure-contract-spike-evidence.md`.
+
+**Goal:** 用 MemoFlow fixture 对关键方案做可重复比较，不接入生产代码。
+
+**Why now:** Library 的类型体验、编译成本和状态机收益不能只由文档推断。
+
+**Scope:** 临时 worktree 或 `tools/experiments/failure-contract-spike/**`；三组 spike：
+
+1. native `switch + assertNever` vs `ts-pattern` vs neverthrow ergonomics；
+2. typed reducer vs XState v5 Auth flow；
+3. Zod single-source failure registry + retry policy evaluation。
+
+**Out of scope:** 不修改 feature production code，不提交未经选择的 lockfile 变化。
+
+**Protected contracts:** 所有输入/输出 fixture 使用当前兼容 wire shape；无 route/channel/runtime registration。
+
+**Implementation:**
+
+1. 冻结同一 Auth provider fixture 和 union；
+2. 实现三版 exhaustive mapper；
+3. 注入新增 case，记录编译/测试失败质量；
+4. 比较 typecheck time、bundle delta、LOC、测试与 Agent 修改体验；
+5. 实现 reducer/XState 两版完整 Auth state graph；
+6. 验证 cancel、retry、unmount/remount、locale change；
+7. 实现 registry 推导 code/schema/http/i18n/telemetry；
+8. 记录结果并删除无关实验产物。
+
+**Tests:** spike-local Vitest、TypeScript noEmit、bundle/metafile comparison、mutation fixtures。
+
+**Acceptance:** 每个候选有量化/可复现证据；结果不依赖主观“更优雅”。
+
+**Dependencies:** ACR-R01。
+
+**Risks:** microbenchmark 不能代表全仓；选择真实 Auth union 和当前 tsconfig，并把结果视为准入证据而非性能承诺。
+
+## ACR-R03 — Freeze library adoption and approve ADR-049 implementation
+
+**Status:** Completed on 2026-08-17. ADR-049 accepted for implementation; production work unlocked from ACR-001.
+
+**Goal:** 形成签字式 adopt/borrow/defer/reject 决策，并解除生产重构冻结。
+
+**Why now:** Phase 0–7 的 production tickets 必须依赖稳定的基础模型。
+
+**Scope:** ADR-049、研究文档、标准、active plan、spike report。
+
+**Out of scope:** 不在同一 ticket 开始 Auth 或 shared foundation 生产实现。
+
+**Protected contracts:** ADR-049 ownership decisions、existing wire/deployment contracts。
+
+**Implementation:**
+
+1. 审阅 ACR-R02 evidence；
+2. 记录 `ts-pattern` 延期、本轮不加入依赖；
+3. 记录 Auth 采用 typed reducer，XState 延期到未来复杂 workflow ADR；
+4. 确认 neverthrow/Effect/Connect/Temporal 不形成第二轨；
+5. 冻结 `FailureRetryHint`、`OperationRetryPolicy`、`RecoveryAction`；
+6. 冻结 single-source registry shape；
+7. 更新依赖、风险、验证命令；
+8. 明确 Phase 0 production work 是否解锁。
+
+**Tests:** docs-check、governance-check、spike evidence link validation。
+
+**Acceptance:** ADR 和计划没有未决基础模型；生产 ticket 明确允许的库和 ownership 边界。
+
+**Dependencies:** ACR-R02。
+
+**Risks:** 为追求一次完美设计长期阻塞；Gate 只冻结基础语义和 library boundary，不预先设计每个 feature code。
+
+## ACR-001 — Freeze the architecture and failure inventory
+
+**Goal:** 生成可重复的全仓 inventory，记录 failure code、message branch、raw rethrow、provider leakage、
+UI raw message、contracts ownership 和 feature dependencies。
+
+**Why now:** 没有 baseline 无法证明迁移减少了问题，也无法区分新回归和历史债务。
+
+**Scope:** `tools/governance` 新 inventory 脚本、机器 JSON 输出、human audit summary；排除 generated/report/test artifacts。
+
+**Out of scope:** 不把所有命中直接定为错误；不修改生产代码。
+
+**Protected contracts:** 现有 governance target 和 target-baseline 格式。
+
+**Implementation:**
+
+1. 将本审计使用的启发式扫描整理为 AST/structured scanner；
+2. 输出按 package、pattern、file 的 JSON；
+3. 分类 production/test/generated；
+4. 对 message branch/provider code 建 allowlist schema，字段含 owner/reason/retireBy；
+5. 保存初始 baseline，不自动豁免新增文件；
+6. 添加 scanner unit tests 和 mutation fixtures；
+7. 将 human summary 链接到本审计。
+
+**Tests:** scanner positive/negative fixtures；删除/新增命中后 baseline diff 必须可见。
+
+**Acceptance:** CI 可生成同一 inventory；新 production violation 不被历史 baseline 吞掉。
+
+**Dependencies:** ACR-R03。
+
+**Risks:** regex false positive；通过 AST 和明确 scope 分类控制。
+
+## ACR-002 — Add report-only failure governance
+
+**Goal:** 在不阻塞迁移前提下报告 provider leakage、message branching、raw message rethrow 和 UI raw message。
+
+**Why now:** 先观测再逐类 fail closed，避免一次性阻塞全仓。
+
+**Scope:** `tools/governance`、governance target summary、allowlist policy。
+
+**Out of scope:** 不修改 feature code。
+
+**Protected contracts:** `pnpm nx run memoflow:governance-check` 的现有检查顺序和输出可读性。
+
+**Implementation:**
+
+1. 添加四类 rule ID；
+2. 只对新增 diff fail，历史项 report；
+3. provider literal allowlist 仅允许 infrastructure adapter/fixture；
+4. message parser allowlist 必须有 retireBy；
+5. raw `throw new Error(result.error.message)` 无新豁免；
+6. 将 summary artifact 接入 CI evidence。
+
+**Tests:** mutation fixtures；allowlist 过期测试；generated code exclusion。
+
+**Acceptance:** 在当前 main 上 report 稳定；人为新增违规会红。
+
+**Dependencies:** ACR-001。
+
+**Risks:** 噪音使规则失去信任；先限定高置信模式。
+
+## ACR-010 — Introduce JSON-safe PublicFailure primitives
+
+**Goal:** 在 `@memoflow/contracts/result` 引入 category、typed details、failure retry hint 和 typed public failure，并定义 operation retry/recovery boundary，保持现有 wire 兼容。
+
+**Why now:** 所有 feature migration 的共同依赖。
+
+**Scope:** contracts result primitives、schema/validator、exports、unit tests。
+
+**Out of scope:** 不立即删除 `ResultError`、message/context/cause。
+
+**Protected contracts:** `Result<T>`、HttpResponse/IpcResult serialized shape、existing imports。
+
+**Implementation:**
+
+1. 新增 `failure-category.ts`、`failure-retry-hint.ts`、`public-failure.ts`；
+2. 定义 per-code typed details、FailureReference 与 JSON-safety restriction；
+3. 在 operation contract/patterns seam 定义 `OperationRetryPolicy`、backoff 与 `RecoveryAction`；
+4. 为 `Result<T, E>` 增加受约束 generic compatibility；
+5. 提供 legacy ResultError → PublicFailure compatibility mapper；
+6. serializer 明确排除 cause/Error instance；
+7. 更新 subpath exports 和 JSDoc；
+8. 添加 compile-time `satisfies`、retry-safety 与 secret-negative fixtures。
+
+**Tests:**
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/contracts/vitest.config.ts
+pnpm nx run contracts:typecheck
+pnpm nx run contracts:lint
+```
+
+**Acceptance:** 现有 consumers 无 wire break；新 typed Result 可穷尽 code；JSON-safety tests 通过。
+
+**Dependencies:** ACR-002。
+
+**Risks:** TypeScript 泛型传播导致大面积 errors；先使用 default generic 保持兼容。
+
+## ACR-011 — Separate diagnostic failures from public failures
+
+**Goal:** cause/stack/provider detail 通过 observer/logger 传递，不再依赖 public ResultError。
+
+**Why now:** provider ACL 和 safe serialization 前必须有内部排障通道。
+
+**Scope:** observer diagnostic API、ResultErrorException bridge、API middleware/http-client logging。
+
+**Out of scope:** 不重做整个 observability pipeline。
+
+**Protected contracts:** ADR-045 trace/request context、ADR-047 single observer、existing log correlation。
+
+**Implementation:**
+
+1. 定义 internal diagnostic input，不放 contracts public exports；
+2. mapper 在返回 safe failure 同时 record diagnostic；
+3. API global handler 对 unknown error 只返回 safe internal failure；
+4. client network cause 留在 local observer，不入 IPC/HTTP envelope；
+5. durable receipt builder只接受 PublicFailure；
+6. 添加 secret redaction tests。
+
+**Tests:** API middleware、http-client、receipt persistence、trace correlation unit tests。
+
+**Acceptance:** public serialization 不能包含 Error/cause/stack/provider body；trace 仍可定位真实原因。
+
+**Dependencies:** ACR-010。
+
+**Risks:** 诊断信息丢失；先建立 observer tests 再删除旧 cause 路径。
+
+## ACR-012 — Create feature failure registry and projection validators
+
+**Goal:** 每个 public code 都有 category、operation、typed details、retry hint、HTTP/IPC/i18n/telemetry coverage，并从一个 registry object 推导。
+
+**Why now:** 防止新 code 再次成为任意 string。
+
+**Scope:** registry schema、validator、governance fixtures；Auth registry 作为首个实例。
+
+**Out of scope:** 不一次登记全仓所有历史 code。
+
+**Protected contracts:** existing code strings during compatibility period。
+
+**Implementation:**
+
+1. 定义 registry schema；
+2. 支持 feature-local registry；
+3. 验证 code union 与 registry 双向完整；
+4. 验证 HTTP policy、i18n key、typed details schema 与 retry hint；
+5. 未登记新 code fail closed；
+6. legacy code 可登记 alias + retireBy；
+7. 从同一 object 推导 code union、Zod schema、HTTP/i18n/telemetry tables；
+8. 添加 registry mutation、unknown-code 和 unsafe-retry fixtures。
+
+**Tests:** contracts/governance direct tests；删除 registry row 必须红。
+
+**Acceptance:** Auth 新增 code 时缺任何 projection 都无法通过 CI。
+
+**Dependencies:** ACR-010、ACR-011。
+
+**Risks:** registry 成为第二套手工清单；后续从同一 object 推导 type/schema，禁止平行维护。
+
+## ACR-020 — Map BetterAuth into MemoFlow-owned semantics
+
+**Goal:** BetterAuth code/message 止于 `packages/cloud-auth` adapter。
+
+**Why now:** 修复已复现 P0，并作为目标模式试点。
+
+**Scope:** cloud-auth client/server adapter、Auth failure/outcome contracts、compatibility mapping。
+
+**Out of scope:** 不改变 BetterAuth provider、DB schema、OAuth product policy。
+
+**Protected contracts:** auth routes、cookies/session、email verification security、device authorization、account closure。
+
+**Implementation:**
+
+1. 定义 Auth failure registry；
+2. 定义 SignIn/SignUp outcome union；
+3. 建立 provider response parser + native exhaustive mapper；
+4. invalid credentials 映射 MemoFlow code；
+5. email unverified 映射 normal outcome；
+6. duplicate signup 以 DB/provider unique 为 authoritative，pre-check 只优化；
+7. provider code 仅写 internal diagnostic；
+8. 保持 legacy client response compatibility bridge。
+
+**Tests:** BetterAuth in-memory matrix、client mapping、provider-code-negative assertion。
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/cloud-auth/vitest.config.ts
+pnpm nx run cloud-auth:typecheck
+pnpm nx run cloud-auth:lint
+```
+
+**Acceptance:** cloud-auth public Result/outcome 不含 BetterAuth code/raw message。
+
+**Dependencies:** ACR-012。
+
+**Risks:** BetterAuth 真实 response shape 版本漂移；用 fixture + integration harness 锁定。
+
+## ACR-021 — Establish one Auth application state owner
+
+**Goal:** 登录、注册、验证、forgot/reset 的 operation state、outcome、failure、receipt 只有一个 owner。
+
+**Why now:** provider mapping完成后，必须消除 `useWebAuth`/app-vue/Pinia 双轨。
+
+**Scope:** app-vue auth application state/composables、Web host-specific OAuth/redirect adapter、DI keys。
+
+**Out of scope:** 不强迫 Desktop 与 Web 使用同一个 store 实例；共享的是 application semantics。
+
+**Protected contracts:** Web auth route/scenes、Desktop device flow、password receipt security、test selectors。
+
+**Implementation:**
+
+1. 使用 ACR-R03 批准的 feature-owned typed reducer；
+2. 将 login/register/password outcome/failure 归同一 composable/store boundary；
+3. Web 只保留 browser redirect/OAuth host adapter；
+4. 清除重复 DI key 或明确 host extension；
+5. pending verification 由 current outcome 派生；
+6. 每次 operation start 清理 incompatible state；
+7. receipt 只持久化 safe failure fields；
+8. locale message 改 computed projection。
+
+**Tests:** state transitions、unmount/remount、locale change、concurrent submit、secret-negative tests。
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/app-vue/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config apps/web/vitest.config.ts
+pnpm nx run app-vue:typecheck
+pnpm nx run web:typecheck
+```
+
+**Acceptance:** 一个 operation 不再同时写 local refs 和 Pinia 两套失败真值；raw message 不持久化。
+
+**Dependencies:** ACR-020。
+
+**Risks:** Web/AuthApp 与 main app bootstrap 生命周期不同；通过 host adapter 而非复制 state machine 解决。
+
+## ACR-022 — Make Auth HTTP/IPC/UI semantics parity-complete
+
+**Goal:** Auth outcome/failure 在 server/client/Web/Desktop 具有同一 canonical semantics。
+
+**Why now:** 证明新模型可跨所有边界。
+
+**Scope:** HTTP/IPC projection、Web/desktop consumers、i18n registry、parity fixtures。
+
+**Out of scope:** 不改变 routes/channels。
+
+**Protected contracts:** ADR-048 parity、existing session/cookie/device flow。
+
+**Implementation:**
+
+1. 为 Auth registry建立 HTTP policy；
+2. IPC 不携带 HTTP status；
+3. Web/Desktop consume同一 outcome/failure union；
+4. 全 locale i18n coverage；
+5. recovery policy、message registry 与 failure retry hint 分离；
+6. unknown/provider failure safe fallback；
+7. 添加 locale live retranslation fixture；
+8. 添加 provider raw message not rendered fixture。
+
+**Tests:** HTTP/IPC parity、component tests、Web auth contract E2E。
+
+**Acceptance:** 相同 Auth fixture 在 HTTP/IPC 得到相同 code/outcome；只有 HTTP status不同。
+
+**Dependencies:** ACR-021。
+
+**Risks:** Desktop cloud connection有独立状态；只共享语义，不强制相同 UI flow。
+
+## ACR-023 — Replace Auth E2E implicit registration with deterministic fixtures
+
+**Goal:** 通用 login helper 只登录，不根据 UI message 猜数据库状态并自动注册。
+
+**Why now:** 当前一个 Auth 文案回归使多个非 Auth shards 失败。
+
+**Scope:** Web E2E global setup/helpers/test user factory、mail verification fixture。
+
+**Out of scope:** 不删除专门的 signup/verification E2E。
+
+**Protected contracts:** existing test users、test DB isolation、mail capture。
+
+**Implementation:**
+
+1. global setup 通过 API/DB 创建 verified user；
+2. fixture 创建使用 deterministic id/email namespace；
+3. login helper 对失败立即报告 stable code/trace；
+4. 移除 UI 文案驱动注册；
+5. signup tests 使用独立新邮箱；
+6. parallel shard 用户隔离；
+7. teardown清理；
+8. suite start 校验 build revision。
+
+**Tests:** auth login/signup/verification、dashboard/shell dependent suites、parallel shard repeat run。
+
+**Acceptance:** 更改错误文案不会触发 fixture 行为变化；非 Auth suites 不再因账号准备失败级联。
+
+**Dependencies:** ACR-022。
+
+**Risks:** DB fixture绕过真实 signup；真实 signup由专门 E2E继续覆盖。
+
+## ACR-030 — Remove Account and Repository message/status leakage
+
+**Goal:** Account closure 和 GitHub repository flows 不在 application 中解析 message/provider status。
+
+**Why now:** 两者是 Auth 之外最明确的 provider leakage 证据。
+
+**Scope:** account close use case、repository GitHub adapters/application ports、failure registries。
+
+**Out of scope:** 不改变 account closure saga 或 GitHub permission policy。
+
+**Protected contracts:** closure events/receipts、repository connection/write request/idempotency。
+
+**Implementation:**
+
+1. Account repository/coordinator返回 typed not-found/closure failure；
+2. 删除 `message.includes('Account not found')`；
+3. GitHub adapter将 401/403/404/413 映射 repository-owned failures；
+4. application不 import/inspect provider error status；
+5. UI 使用 registry translation/recovery；
+6. webhook安全错误保持中性；
+7. 添加 provider fixture matrix。
+
+**Tests:**
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/account/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/repository/vitest.config.ts
+pnpm nx run account:typecheck
+pnpm nx run repository:typecheck
+```
+
+**Acceptance:** Account/Repository application production code无 message/provider-status branch。
+
+**Dependencies:** ACR-023。
+
+**Risks:** 相同 HTTP status在不同 operation语义不同；mapper必须 operation-specific。
+
+## ACR-031 — Replace AI stringly typed failures with typed turn outcomes
+
+**Goal:** AI turn/stream/host runtime 不再用 `error?: string` 混合 code/message/provider detail。
+
+**Why now:** AI 是 failure protocol 密度最高、跨 runtime 最复杂的区域。
+
+**Scope:** turn engines、assistant facade events、client stream events、UI chat session、provider adapters。
+
+**Out of scope:** 不改变审批 gate、tool schema、model selection 或 conversation persistence。
+
+**Protected contracts:** streaming ordering、proposal approval、thread/conversation identity、cancellation semantics。
+
+**Implementation:**
+
+1. 定义 `TurnOutcome` 和 `TurnFailure` registry；
+2. completed/aborted/waiting_approval 作为 outcome；
+3. provider unavailable/ownership/internal 等作为 typed failure；
+4. provider raw detail止于 gateway；
+5. SSE event传 public failure；
+6. UI chat item保存 failure而非 errorMessage；
+7. abort detection优先 AbortSignal/typed cause，清除 message parser；
+8. runtime invariant constants改 typed fault/guard。
+
+**Tests:** direct/readonly engines、SSE fixtures、cancel/approval/retry、UI rendering。
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/ai/vitest.config.ts
+pnpm nx run ai:typecheck
+pnpm nx run ai:lint
+```
+
+**Acceptance:** AI production public status不再含 arbitrary `error?: string`；stream terminal failure schema稳定。
+
+**Dependencies:** ACR-023。
+
+**Risks:** streaming compatibility；先双读 legacy field，单写新 field，再版本化移除。
+
+## ACR-032 — Eliminate presentation raw-message ownership
+
+**Goal:** app-vue/Web/Desktop presentation不直接展示或持久化任意 `result.error.message`。
+
+**Why now:** provider/application迁移后，UI必须完成消费闭环。
+
+**Scope:** shared translator、repository/settings/auth/AI surfaces、global error boundary、durable receipts。
+
+**Out of scope:** 不重做所有 UI layout。
+
+**Protected contracts:** user-visible recovery、test selectors、receipt request IDs。
+
+**Implementation:**
+
+1. 建立 typed failure translation adapter；
+2. UI refs/store保存 failure/outcome；
+3. raw message direct assignments迁移；
+4. global error boundary区分 programmer crash 与 public operation failure；
+5. i18n registry完整性 gate；
+6. locale live retranslation；
+7. receipt safe schema；
+8. raw-message negative render tests。
+
+**Tests:** app-vue/web component tests、locale tests、persistence tests。
+
+**Acceptance:** production UI raw message inventory清零或全部仅用于 internal developer surface。
+
+**Dependencies:** ACR-030、ACR-031。
+
+**Risks:** 某些 provider错误无对应code；先映射 generic feature unavailable/internal，不展示raw message。
+
+## ACR-040 — Pilot DomainFault and operation failures in Task and Goal
+
+**Goal:** 证明 domain fault、application mapper、public failure不需要共享 Error class。
+
+**Why now:** Task/Goal有丰富不变量、并发和跨模块语义，是最有代表性的 domain pilot。
+
+**Scope:** Task complete/update/hierarchy；Goal update/archive/weight/review selected operations。
+
+**Out of scope:** 不一次迁移全部 use case。
+
+**Protected contracts:** optimistic locking、Goal contribution、reliable receipt、existing DTO/route。
+
+**Implementation:**
+
+1. 建立 Task/Goal domain fault unions；
+2. 选择 2-3 个 operation定义 outcome/failure；
+3. domain不再返回 generic ResultError/HTTP code；
+4. application mapper穷尽fault；
+5. feature contracts增加typed failure/outcome；
+6. HTTP/IPC policy与i18n registry；
+7. legacy code compatibility mapping；
+8. 禁止新增 DomainError subclass。
+
+**Tests:** domain state tests、mapper table tests、transport parity、UI recovery。
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/task/vitest.use-cases.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/goal/vitest.use-cases.config.ts
+pnpm nx run task:typecheck
+pnpm nx run goal:typecheck
+```
+
+**Acceptance:** pilot operation从 domain 到 UI 无 HTTP/provider/raw message coupling。
+
+**Dependencies:** ACR-032。
+
+**Risks:** fault和public code重复看似增加类型；文档和mapper明确它们不同稳定边界。
+
+## ACR-041 — Migrate Reminder and Schedule operational outcomes
+
+**Goal:** reminder response/snooze、schedule execution/claim/retry 使用 typed outcome/failure。
+
+**Why now:** 这些模块包含用户动作、后台执行和 durable recovery，不能继续用 string error。
+
+**Scope:** selected Reminder response and Schedule execution operations。
+
+**Out of scope:** 不重做 occurrence/outbox 模型本身。
+
+**Protected contracts:** scheduler ownership、claim/lease、notification delivery、execution receipts。
+
+**Implementation:**
+
+1. 定义 Reminder response outcome；
+2. snooze/complete/dismiss 失败使用 operation codes；
+3. Schedule execution status与failure拆分；
+4. persisted last_error只存 safe code/summary，internal cause在observer；
+5. worker retry根据 directive/typed category；
+6. HTTP/IPC/UI mapping；
+7. PowerSync/Prisma parity fixtures。
+
+**Tests:**
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/reminder/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/schedule/vitest.config.ts
+pnpm nx run reminder:typecheck
+pnpm nx run schedule:typecheck
+```
+
+**Acceptance:** durable state可区分 business failure code、retry state和diagnostic detail。
+
+**Dependencies:** ACR-040。
+
+**Risks:** 持久化 schema兼容；先增加code字段/codec version，不覆盖历史文本直到迁移完成。
+
+## ACR-050 — Classify and shrink contracts by ownership
+
+**Goal:** 为 contracts 551 个文件建立 owner分类，开始从 absolute registry迁向 boundary-first。
+
+**Why now:** 新模式已通过多个feature证明，才能安全迁移中央类型。
+
+**Scope:** contracts inventory、分类manifest、Goal/Task试点、exports/aliases。
+
+**Out of scope:** 不一次移动全部文件。
+
+**Protected contracts:** published subpaths、Zod/OpenAPI schema、RPC maps、durable events。
+
+**Implementation:**
+
+1. 每个contracts文件标记 `wire/public`、`durable`、`domain`、`internal`、`provider`、`legacy`；
+2. 自动检查未分类新增文件；
+3. Goal/Task选择domain entity interfaces迁回feature；
+4. 保留snapshot/command/outcome schema；
+5. 增加命名 mapper；
+6. compatibility re-export登记retireBy；
+7. 收窄root exports；
+8. 记录lines/fan-out趋势。
+
+**Tests:** contracts build/typecheck、consumer affected typecheck、wire schema snapshots、package export audit。
+
+**Acceptance:** pilot domain class不再implements wire interface；public subpath兼容；中央domain inventory下降。
+
+**Dependencies:** ACR-041。
+
+**Risks:** import churn巨大；每PR只迁一个语义簇并保持compatibility alias。
+
+## ACR-051 — Align feature tags with vertical-slice reality
+
+**Goal:** Nx package tag和包内分层规则不再互相矛盾。
+
+**Why now:** contracts/feature ownership清晰后再调整graph语义。
+
+**Scope:** project tags、eslint constraints、package-internal AST audit、architecture docs。
+
+**Out of scope:** 不拆分每个feature为四个独立npm package。
+
+**Protected contracts:** current package names/build targets/import paths。
+
+**Implementation:**
+
+1. 引入 `layer:feature` 或等价tag；
+2. feature package不再宣称整个包是domain；
+3. Nx约束feature isolation；
+4. AST audit约束domain/application/transport/infrastructure；
+5. composition-only paths显式规则；
+6. 移除允许domain→infra的误导性说明；
+7. migration一次覆盖所有feature project tags。
+
+**Tests:** Nx graph、eslint fixtures、package internal mutation tests、全workspace lint。
+
+**Acceptance:** package graph表达vertical slice；domain source仍不能import infra；无长期path allowlist。
+
+**Dependencies:** ACR-050。
+
+**Risks:** Nx affected graph变化；在单独PR执行并比较targets/cache行为。
+
+## ACR-060 — Replace cross-feature implementation dependencies with capability ports
+
+**Goal:** Data Portability、Schedule Orchestration、AI等编排只依赖public ports/contracts。
+
+**Why now:** feature ownership和tags稳定后才能收敛跨featuregraph。
+
+**Scope:** verified direct dependencies and host wiring。
+
+**Out of scope:** 不改变业务执行顺序和数据语义。
+
+**Protected contracts:** export/import transaction、schedule projection、AI actions、module lifecycle。
+
+**Implementation:**
+
+1. 为consumer定义所需最小read/write capability port；
+2. provider feature或host adapter实现；
+3. apps/api/Desktop composer注入；
+4. 删除consumer对provider concrete/internal import；
+5. parity/object-identity tests；
+6. graph inventory确认fan-out下降；
+7. architecture surface manifest锁定port/provider/wiring。
+
+**Tests:** affected feature direct tests、API/Desktop composer tests、architecture surface mutation fixtures。
+
+**Acceptance:** Data Portability/Schedule Orchestration/AI application不依赖feature implementation。
+
+**Dependencies:** ACR-051。
+
+**Risks:** 创建过宽“万能port”；坚持consumer-owned最小接口和operation-specific DTO。
+
+## ACR-061 — Enforce single host composition and module identity
+
+**Goal:** API/Desktop/AI executor不重复创建同一feature module/runtime。
+
+**Why now:** ports完成后，host可以成为唯一composition owner。
+
+**Scope:** host composers、module handles、lifecycle/order、AI API/Desktop adapters。
+
+**Out of scope:** 不合并API和Desktop host；它们仍有不同platform adapters。
+
+**Protected contracts:** bootstrap order、start/stop/drain、routes/channels、worker ownership。
+
+**Implementation:**
+
+1. composer显式返回application ports；
+   2.跨featureexecutor只消费port；
+2. 删除module factory deep construction；
+3. object identity tests；
+4. start/stop reverse order tests；
+5. host-specific adapter共享application executor；
+6. single runtime owner/lease policy文档与gate。
+
+**Tests:** API smoke、Desktop main tests、composer identity/surface tests。
+
+**Acceptance:** 每host每feature一个module instance；AI/portability/orchestration不持有第二套lifecycle。
+
+**Dependencies:** ACR-060。
+
+**Risks:** bootstrap顺序改变；先characterization tests，保持registration order。
+
+## ACR-070 — Standardize deterministic test fixtures and semantic assertions
+
+**Goal:** 测试断言 code/outcome/typed metadata，fixture不通过UI文案和隐式副作用准备。
+
+**Why now:** 生产语义迁移完成后，测试应成为长期contract gate。
+
+**Scope:** test-utils、global setup、E2E helpers、contract test conventions。
+
+**Out of scope:** 不重写所有历史测试。
+
+**Protected contracts:** product journey coverage、sharding、test DB isolation。
+
+**Implementation:**
+
+1. 新建fixture API/factory；
+2. 稳定账号/实体/verification状态；
+3. helper职责单一；
+4. error path断言code/category/outcome；
+5. 文案只在i18n/presentation tests断言；
+6. parallel-safe namespace；
+7. retry/flaky evidence分类；
+8. test inventory标注contract layer。
+
+**Tests:** repeated sharded Web Flow、API/Desktop integration、fixture cleanup。
+
+**Acceptance:** 修改文案不使domain/fixture tests失败；修改code/mapping会使contract tests失败。
+
+**Dependencies:** ACR-061。
+
+**Risks:** fixtures绕过业务路径；真实用户journey仍保留独立E2E。
+
+## ACR-071 — Make source/build/runtime configuration verifiable
+
+**Goal:** 验收前证明源码revision、Web/API image和环境schema一致。
+
+**Why now:** 防止使用旧/dirty部署验证新代码。
+
+**Scope:** OCI labels、build-info endpoint/meta、compose validation、env schema。
+
+**Out of scope:** 不重做CI/CD平台。
+
+**Protected contracts:** compose file names、health endpoints、secret handling。
+
+**Implementation:**
+
+1. clean build要求revision+dirty flag；
+2. API暴露sanitized build identity；
+3. Web嵌入build meta；
+4. E2E preflight比较expected/web/api revision；
+5. mismatch fail fast；
+6. 定义local/production env schemas；
+7. public/secret/required/forbidden分类；
+8. diagnostics artifact记录compose config和revision，不记录secret。
+
+**Tests:** build identity unit、compose smoke、env missing/forbidden fixtures。
+
+**Acceptance:** E2E无法对旧revision继续执行；production-like build拒绝dirty source。
+
+**Dependencies:** ACR-070。
+
+**Risks:** 本地开发需要dirty build；允许显式dev模式，但不得作为验收evidence。
+
+## ACR-080 — Retire DomainError and legacy failure plumbing
+
+**Goal:** 删除混合HTTP/diagnostic的global DomainError和已迁移legacy paths。
+
+**Why now:** 所有主要feature已拥有新语义后再删除旧轨。
+
+**Scope:** utils error hierarchy、ResultError compatibility fields、global status map、aliases。
+
+**Out of scope:** 不删除仍被明确延期feature使用的alias，除非有迁移计划。
+
+**Protected contracts:** current public wire version，直到versioned migration完成。
+
+**Implementation:**
+
+1. inventory剩余subclass；
+2. feature-by-feature迁移；
+3. transport不读取httpStatus；
+4. diagnostics不读取DomainError context；
+5. 删除global class/helpers；
+6. 收缩ResultError public fields；
+7. 删除feature-specific global HTTP map rows；
+8. 清理aliases和旧i18n keys。
+
+**Tests:**全仓 typecheck/lint/tests、wire compatibility、governance inventory zero。
+
+**Acceptance:** production不引用`DomainError`；public failure无cause/arbitrary context；旧status map不拥有feature codes。
+
+**Dependencies:** ACR-071。
+
+**Risks:** 隐藏consumer；先把root export标deprecated并用package export audit定位。
+
+## ACR-081 — Close the architecture with fail-closed governance
+
+**Goal:** 将report-only规则升级为全仓fail-closed并冻结目标架构surface。
+
+**Why now:** legacy清零后才能避免永久baseline。
+
+**Scope:** governance target、architecture surface manifest、docs/status updates。
+
+**Out of scope:** 不保留无期限historical allowlist。
+
+**Protected contracts:** governance runtime、CI evidence、mutation test policy。
+
+**Implementation:**
+
+1. message/provider/raw UI rules全量fail；
+2. registry/i18n/transport/json-safety全量fail；
+3. compatibility allowlist过期fail；
+4. architecture surface锁定primitives/ports/mappers/wiring；
+5. mutation tests证明每条规则有效；
+6. ADR-049状态改为 implemented，并回填全部证据；
+7. 计划归档并回填actual evidence。
+
+**Tests:**
+
+```bash
+pnpm nx run memoflow:docs-check --skip-nx-cache
+pnpm nx run memoflow:governance-check --skip-nx-cache
+pnpm typecheck
+pnpm lint
+```
+
+加上受影响direct Vitest、integration、Web Flow、API smoke、Desktop/local Docker journeys。
+
+**Acceptance:** 新增未登记code/provider leakage/message branch/raw public message会在单次CI中失败。
+
+**Dependencies:** ACR-080。
+
+**Risks:** gate runtime增长；复用inventory、增量扫描和Nx cache，不能降低规则完整性。
+
+## 10. Verification Matrix
+
+| Layer            | 必须验证                                       | 证据                       |
+| ---------------- | ---------------------------------------------- | -------------------------- |
+| Domain           | fault kind/invariant/state                     | feature domain tests       |
+| Application      | fault/port failure → outcome/public failure    | table-driven mapper tests  |
+| Provider adapter | provider fixture → MemoFlow semantics          | adapter contract tests     |
+| Contracts        | JSON-safe schema/code registry                 | contracts tests/typecheck  |
+| HTTP             | status/header/safe envelope                    | API adapter tests          |
+| IPC              | same data/code without HTTP leakage            | IPC parity tests           |
+| SSE              | ordering + terminal typed failure              | stream integration tests   |
+| UI               | code/details → message/recovery; locale change | component tests            |
+| Retry executor   | retry hint ∩ idempotency/policy/attempt budget | policy/mutation tests      |
+| Persistence      | receipt contains only safe fields              | integration/negative tests |
+| E2E              | deterministic journey, no fixture guessing     | Web/Desktop flows          |
+| Governance       | violation/mutation causes failure              | governance tests           |
+| Deployment       | source=build=runtime revision                  | preflight/smoke artifact   |
+
+## 11. Standard Validation Commands
+
+### Docs and governance
+
+```bash
+pnpm nx run memoflow:docs-check --skip-nx-cache
+pnpm nx run memoflow:governance-check --skip-nx-cache
+```
+
+### Shared foundation
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/contracts/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/http-client/vitest.config.ts
+pnpm nx run contracts:typecheck
+pnpm nx run http-client:typecheck
+```
+
+### Auth vertical slice
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/cloud-auth/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/app-vue/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config apps/web/vitest.config.ts
+pnpm nx run cloud-auth:typecheck
+pnpm nx run app-vue:typecheck
+pnpm nx run web:typecheck
+```
+
+### Feature migrations
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/account/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/repository/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/ai/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/task/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/goal/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/reminder/vitest.config.ts
+node node_modules/vitest/vitest.mjs run --config packages/schedule/vitest.config.ts
+```
+
+需要真实数据库时使用对应 `vitest.integration.config.ts`，串行执行并记录环境前置条件。
+
+## 12. Risk Ledger
+
+| Risk                        | Severity | Containment                                                        |
+| --------------------------- | -------- | ------------------------------------------------------------------ |
+| wire shape break            | P0       | compatibility serializer + parity fixtures + versioned removal     |
+| public code爆炸             | P1       | operation-specific unions，shared只保留category                    |
+| mapper样板增多              | P2       | codegen/registry推导，不回退provider leakage                       |
+| contracts迁移churn          | P1       | one semantic cluster per PR + compatibility re-export              |
+| UI丢失细节                  | P1       | typed details + requestId，internal detail进入observer             |
+| diagnostics退化             | P0       | observer evidence先行，negative public serialization tests         |
+| E2E fixture绕过业务         | P2       | fixture和真实journey分层保留                                       |
+| host wiring回归             | P0       | module identity/lifecycle/bootstrap characterization tests         |
+| governance噪音              | P1       | high-confidence rules、AST、到期allowlist                          |
+| long migration dual-track   | P1       | 每个alias有owner/retireBy；Phase 7强制清理                         |
+| unknown feature code变500   | P1       | category required + registry completeness + safe internal fallback |
+| provider升级                | P1       | adapter fixtures/version matrix，application无provider依赖         |
+| unsafe automatic retry      | P0       | retry hint 与 operation idempotency/receipt policy 交叉验证        |
+| library lock-in             | P1       | library types 不出 boundary；spike + approved usage scope          |
+| typecheck/bundle regression | P1       | spike baseline、dependency budget、targeted adoption               |
+
+## 13. Review and Repair Protocol
+
+每个 Phase 完成后进行 batch review，按以下层级检查：
+
+1. **Contract correctness**：code/outcome/schema/status/IPC parity；
+2. **Vertical completeness**：provider/domain → application → transport → client → UI；
+3. **Behavioral completeness**：success、normal outcome、validation、retry hint/policy、recovery、cancel、unknown；
+4. **Engineering quality**：owner、duplication、typing、security、observability；
+5. **Plan integrity**：acceptance evidence、实际命令、remaining inventory。
+
+Finding 分级：
+
+- P0：wire/security/data/primary path broken；
+- P1：required semantics或boundary bypass；
+- P2：robustness/test/maintainability；
+- P3：polish。
+
+Repair pass 按根因分组，不按文件数量分组。修复后先运行 narrow tests，再运行 affected packages、
+governance、integration和product journey。Green build不能替代行为证据。
+
+## 14. Completion Definition
+
+计划完成必须同时满足：
+
+- [x] ACR-R01/R02/R03 的研究、spike 和 library decision 有实际证据；
+- [x] 未批准 library 未进入 production；批准 library type 未成为 contract/durable owner；
+- [x] failure retry hint、operation retry policy、recovery action 已在 ADR/标准中分离；
+- [ ] Auth、Account、Repository、AI、Goal、Task、Reminder、Schedule 使用 MemoFlow-owned failure/outcome；
+- [ ] provider code/status/message 不离开 infrastructure adapter；
+- [ ] production message branching 和 raw Result message rethrow inventory 清零；
+- [ ] UI 不直接展示/持久化 arbitrary result message；
+- [ ] `DomainError` 退役；
+- [ ] public failure JSON-safe、typed、registered、localized、transport-covered；
+- [ ] normal outcomes 不计为 error；
+- [ ] contracts 明确 boundary-first，absolute type centralization 已退役；
+- [ ] cross-feature orchestration依赖port并由host装配；
+- [ ] feature package tags和包内分层规则一致；
+- [ ] E2E fixture deterministic；
+- [ ] source/build/runtime revision可验证一致；
+- [ ] docs/governance/typecheck/lint/direct tests/integration/product journeys全部有实际证据；
+- [ ] 所有compatibility alias和allowlist已删除或有明确、尚未到期的外部阻塞原因；
+- [ ] ADR-049状态和本计划归档信息与实际实现一致。

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -4,7 +4,7 @@ tags:
   - active
 description: 进行中的计划目录与当前状态
 created: 2026-04-26T00:00:00
-updated: 2026-08-14T00:00:00Z
+updated: 2026-08-17T00:00:00+09:00
 ---
 
 # Active Plans
@@ -13,18 +13,19 @@ updated: 2026-08-14T00:00:00Z
 
 ## 当前计划
 
-| 计划                                                                                            | 当前状态                                                                                                                                                                                         |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [CI/CD Platform V2 一次性重构](./2026-08-05-ci-cd-platform-v2-refactor.md)                      | **Architecture implementation and PR cutover complete**：六平面契约、capability workspace、artifact 晋级、run observation；保留以采集长期 timing/fault 运营证据（baseline-v1 待 comparable run） |
-| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)                     | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称                                                                                                                      |
-| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md)            | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式                                                                                                                           |
-| [Goal / Task Composition Root 外移](./2026-08-14-goal-task-composition-root-externalization.md) | **Step 1-4 完成**：repository-set ingredient seams、transport instance-bound、API/Desktop host composers 与注入式 repository consumers 落地；Step 5（docs/surface lock）进行中                   |
+| 计划                                                                                   | 当前状态                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [应用契约与架构大重构](./2026-08-17-application-contract-and-architecture-refactor.md) | **Implementation active**：ACR-R01/R02/R03 研究、隔离 spike 与设计 Gate 已完成；采用 native union/switch + Zod strict registry，生产实施从 ACR-001 起按 PR 批次推进                              |
+| [CI/CD Platform V2 一次性重构](./2026-08-05-ci-cd-platform-v2-refactor.md)             | **Architecture implementation and PR cutover complete**：六平面契约、capability workspace、artifact 晋级、run observation；保留以采集长期 timing/fault 运营证据（baseline-v1 待 comparable run） |
+| [统一助手与可插拔 Agent Host](./2026-07-17-unified-assistant-agent-host.md)            | **主产品能力线**：统一助手、右侧工作台、Workflow/Turn/Model；完成定义未宣称                                                                                                                      |
+| [夜间 hygiene + Agent Host 持续执行](./2026-07-25-nightly-hygiene-and-agent-host.md)   | **执行协议**：GOAL_PRIORITY 服务 agent-host 切片；门禁与 residual 格式                                                                                                                           |
 
 ## 本轮已归档（2026-08-16）
 
-| 计划                                                                                         | 结果                                                                                                                                                                                                                                                   |
-| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [RefArch Phase 6：可观测性与装配治理](../archive/2026-08-15-refarch-phase6-observability.md) | Steps 1-7 完成：single observer/有界 metrics/opt-in OTel、transport-only module 契约、三组 AST surface locks + 双语 JSDoc audit 接入 governance-check、ADR-047、四宿主关键 journey（API/AI/Web/Desktop）与全量门禁通过；详见计划内 gate 记录与偏差说明 |
+| 计划                                                                                                     | 结果                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [RefArch Phase 6：可观测性与装配治理](../archive/2026-08-15-refarch-phase6-observability.md)             | Steps 1-7 完成：single observer/有界 metrics/opt-in OTel、transport-only module 契约、三组 AST surface locks + 双语 JSDoc audit 接入 governance-check、ADR-047、四宿主关键 journey（API/AI/Web/Desktop）与全量门禁通过；详见计划内 gate 记录与偏差说明 |
+| [Goal / Task Composition Root 外移](../archive/2026-08-14-goal-task-composition-root-externalization.md) | Goal/Task repository-set ingredient seams、instance-bound transport、API/Desktop host composers、repository consumer 注入与 surface locks 已闭合；计划已归档                                                                                           |
 
 ## 本轮已归档（2026-08-15）
 

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -5,7 +5,7 @@ tags:
   - reference
 description: 项目规则与规范入口
 created: 2025-01-22T00:00:00
-updated: 2026-05-16T00:00:00
+updated: 2026-08-17T00:00:00+09:00
 ---
 
 # 项目规范
@@ -14,25 +14,26 @@ updated: 2026-05-16T00:00:00
 
 ## 当前规范文档
 
-| 文档 | 用途 |
-| --- | --- |
-| [architecture.md](./architecture.md) | 通用架构与分层规则 |
-| [contract-module-development-spec.md](./contract-module-development-spec.md) | `packages/contracts` 模块结构、纯类型边界与 API/Protocol 约束 |
-| [domain-client-spec.md](./domain-client-spec.md) | client 领域层约束 |
-| [domain-event-spec.md](./domain-event-spec.md) | 领域事件约束 |
-| [domain-server-spec.md](./domain-server-spec.md) | server 领域层约束 |
-| [domain-shared-class-value-object-spec.md](./domain-shared-class-value-object-spec.md) | class 值对象约束 |
-| [domain-shared-type-value-object-spec.md](./domain-shared-type-value-object-spec.md) | type 值对象约束 |
-| [import-path-policy.md](./import-path-policy.md) | import 路径：`@memoflow/*` 公开入口、包内相对路径、可选 `@/` |
-| [monorepo-build-standard.md](./monorepo-build-standard.md) | workspace 开发态源码引用与构建态产物引用规范 |
-| [types-undefined-or-null-spec.md](./types-undefined-or-null-spec.md) | `undefined` / `null` 约定 |
-| [configs-vs-constants规范.md](./configs-vs-constants规范.md) | config 与 constant 边界 |
-| [枚举与常量对象规范(Enum&Constant-Objects).md](./枚举与常量对象规范(Enum&Constant-Objects).md) | 枚举与常量对象写法 |
-| [枚举类型在数据库中改为string.md](./枚举类型在数据库中改为string.md) | 数据库存 `string` 的约束说明 |
-| [enum写法.md](./enum写法.md) | enum 写法约定 |
-| [值对象可以是type.md](./值对象可以是type.md) | 轻量值对象边界 |
-| [值对象里的时间使用number时间戳-毫秒.md](./值对象里的时间使用number时间戳-毫秒.md) | 时间值表达约定 |
-| [id值对象生成id的实现.md](./id值对象生成id的实现.md) | ID 生成实现约定 |
+| 文档                                                                                             | 用途                                                            |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| [architecture.md](./architecture.md)                                                             | 通用架构与分层规则                                              |
+| [failure-and-outcome-contracts.md](./failure-and-outcome-contracts.md)                           | 领域故障、应用结果、公开失败、provider 映射、传输与 UI 恢复规范 |
+| [contract-module-development-spec.md](./contract-module-development-spec.md)                     | `packages/contracts` 模块结构、纯类型边界与 API/Protocol 约束   |
+| [domain-client-spec.md](./domain-client-spec.md)                                                 | client 领域层约束                                               |
+| [domain-event-spec.md](./domain-event-spec.md)                                                   | 领域事件约束                                                    |
+| [domain-server-spec.md](./domain-server-spec.md)                                                 | server 领域层约束                                               |
+| [domain-shared-class-value-object-spec.md](./domain-shared-class-value-object-spec.md)           | class 值对象约束                                                |
+| [domain-shared-type-value-object-spec.md](./domain-shared-type-value-object-spec.md)             | type 值对象约束                                                 |
+| [import-path-policy.md](./import-path-policy.md)                                                 | import 路径：`@memoflow/*` 公开入口、包内相对路径、可选 `@/`    |
+| [monorepo-build-standard.md](./monorepo-build-standard.md)                                       | workspace 开发态源码引用与构建态产物引用规范                    |
+| [types-undefined-or-null-spec.md](./types-undefined-or-null-spec.md)                             | `undefined` / `null` 约定                                       |
+| [configs-vs-constants规范.md](./configs-vs-constants规范.md)                                     | config 与 constant 边界                                         |
+| [枚举与常量对象规范(Enum&Constant-Objects).md](<./枚举与常量对象规范(Enum&Constant-Objects).md>) | 枚举与常量对象写法                                              |
+| [枚举类型在数据库中改为string.md](./枚举类型在数据库中改为string.md)                             | 数据库存 `string` 的约束说明                                    |
+| [enum写法.md](./enum写法.md)                                                                     | enum 写法约定                                                   |
+| [值对象可以是type.md](./值对象可以是type.md)                                                     | 轻量值对象边界                                                  |
+| [值对象里的时间使用number时间戳-毫秒.md](./值对象里的时间使用number时间戳-毫秒.md)               | 时间值表达约定                                                  |
+| [id值对象生成id的实现.md](./id值对象生成id的实现.md)                                             | ID 生成实现约定                                                 |
 
 ## 使用约定
 

--- a/docs/standards/architecture.md
+++ b/docs/standards/architecture.md
@@ -1,106 +1,418 @@
+---
+tags:
+  - standards
+  - architecture
+  - layering
+  - contracts
+description: MemoFlow 运行时容器、垂直 feature、领域/应用/基础设施、契约和组合根规范
+created: 2026-01-15T00:00:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
 # 架构与分层规则
 
-## 核心边界
+## 1. 核心边界
 
-- `apps/*` 是运行时容器，负责入口、装配、环境配置和平台适配。
-- `packages/*` 承载可复用的业务模块、共享类型和基础能力。
-- 共享契约集中在 `packages/contracts`，跨模块共享的值对象与通用领域类型集中在 `packages/domain-shared`。
-- 文档、代码和治理脚本都以当前 Nx 工作区结构为准，不再维护脱离仓库现实的“理想结构图”。
+- `apps/*` 是运行时容器，负责入口、宿主装配、环境配置、生命周期和平台适配。
+- `packages/<feature>` 是垂直业务切片，内部包含 domain、application、transport、infrastructure 和 client seam。
+- `packages/contracts` 是**跨边界稳定契约中心**，只拥有 request、query、snapshot、outcome、public failure、event、RPC 和 serialization primitive。
+- `packages/domain-shared` 只保存真正跨 bounded context 且业务语义一致的值对象和纯领域 primitive。
+- `packages/utils` 保存技术性、无业务所有权的通用能力，不拥有全局业务错误层级。
+- 数据库、PowerSync、HTTP client、IPC client 等基础设施 package 不承载 feature business policy。
+- 文档、代码和治理脚本都以当前 Nx 工作区和可执行证据为准；目标架构通过迁移计划逐步实现，不假装当前代码已经全部符合。
 
-## 依赖方向
+详细失败/结果所有权见：
 
-箭头含义：`A -> B` 表示 "A 依赖 B"（B 是 A 的下游依赖）。
+- [ADR-049](../architecture/adr/ADR-049-domain-outcome-and-failure-contracts.md)；
+- [失败与结果契约规范](./failure-and-outcome-contracts.md)；
+- [Contracts 模块开发规范](./contract-module-development-spec.md)。
+
+## 2. 依赖方向
+
+箭头 `A -> B` 表示 A 依赖 B。
 
 ```text
-app (runtime container) -> ui -> application -> domain -> shared
-infrastructure -> domain (通过 port/adapter 接口)
+host app
+  -> presentation/client adapter
+  -> feature public application port
+  -> application
+  -> domain
+
+transport -> application
+infrastructure -> application/domain-owned ports
+host composer -> concrete infrastructure + feature factory
 ```
 
-## Nx Layer Tags
+关键规则：
 
-| Tag            | 对应位置                                                                            | 职责                                             |
-| -------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `layer:shared` | `packages/contracts`、`packages/domain-shared`、`packages/utils`                    | 最底层共享依赖，不承载业务逻辑                   |
-| `layer:domain` | `packages/{feature}`（含 domain-server、application-server、infrastructure-server） | 领域包，内部再细分 domain/application/infra 子层 |
-| `layer:infra`  | 基础设施包（database、powersync 等）                                                | 技术实现，不含业务规则                           |
-| `layer:ui`     | `packages/app-vue`、`packages/app-react`、`packages/ui-vue-shadcn`                  | 展示层                                           |
-| `layer:app`    | `apps/*`                                                                            | 运行时容器，只做装配和平台适配                   |
+- Domain 不依赖 application、transport、infrastructure、UI 或 host。
+- Application 依赖 domain 和 Port，不依赖 Express、Electron、Vue、Pinia、Prisma 或 provider SDK。
+- Infrastructure 实现 Port，负责 DB/provider/filesystem/network 的 anti-corruption mapping。
+- Transport 只做 context/auth 提取、schema validation、application delegation 和协议投影。
+- Presentation 只消费 public outcome/failure/snapshot，不重新实现业务不变量。
+- Host app 选择 concrete adapter、建立 module instance、控制 start/stop/drain；feature transport 不从 bootstrap context 偷取 DB 再自行组装。
 
-## 规则
+## 3. 垂直 Feature Package
 
-- Domain 业务逻辑（`domain-server`）不能依赖基础设施实现、UI 框架或运行时容器。
-- Application 层负责编排 use case，不直接触碰 Express、Electron、Pinia、Vue 组件等框架对象。
-- Infrastructure 层实现仓储、传输、数据库、文件系统等技术细节。
-- UI / Presentation 层只负责展示、交互和状态编排，不承载核心业务规则。
-- 新功能优先以领域包为单位落地，不再把业务逻辑长期堆积在 `apps/*`。
+当前采用单 package 多层模式：
 
-### 包内分层说明
+```text
+packages/<feature>/src/
+├── server/
+│   ├── domain/
+│   ├── application/
+│   ├── infrastructure/
+│   └── transport/
+├── client/ or application-client/
+├── api/
+├── electron/
+└── index.ts
+```
 
-当前采用"单包多层"模式：每个领域包（`packages/*`）内部同时包含 `domain-server`、`application-server`、`infrastructure-server`、`api` 等子目录，它们在 Nx 中共享同一个 `layer:domain` tag。
+### 3.1 Domain
 
-- `domain-server`：纯业务逻辑，不得依赖 infra 或 framework。
-- `application-server`：编排 use case，依赖 domain-server。
-- `infrastructure-server`：技术实现（Prisma、外部 API），依赖 domain-server 接口。
-- `api/module.ts`：传输与生命周期适配器，不再承担组合根职责。feature 组装（选择 adapter → repository → application instance）由宿主 runtime composer 在 `register()` 之前完成（示范：`apps/api/src/runtime/compose-governance.ts`、`apps/desktop/src/main/runtime/compose-governance.ts`），`register()` 只做 transport 注册与模块生命周期（start/dispose）。Governance、Goal、Task 以及全部 batch 模块（account、data-portability、notification、reminder、repository、schedule、setting、AI）都已迁移到 host composer；API AI 最后一个 composition residual 已由 `2026-08-14-api-ai-composition-root-externalization.md` 关闭，`apps/api/src/runtime/compose-ai.ts` 在 API lane 拥有 Prisma 集合、服务 runtime 适配器与宿主能力 port。lint 规则允许 `layer:domain -> layer:infra` 以支持适配器选择。
-- **App-local module composition（无 `context.db` 消费者）**：RefArch Phase 6 关闭了所有 registration-time `context.db` 消费者。PowerSync 改为 `composePowerSyncApiModule({ db, config? })`，Dashboard 改为 `composeDashboardApiModule({ dashboardReadPort, activityLedgerRuntime })`，DB-backed adapter/ledger 都在宿主 runtime 工厂闭包中先绑定，`register()` 只针对仅含 transport 的上下文挂载路由。feature 包 host 适配器（如 `apps/api/src/modules/ai/*.adapter.ts`）不消费 bootstrap context，其 `db`/`repositoryStorageBaseDir` 由宿主 composer（`apps/api/src/runtime/compose-ai.ts`）显式注入；同理 `@memoflow/ai` root 的 `AIService*Adapter` + `AIEvaluationReportFileAdapter` 作为宿主 composer 例外继续导出。它们不属于 transport seam，不参与 feature 组合。
-- `controllers`：传输层适配器，依赖 application-server。
+拥有 aggregate、entity、value object、policy、Domain Fault 和 domain-owned Port。
 
-当前已经由 `tools/governance/package-internal-boundary-audit.mjs` 在 repo 级别执行第一层包内分层治理，并接入 `pnpm nx run memoflow:governance-check`。
+禁止：
 
-- 当前审计重点覆盖：
-  - `domain-server` 不得导入 `infrastructure-server`、`application-client`、`infrastructure-client`、`api`、`controllers`
-  - `application-server` 不得导入 `infrastructure-server`、`application-client`、`infrastructure-client`、`api`、`controllers`
-  - `controllers` 不得导入 `infrastructure-server`、`infrastructure-client`、`api`
-- 当前仍存在少量已登记的 known violations；这些属于待清零的技术债，不表示规则尚未存在。
-- 后续若 repo-level audit 覆盖不够细，再评估是否进一步抽成 ESLint rule。
+- HTTP status、i18n、provider code、requestId/traceId；
+- Prisma/PowerSync/SDK；
+- wire DTO interface implementation；
+- persistence/client serialization policy。
 
-## App 容器治理规则
+### 3.2 Application
 
-`apps/*` 是运行时容器，不是业务逻辑的归属地。
+拥有 use case、operation outcome、Domain Fault/public failure mapper、transaction orchestration、consumer-owned capability Port。
 
-**允许的 app-local 代码**：
+Application boundary优先返回 typed：
 
-- 入口点（`main.ts`、`index.tsx`、`app.py`）
-- DI 装配（wiring domain modules to infrastructure）
-- 环境配置、路由映射
-- Runtime-specific integration（Electron IPC handlers、Express middleware、Expo routing）
-- Platform-specific adapters（实现 packages 暴露的 port 接口）
+```text
+Result<OperationOutcome, OperationFailure>
+```
 
-**不允许的 app-local 代码**：
+预期的“下一步状态”是 Outcome，不是 generic error。
 
-- Domain 实体、值对象、业务规则
-- Application use case 实现
-- 跨 app 重复的业务逻辑（应提取到 packages）
+### 3.3 Infrastructure
 
-**治理方式**：
+拥有：
 
-- 包内分层已优先由治理脚本执行；app-local 业务逻辑归属仍以文档约束与 code review 把关为主
-- 重复出现的 app-local 业务逻辑（如 api 和 desktop 共享的 schedule source executor）应提取到共享包
-- 新增 app-local 模块需在 PR 中说明为何不能放在 packages 中
+- repository adapter；
+- Prisma/PowerSync mapper；
+- BetterAuth/GitHub/AI provider ACL；
+- technical retry/backoff；
+- diagnostic enrichment；
+- filesystem/network/native platform implementation。
 
-## 仓库约定
+Provider code/status/message 不得离开该层。
 
-- 不要求向后兼容；优先做直接、结构化的根因修复。
-- 如果规则已经能够由 `nx.json`、`eslint.config.ts`、`project.json`、测试或治理脚本直接表达，文档只保留原则与边界，不重复抄配置。
-- 当架构决策影响多个模块或改变长期规则时，补 ADR，而不是在 README 或实现说明里长期堆积背景。
+### 3.4 Transport
 
-## 机器可执行治理与审计（新增）
+拥有：
 
-为保证架构规则的可验证性与可执行性，本仓库已将一部分关键规则迁移为机器可执行的治理脚本与 lint 规则，并继续收紧剩余豁口：
+- HTTP/IPC/SSE 参数投影；
+- auth/context extraction；
+- adapter-owned runtime validation；
+- public failure → status/header/envelope；
+- route/channel registration。
 
-- 运行 pnpm nx run memoflow:governance-check 可以执行完整治理审计链（JSDoc 审计、包内分层约束、根导出审计、raw event bus 回退审计等）。
-- 常用治理脚本位于 tools/governance：
-  - governance-module-docs-audit.mjs — 检查 JSDoc / 注释质量（English-first、@param/@returns、@internal 等）。
-  - package-internal-boundary-audit.mjs — 校验包内分层边界（禁止 domain-server 直接导入 infrastructure-server 等）。
-  - package-export-audit.mjs — 检查根 barrel 是否泄露具体 infra 实现。
-  - raw-event-bus-audit.mjs — 禁止非 infra 生产代码直接回退到 `eventBus.on/off/send(...)`。
-  - trim-root-exports.mjs — 自动化候选修复：移除根导出中的 infra re-export（会生成可审查的修改并提交小粒度 PR）。
-  - fix-governance-jsdoc.mjs — best-effort JSDoc 补全脚本（需要人工复核）。
+Controller 不应二次解析 raw request，也不应执行 provider/domain error mapping。
 
-治理变更流程（建议）：
+### 3.5 Client / Presentation Adapter
 
-1. 在 feature 分支运行 pnpm nx run memoflow:governance-check 并修复本地问题。
-2. 若需要跨包修改（如收窄根导出），运行 tools/governance/trim-root-exports.mjs 的 dry-run，审阅变更后提交小粒度 PR。
-3. 为临时豁免登记 owner 与 targetDate（tools/governance/target-baseline-manifest.json），并在到期前逐步消化豁免。
+拥有：
 
-原则：文档记录原则与理由，机器化脚本负责可检验的实现性规则。
+- query/mutation state；
+- loading/empty/outcome/failure；
+- recovery action；
+- stable code/outcome → i18n/view projection；
+- host-specific navigation/redirect/native bridge。
+
+不拥有服务端业务不变量，不根据 raw message/provider status 分支。
+
+## 4. Contracts Ownership
+
+### 4.1 必须进入 contracts
+
+- 跨 app/process/package public boundary 的 command/query；
+- runtime validation schema；
+- response snapshot；
+- operation outcome；
+- public failure code/schema；
+- RPC/event map；
+- durable event/message/receipt；
+- serialization-safe primitive；
+- public application/client port。
+
+### 4.2 默认留在 feature
+
+- domain aggregate/entity interface；
+- Domain Fault；
+- repository/internal Port；
+- application helper/transaction state；
+- persistence/provider row；
+- UI props/local state；
+- diagnostic cause/stack。
+
+“多层都会用”不等于“跨边界 public”。contracts 与 domain 通过命名 mapper连接，不通过 class `implements` 强耦合。
+
+## 5. 失败与结果所有权
+
+| 语义                      | Owner                               | 示例                               |
+| ------------------------- | ----------------------------------- | ---------------------------------- |
+| 领域拒绝                  | feature domain                      | `TaskHierarchyCycle`               |
+| 正常用例分支              | feature application/public contract | `email_verification_required`      |
+| 跨边界失败                | contracts/<feature>                 | `AUTH_INVALID_CREDENTIALS`         |
+| 通用失败类别              | contracts/result                    | `conflict`、`unavailable`          |
+| provider/DB 失败          | infrastructure adapter              | BetterAuth `EMAIL_NOT_VERIFIED`    |
+| HTTP status/header        | HTTP transport                      | `409`、`Retry-After`               |
+| IPC/SSE projection        | IPC/SSE adapter                     | terminal failure envelope          |
+| 文案与恢复动作            | presentation                        | locale key、focus/retry/navigation |
+| cause/stack/provider body | observer/logger                     | diagnostic only                    |
+
+硬规则：
+
+1. message 不驱动业务分支；
+2. provider code 不进入 application/UI；
+3. Domain Fault 不含 HTTP/i18n；
+4. Public Failure JSON-safe、无 cause/stack；
+5. HTTP/IPC 使用同一 canonical outcome/failure；
+6. UI 保存 stable semantics，不保存最终文案；
+7. 正常下一步状态不计入 error rate。
+
+## 6. Cross-feature Communication
+
+### 6.1 同步调用
+
+跨 feature query/command 使用：
+
+- consumer-owned narrow Port；或
+- provider feature 的 public application port。
+
+Port 由 host composer 注入 concrete adapter。禁止 consumer import provider infrastructure/application implementation。
+
+### 6.2 异步副作用
+
+跨模块可靠副作用使用 versioned durable message、outbox/inbox/receipt。进程内 EventBus 只能做低延迟 wake-up，不能是唯一真值。
+
+### 6.3 关系与引用
+
+跨 feature 不直接修改对方表或 aggregate。关系、贡献、投递等使用明确 contract/ledger，由 owning module处理。
+
+### 6.4 禁止万能 Service
+
+不要用一个全局 `BusinessService`、`ErrorService`、`ModuleRegistry` 承担所有 feature 语义。Port 应小、面向 consumer、按 capability/operation 命名。
+
+## 7. Composition Root
+
+Feature package 暴露：
+
+- domain/application factory；
+- repository/adapters 的宿主装配 ingredient；
+- transport module factory，接收已组装 instance；
+- explicit application port；
+- runtime contribution/lifecycle interface。
+
+Host runtime composer负责：
+
+```text
+choose persistence/provider adapter
+  -> build repository/capability ports
+  -> create feature application instance
+  -> bind runtime contributions
+  -> create HTTP/IPC transport module
+  -> register/start
+```
+
+规则：
+
+- 每个 host、每个 feature 只有一个 authoritative module instance；
+- AI、Data Portability、Schedule Orchestration 等 consumer 不得偷偷创建第二个 feature module；
+- `register()` 不读取 `context.db` 重新组装；
+- start/stop/drain 有明确顺序和失败清理；
+- destroy 按依赖逆序；
+- application port object identity 通过 composer tests 锁定；
+- 全局唯一 worker/scheduler 使用 DB lease/ownership，不靠“只有一个进程”的假设。
+
+## 8. Apps as Runtime Containers
+
+### 8.1 允许的 app-local 代码
+
+- 入口点；
+- host DI/composer；
+- environment/config；
+- route/channel mounting；
+- Express/Electron/Expo 等 platform integration；
+- provider capability adapter；
+- runtime lifecycle；
+- deployment/health/build identity。
+
+### 8.2 不允许的 app-local 代码
+
+- Domain aggregate/value object/business rule；
+- feature application use case；
+- 跨 app 重复的业务执行器；
+- provider error到业务语义的重复映射；
+- 第二套 feature state machine；
+- app-local复制的 public contract。
+
+重复出现在 API/Desktop 的业务编排应下沉到 feature/application package；app仅实现不同 platform Port。
+
+## 9. Presentation and Client State
+
+- Server state使用 query/mutation boundary，不复制为多个互相竞争的 local store；
+- operation state有一个 owner；
+- outcome/failure保留机器语义，文案用 computed projection；
+- locale变化不需要重新请求；
+- recovery根据 code/outcome，不根据 message；
+- durable receipt只保存safe code/params/retry/request reference；
+- programmer crash和public operation failure使用不同 UI boundary；
+- Web/Desktop可有不同 presentation，但共享 application semantics和contract。
+
+“Client Domain”不是第二套服务端领域模型。客户端需要的通常是 snapshot/view model、interaction state和host adapter，而不是复制 aggregate和业务校验。
+
+## 10. Persistence and Mapping
+
+- Domain model不 import DB row；
+- infrastructure mapper负责 row ↔ domain state；
+- application mapper负责 domain ↔ public snapshot/outcome/failure；
+- transport projector负责 raw request ↔ canonical command；
+- mapper不执行授权、持久化或业务决定；
+- `as unknown as` 不能代替 mapper；
+- Prisma错误先在adapter分类，再按operation映射public semantics；
+- PowerSync/Prisma必须通过相同application contract证明行为一致。
+
+## 11. Nx Tags 与包内治理
+
+### 11.1 当前现实
+
+当前多数 feature package 使用 `layer:domain`，但 package 内包含 domain/application/infrastructure/transport。该 tag 是历史上的粗粒度 package tag，不代表整个 package 都是纯 domain。
+
+`package-internal-boundary-audit.mjs` 是包内 source-layer 依赖方向的当前权威门禁。Nx graph主要控制 package isolation和app/ui/shared/infra大层级。
+
+### 11.2 目标
+
+Active architecture plan 将评估迁移到 `layer:feature` / `type:feature` 或等价标签：
+
+- package tag表达vertical slice；
+- AST audit表达domain/application/infra/transport；
+- 不再通过允许“domain package → infra package”解释内部适配器；
+- 不要求把每个feature拆成多个npm package。
+
+在迁移完成前，不得以粗粒度 Nx tag 为理由绕过包内 audit。
+
+## 12. 当前包内治理
+
+`tools/governance/package-internal-boundary-audit.mjs` 已接入
+`pnpm nx run memoflow:governance-check`，主要覆盖：
+
+- domain 不导入 infrastructure、application-client、api、controllers；
+- application 不导入 infrastructure、client、api、controllers；
+- controllers 不导入 infrastructure/client/api；
+- package root不泄漏 concrete infrastructure；
+- raw event bus等回退路径受审计。
+
+现有 known violations 是迁移债务，不代表规则无效。新增 violation 必须 fail closed，不能通过扩大baseline隐藏。
+
+ADR-049 后续治理还将增加：
+
+- provider code leakage；
+- message-based branch；
+- raw Result message rethrow；
+- public failure registry/JSON-safety；
+- i18n/HTTP/IPC coverage；
+- compatibility alias expiry。
+
+未落地前不得在文档中宣称这些新规则已执行；以 active plan evidence为准。
+
+## 13. 测试分层
+
+| 层             | 测试责任                                         |
+| -------------- | ------------------------------------------------ |
+| Domain         | invariant、state、Domain Fault、domain fact      |
+| Application    | fault/port failure → outcome/public failure      |
+| Infrastructure | provider/DB fixture → MemoFlow semantics         |
+| Contract       | schema、serialization、registry、compatibility   |
+| Transport      | auth/context、validation、status/envelope/parity |
+| Presentation   | i18n、recovery、locale、safe persistence         |
+| E2E            | deterministic product journey、host integration  |
+| Governance     | forbidden pattern和surface mutation fixture      |
+
+测试 fixture不得通过UI文案猜测数据前置条件；global setup/API/DB fixture负责确定性准备，真实signup/import等journey另行覆盖。
+
+## 14. Deployment and Configuration Boundary
+
+- `.env` 文件不是配置契约；每个host使用typed environment schema；
+- schema声明required、optional、public、secret、forbidden和environment-specific字段；
+- build产物包含sanitized revision/dirty/build metadata；
+- product/E2E验收前校验 source revision = Web build = API build = runtime compose evidence；
+- dirty/old image可以用于开发，不得作为正式验收证据；
+- diagnostics artifact不包含secret。
+
+## 15. 仓库约定
+
+- 当前项目处于快速演进期，可优先做根因修复，但仍需保护公开wire、数据和product journey；
+- breaking change必须有明确migration，不能用“无需兼容”跳过数据/协议安全；
+- 规则可机器化时由治理脚本执行，文档记录所有权和理由；
+- 跨多个feature或长期规则的变更必须有ADR；
+- implementation plan记录阶段、tickets、验证和rollback；
+- 完成声明只基于实际运行命令和证据。
+
+## 16. 机器可执行治理
+
+常用入口：
+
+```bash
+pnpm nx run memoflow:docs-check --skip-nx-cache
+pnpm nx run memoflow:governance-check --skip-nx-cache
+```
+
+现有治理能力包括：
+
+- JSDoc/public surface；
+- package internal boundary；
+- package export；
+- architecture surface locks；
+- raw event bus；
+- test inventory/oracle；
+- transport parity与schema引用规则；
+- target baseline/到期治理。
+
+治理变更流程：
+
+1. 先生成current inventory；
+2. 修复高风险路径或建立有期限baseline；
+3. 添加positive/negative/mutation fixture；
+4. 在feature分支运行docs/governance；
+5. 合并后逐步从report-only升级fail-closed；
+6. 禁止无owner/retireBy的长期allowlist。
+
+## 17. 架构 Code Review Checklist
+
+- [ ] 代码的语义owner是谁：domain/application/contract/infra/transport/presentation/host？
+- [ ] 是否把provider/HTTP/UI细节放进domain/application？
+- [ ] 是否把feature-private类型误放进contracts/shared？
+- [ ] normal alternate state是否建模为outcome？
+- [ ] public failure是否typed、JSON-safe、可穷尽？
+- [ ] 跨feature是否依赖narrow port而非implementation？
+- [ ] module instance是否由host唯一组装？
+- [ ] mapper是否显式且无业务副作用？
+- [ ] HTTP/IPC/PowerSync是否使用同一application contract？
+- [ ] UI是否保存semantics而非message？
+- [ ] tests是否按层验证且fixture确定性？
+- [ ] governance是否能阻止同类回归？
+
+## 18. 结论
+
+MemoFlow 的目标不是把所有东西放进同一个共享包，也不是把每个feature拆成几十个npm package。目标是让每个变化只有一个明确owner：
+
+```text
+业务规则变 -> feature domain
+用例流程变 -> feature application
+边界shape变 -> contracts
+provider/DB变 -> infrastructure adapter
+HTTP/IPC变 -> transport
+文案/交互变 -> presentation
+宿主/部署变 -> apps runtime
+```
+
+当依赖方向与所有权一致时，Web、Desktop、API、PowerSync和AI才能共享业务语义，而不共享实现偶然性。

--- a/docs/standards/contract-module-development-spec.md
+++ b/docs/standards/contract-module-development-spec.md
@@ -3,81 +3,288 @@ tags:
   - standard
   - contract
   - packages-contracts
-description: contracts 模块开发规范
+description: contracts 模块的 boundary-first 开发规范
 created: 2026-02-03T00:00:00
-updated: 2026-04-26T00:00:00
+updated: 2026-08-17T00:00:00+09:00
 ---
 
 # Contracts 模块开发规范
 
 适用范围：`packages/contracts`
 
-`packages/contracts` 是当前工作区的共享契约中心。这里定义跨 app、跨包需要复用的类型、Schema 与协议，不承载业务逻辑、容器装配或运行时行为。
+`packages/contracts` 是 MemoFlow 的**跨边界契约中心**，不是所有 TypeScript 类型、领域实体和实现接口的
+绝对注册中心。本文实现 ADR-049，并取代 ADR-017 所定义的 absolute type centralization。
 
-## 核心原则
+## 1. 核心原则
 
-- 纯类型优先：以 `type`、`interface`、Schema、常量对象为主，不写业务逻辑实现。
-- 分层清晰：`protocol` 依赖 `api`，`api` 依赖 `aggregates` / `dtos` / `entities` / `value-objects`，不要反向导入。
-- 单一真值：跨边界共享的数据结构必须从 `packages/contracts` 导出，调用方不要重新发明同名类型。
-- 代码现实优先：如果当前模块结构与旧文档不一致，以现有代码、导出入口和测试为准，再回补文档。
+### 1.1 Boundary-first
 
-## 推荐目录
+只有需要跨以下边界稳定复用的类型才进入 contracts：
 
-新模块优先对齐 `packages/contracts/src/modules/authentication/` 的结构：
+- app/process：API、Web、Desktop、worker；
+- transport：HTTP、IPC、SSE；
+- package public application/client port；
+- durable event/message/receipt；
+- serialization/language boundary；
+- OpenAPI/RPC schema；
+- public snapshot/query response。
+
+“Domain 和 Infrastructure 都会用”不自动构成进入 contracts 的理由。内部共享应优先由 owning feature
+定义 port/type，并保持依赖方向。
+
+### 1.2 Schema 与类型单一来源
+
+需要 runtime validation 的边界契约必须以一个 schema object 为真值，并从 schema 推导 TypeScript type。
+禁止 schema、interface、RPC map 和 OpenAPI request 各自维护平行 shape。
+
+### 1.3 Contract 只表达可传输语义
+
+contracts 不包含：
+
+- 业务方法实现；
+- framework/runtime/container wiring；
+- Error instance、stack、cause；
+- provider/Prisma row；
+- logger/trace implementation；
+- UI component props；
+- feature-private repository type；
+- 仅供 domain class `implements` 的数据接口。
+
+### 1.4 Domain model 与 contract 通过 mapper 连接
+
+Domain aggregate/entity 是业务不变量的 source of truth。Contract 是边界投影。
+
+推荐：
 
 ```text
-modules/{domain}/
-├── aggregates/
+CreateTaskSchema -> CreateTaskCommand
+Task aggregate -> toTaskSnapshot() -> TaskSnapshot
+TaskDomainFault -> mapTaskFaultToFailure() -> TaskFailure
+```
+
+禁止让 domain class 因为网络 DTO 而实现 contracts interface。
+
+## 2. Contracts 中允许的类型
+
+| 类型                             | 是否进入 contracts | 示例                      |
+| -------------------------------- | ------------------ | ------------------------- |
+| API command/query schema         | 是                 | `CreateTaskSchema`        |
+| response snapshot                | 是                 | `TaskSnapshot`            |
+| public operation outcome         | 是                 | `SignInOutcome`           |
+| public failure code/schema       | 是                 | `AuthFailure`             |
+| RPC map / HTTP canonical input   | 是                 | `TaskRpcMap`              |
+| durable domain event payload     | 是                 | `task:completed@v1`       |
+| reliable receipt/timeline schema | 是                 | `OperationReceipt`        |
+| shared serialization primitive   | 是                 | `YmdString`、`JsonValue`  |
+| domain aggregate class/interface | 否                 | `Task` aggregate          |
+| domain fault                     | 否                 | `TaskHierarchyCycle`      |
+| repository row/Prisma type       | 否                 | `Prisma.TaskGetPayload`   |
+| provider SDK error               | 否                 | BetterAuth/GitHub errors  |
+| application-internal helper      | 否                 | local orchestration state |
+| component props                  | 否                 | Vue props                 |
+| diagnostic cause                 | 否                 | stack/provider response   |
+
+## 3. 推荐目录
+
+新模块优先采用：
+
+```text
+modules/{feature}/
 ├── api/
-├── domain/
-│   └── events/
-├── dtos/
-├── entities/
+│   ├── commands.ts
+│   ├── queries.ts
+│   ├── snapshots.ts
+│   └── schemas.ts
+├── events/
+│   └── *.event.ts
+├── failures.ts
+├── outcomes.ts
 ├── protocol/
-│   ├── {domain}-event-map.ts
-│   └── {domain}-rpc-map.ts
-├── value-objects/
+│   ├── {feature}-event-map.ts
+│   └── {feature}-rpc-map.ts
+├── primitives/
 └── index.ts
 ```
 
-## 分层规则
+当前已有 `aggregates/`、`entities/`、`value-objects/` 目录不要求一次性删除，但新增类型前必须判断它是
+wire snapshot 还是 domain model：
 
-### Protocol
+- wire snapshot：重命名/迁移到 `api/snapshots` 或明确的 transfer 目录；
+- domain model：迁回 owning feature；
+- shared serialization primitive：保留在 contracts/shared/primitives；
+- legacy：登记 owner 和退役条件。
 
-- 只定义对外协议映射，例如 RPC map、event map。
-- RPC key 使用 `'domain:kebab-case-operation'`。
-- Event key 使用 `'domain:kebab-action-past-tense'`（如 `governance:rule-created`）。
-- 不允许在协议映射里内联复杂对象类型，统一从 `../api` 或其他下层目录导入。
+## 4. API 规则
 
-### API
+- command/query request 必须有 schema；
+- response data 使用 snapshot，不暴露 domain class；
+- `identityId`、actor、trace、request metadata 由 ExecutionContext 提供，不进入 public mutation body；
+- path/query/body 组合使用命名 schema/projector；
+- 时间、ID、nullable、enum 使用明确 transfer representation；
+- 不引用 `protocol`，避免反向依赖；
+- 不内联复杂匿名 response。
 
-- 请求、响应、查询类型集中定义，并通过 `api/index.ts` 暴露。
-- 需要运行时校验的请求/查询优先配套 Zod Schema。
-- 不从 `protocol` 回引类型，避免形成循环依赖。
+## 5. Outcome 与 Failure 规则
 
-### DTO / Aggregate / Entity / Value Object
+详细规范见
+[`failure-and-outcome-contracts.md`](./failure-and-outcome-contracts.md)。最低要求：
 
-- 复杂组合 DTO 放在 `dtos/`。
-- 领域聚合与实体形状分别放在 `aggregates/`、`entities/`。
-- 值对象契约放在 `value-objects/`，并根据需要明确 domain / transfer / persistence 形态。
+- normal alternate state 使用 `*Outcome` union；
+- public failure 使用 feature-owned code union；
+- shared result 只拥有 generic category/envelope；
+- public failure JSON-safe；
+- provider code/message 不进入 contracts；
+- HTTP status 不进入 failure contract；
+- code 必须有 registry、schema、transport/i18n coverage。
 
-## 命名与类型约束
+## 6. Protocol 规则
 
-- 实体标识符优先使用强类型 ID，而不是裸 `string`。
-- 标识字段统一使用 `*Id` 后缀，避免 `*Uuid` 与 `*Id` 并存。
-- 协议、DTO、实体、仓储映射中的标识符命名必须一致。
-- 文件名保持 `kebab-case`，导出符号可以使用 `PascalCase`。
+### RPC map
 
-## 禁止项
+- key 使用 `'feature:kebab-case-operation'`；
+- 参数/返回类型从 `../api`、`../outcomes`、`../failures` 导入；
+- 禁止在 map 中内联复杂 object；
+- HTTP/IPC 使用同一 canonical input/output；
+- positional IPC args 通过 projector 转 canonical input，不改变 application contract。
 
-- 在 `protocol` 中内联请求/响应对象。
-- 在 `contracts` 中放业务逻辑、类方法实现或框架相关代码。
-- API 层类型未从 `api/index.ts` 导出，却被其他层直接深路径引用。
-- DTO 反向依赖 `protocol`。
-- 新模块继续依赖历史理想结构而不是当前 `packages/contracts` 实际代码。
+### Event map
 
-## 检查口径
+- key 使用 `'feature:kebab-action-past-tense'`；
+- durable event 必须有 schema version；
+- event payload 是不可变事实，不是 domain aggregate；
+- messageId、correlationId、causationId、occurredAt 等 envelope metadata 不与业务 payload 混写；
+- consumer-specific projection 不反向写入 event contract。
 
-- 新模块优先参考 `authentication` 的现有结构，而不是已退役脚手架中的历史示例。
-- 文档用于说明规则，不替代 `tsconfig`、导出入口和测试。
-- 如果某条约束已经由代码生成、类型检查或测试覆盖，文档保持短而明确即可。
+## 7. Snapshot 与 Domain Model
+
+### Snapshot
+
+Snapshot 表达某一边界时刻的可序列化状态：
+
+```ts
+export interface TaskSnapshot {
+  readonly id: string;
+  readonly title: string;
+  readonly status: TaskStatusValue;
+  readonly version: number;
+  readonly updatedAt: number;
+}
+```
+
+Snapshot：
+
+- 无方法；
+- 无 lazy getter；
+- 无 repository/provider type；
+- 无 private state；
+- 不作为 domain aggregate constructor props 的强制接口；
+- 由 mapper 显式生成。
+
+### Domain model
+
+Domain model 留在 feature：
+
+```ts
+export class Task extends AggregateRoot<TaskId> {
+  complete(now: Instant): TaskDecision { ... }
+}
+```
+
+Domain model 不需要 `implements TaskSnapshot`，也不直接 `toClientDTO()`。
+
+## 8. Shared Primitive 规则
+
+一个 primitive 进入 contracts/shared 或 contracts/primitives，必须满足：
+
+1. 语义跨 bounded context 完全一致；
+2. 是 serialization-safe representation；
+3. 不依赖 feature business policy；
+4. 不包含运行时 I/O；
+5. 有 schema/round-trip tests。
+
+业务不变量丰富的 class 值对象优先归 `domain-shared` 或 owning feature；其 wire representation 可以在 contracts。
+
+## 9. Public Port 规则
+
+跨 package consumer 需要调用 feature application 时，可以在 contracts 或 feature root 导出 public port。
+
+- Port 使用 command/query/outcome/failure contract；
+- 不暴露 repository/concrete adapter；
+- 不返回 provider SDK type；
+- 不要求 consumer 知道 HTTP/IPC；
+- consumer-owned narrow port 优于 provider-owned万能 service；
+- Port 方法必须能通过 fake 实现进行 application test。
+
+## 10. Export Policy
+
+- package root 只导出高频、稳定、无副作用的 public contract；
+- feature subpath 导出 feature contract；
+- provider/infra/private types 不进入 root；
+- legacy re-export 必须登记 owner/reason/retireBy；
+- 禁止通过 wildcard barrel 意外导出 domain/infra implementation；
+- package-export audit 和 surface specs 必须覆盖新增 public surface。
+
+## 11. 禁止项
+
+- 把“两个文件会用”当作进入 contracts 的唯一理由；
+- 新增 domain aggregate/entity interface 并要求 class implements；
+- 在 contracts 中定义 Error subclass；
+- 在 public failure 中加入 `cause`/stack/provider body；
+- 在 contracts/result 中增加 feature-specific HTTP status 表；
+- 复制 schema 为 interface；
+- protocol map 内联复杂 object；
+- DTO 反向依赖 protocol；
+- contracts import Vue/Express/Electron/Prisma/provider SDK；
+- 将 UI-specific message/recovery action写进业务 code；
+- 新增无版本 durable event。
+
+## 12. 测试与治理
+
+每个 contract change 至少需要：
+
+- schema valid/invalid fixtures；
+- TypeScript inferred type compile fixture；
+- serialization round-trip；
+- HTTP/IPC parity（如果两者消费）；
+- public failure JSON-safety；
+- code registry/i18n/transport coverage；
+- package export/surface test；
+- compatibility fixture（修改已有 wire shape 时）。
+
+推荐命令：
+
+```bash
+node node_modules/vitest/vitest.mjs run --config packages/contracts/vitest.config.ts
+pnpm nx run contracts:typecheck
+pnpm nx run contracts:lint
+pnpm nx run memoflow:governance-check --skip-nx-cache
+```
+
+## 13. Migration Checklist
+
+迁移一簇旧 contracts 类型时：
+
+- [ ] 确认它是 wire/public/durable/domain/internal/provider/legacy 中哪一种；
+- [ ] 指定唯一 owner；
+- [ ] domain 类型迁回 feature，并建立 mapper；
+- [ ] 保留必要 snapshot/schema；
+- [ ] 更新 RPC/event map；
+- [ ] 添加 compatibility re-export（如需要）；
+- [ ] compatibility entry 有 retireBy；
+- [ ] affected consumers typecheck；
+- [ ] wire snapshot/parity 未改变；
+- [ ] root export 未泄漏 implementation；
+- [ ] ownership inventory 数量下降。
+
+## 14. 结论
+
+Contracts 的单一真值是“边界 shape 和协议”的单一真值，不是“整个系统所有概念”的单一真值。
+
+```text
+Domain owns business meaning
+Contracts own boundary representation
+Mappers own translation
+Transports own protocol projection
+```
+
+只有保持这四个 owner，集中契约才能减少漂移，而不是制造新的全局耦合。

--- a/docs/standards/domain-client-spec.md
+++ b/docs/standards/domain-client-spec.md
@@ -1,208 +1,388 @@
 ---
-tags: [standard, domain/client]
+tags:
+  - standard
+  - client
+  - presentation
+description: Web/Desktop 客户端快照、交互状态、结果消费和视图模型规范
+created: 2026-02-03T00:00:00
+updated: 2026-08-17T00:00:00+09:00
 ---
 
-# 客户端领域开发规范：聚合根与实体（垂直模块包）
+# 客户端领域开发规范：快照、状态与视图投影
 
-**版本**: 1.0
-**适用范围**: `apps/{web,desktop}/src/modules/{domain}` 与 `packages/{domain}/` 中客户端领域代码（原 `domain-client` 集中包已取消）
-**读者**: 开发人员, AI 助手
+**适用范围**：`packages/app-vue`、`packages/app-react`、feature client/application-client、
+`apps/web` 与 `apps/desktop` 的 renderer/presentation 代码。
+**依据**：ADR-049、`architecture.md`、`failure-and-outcome-contracts.md`。
 
-## 1. 核心设计理念
+## 1. 定位
 
-在 Client 端（前端/桌面端），领域模型（Domain Model）的职责与 Server 端截然不同。
+客户端通常不需要复制一套服务端 Aggregate/Entity。客户端的主要职责是：
 
-* **Server 端**: 侧重于**数据一致性**、**业务规则校验**、**持久化**和**事件分发**。
-* **Client 端**: 侧重于**数据展示（View Model）**、**UI 状态辅助**、**交互逻辑**以及**数据消费**。
+1. 消费服务端/public contracts 的 snapshot、outcome 和 public failure；
+2. 管理 query/mutation/interaction state；
+3. 将稳定业务语义投影成当前平台的 view model、文案和 recovery action；
+4. 处理 optimistic view、草稿、selection、focus、navigation 和 native bridge；
+5. 保持 Web/Desktop 的产品语义一致，同时允许不同 presentation。
 
-**原则**: Client 端的聚合根是 "Anemic Domain Model" (贫血模型) 与 "Rich View Model" (富视图模型) 的结合体。它**不包含**复杂的业务规则校验和持久化逻辑。
+客户端不拥有服务端业务真值、跨实体不变量、持久化事务或 provider error translation。
 
----
+## 2. 三种客户端模型
 
-## 2. 依赖规则
+不要把所有客户端对象都称为“领域模型”。按责任区分：
 
-Client 端领域对象应当遵守以下依赖限制：
+| 模型              | 用途                                | 示例                |
+| ----------------- | ----------------------------------- | ------------------- |
+| Server Snapshot   | 来自 public contract 的只读数据     | `TaskSnapshot`      |
+| Application State | query/mutation/outcome/failure 状态 | `TaskDetailState`   |
+| View Model        | 展示所需的纯投影                    | `TaskCardViewModel` |
 
-* ✅ **允许依赖**:
-* `@memoflow/utils` (基础工具类，如 `AggregateRoot` 基类)
-* `@memoflow/contracts` (DTO 定义, API 接口)
-* `@memoflow/domain-shared` (值对象, 枚举, 通用纯函数)
+必要时可以有 client-side policy，例如是否显示按钮、如何格式化进度，但它不能替代服务端授权和不变量。
 
+## 3. 依赖规则
 
-* ❌ **禁止依赖**:
-* 服务端运行时依赖（Node-only APIs、Express middleware、数据库驱动等）
-* 数据库相关库 (Prisma, TypeORM 等)
-* UI 框架组件 (React, Vue 组件) —— 领域对象应保持框架无关。
+### 3.1 允许依赖
 
+- `@memoflow/contracts/<feature>` public snapshot/outcome/failure；
+- feature public client/application port；
+- presentation-safe shared primitives；
+- UI framework（仅 presentation/store/composable 层）；
+- host navigation/native bridge interface；
+- i18n formatter；
+- query/state libraries。
 
+### 3.2 禁止依赖
 
----
+- server domain/application/infrastructure deep path；
+- Prisma、PowerSync internal row、database driver；
+- BetterAuth/GitHub/provider SDK error type；
+- Express/API middleware；
+- server-only aggregate repository；
+- raw provider message/status branching；
+- 全局 legacy `DomainError`。
 
-## 3. 代码结构规范
+### 3.3 `domain-shared`
 
-### 3.1 类定义与继承
+只有客户端和服务端业务语义完全一致、且不依赖 server runtime 的值对象才可共享。
 
-* 所有聚合根必须继承自 `AggregateRoot<TId>`。
-* 所有实体必须继承自 `Entity<TId>`。
-* 必须实现对应的 `Contract` 中定义的 Client 接口（如果有）。
+不要在 client 重复服务器端的复杂 business validation。客户端本地 validation用于及时反馈；服务器仍是 authoritative owner。
 
-```typescript
-import { AggregateRoot } from '@memoflow/utils';
-import { IdentityId } from '@memoflow/domain-shared/account';
-import type { AccountClientDTO } from '@memoflow/contracts/account';
+## 4. Snapshot Consumption
 
-export class Account extends AggregateRoot<IdentityId> {
-  // ...
+Public snapshot 是边界数据，不要求再包装成继承 `AggregateRoot` 的 client class。
+
+优先使用纯函数/readonly view model：
+
+```ts
+export interface TaskCardViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly statusLabel: string;
+  readonly progressLabel: string;
+  readonly canOpen: boolean;
 }
 
+export function toTaskCardViewModel(task: TaskSnapshot, t: TranslateFn): TaskCardViewModel {
+  return {
+    id: task.id,
+    title: task.title,
+    statusLabel: t(`task.status.${task.status}`),
+    progressLabel: `${task.progress}%`,
+    canOpen: true,
+  };
+}
 ```
 
-### 3.2 属性 (Properties)
+允许 class 的条件：
 
-* **可见性**: 内部状态使用 `private`，通过 `public` 的 getter 暴露。
-* **类型**: 优先使用 **值对象 (Value Objects)** (来自 `domain-shared`)，而不是原始类型。这保证了展示格式化逻辑的复用。
-* **只读性**: ID 和创建时间等元数据应为 `readonly`。
+- 确实需要封装多个纯 computed behavior；
+- 不复制服务端 state mutation；
+- 不继承 server aggregate基类；
+- 不要求 `implements` wire DTO；
+- 构造通过显式 mapper，而不是将 DTO 与内部状态强耦合。
 
-### 3.3 构造函数 (Constructor)
+## 5. Application State Ownership
 
-* **可见性**: `private`。禁止外部直接 `new`。
-* **参数**: 必须只接收 **API DTO (`ClientDTO`)**。Client 端的数据源头永远是 API，而不是零散的参数。
+每个 operation/flow 只有一个 authoritative state owner。State至少区分：
 
-### 3.4 工厂方法 (Factory Methods)
+```ts
+export type AsyncOperationState<TOutcome, TFailure> =
+  | { readonly status: 'idle' }
+  | { readonly status: 'pending'; readonly startedAt: number }
+  | { readonly status: 'succeeded'; readonly outcome: TOutcome }
+  | { readonly status: 'failed'; readonly failure: TFailure };
+```
 
-* **必须包含**: `fromClientDTO(dto: ClientDTO): ClassName`。
-* **禁止包含**: `create(...)` (用于生成新数据的工厂)。客户端的新建操作是 RPC 调用，不是本地对象创建。
+必要时扩展 canceled、paused、waiting_user_action、replaying 等明确状态。
 
-### 3.5 方法 (Methods)职责
+禁止同一个 operation 同时维护：
 
-#### ✅ 允许的方法类型：
+- local `errorMessage`；
+- Pinia `error`；
+- query library `error`；
+- composable `lastResultError`；
+- durable receipt；
 
-1. **Getters**: 直接暴露内部状态。
-2. **Computed Properties (计算属性)**:
-* 用于 UI 展示的衍生数据。
-* *示例*: `get displayName()`, `get isVip()`, `get progressPercentage()`
+却没有一个清楚的 source of truth。不同投影可以派生，但机器语义只能有一个 owner。
 
+## 6. Outcome Consumption
 
-3. **UI Helpers**:
-* *示例*: `canEdit()`, `hasPermission(p)`
+正常下一步按 outcome `kind` 分支：
 
+```ts
+const result = await auth.signIn(input);
 
-4. **Immutability Helpers (可选)**:
-* 如果配合 React 使用，提供 `cloneWith(...)` 方法以支持不可变更新。
-
-
-5. **Serialization**:
-* `toClientDTO()`: 必须实现，用于序列化后传递给 UI 组件或打印日志。
-
-
-
-#### ❌ 禁止的方法类型：
-
-1. **Business Validation**: 复杂的业务规则校验（应在 Server 端）。
-2. **Persistence**: `save()`, `update()`, `delete()` (应在 Service/Store 层调用 API)。
-3. **Domain Events**: `addDomainEvent()` (Client 端通常只处理 UI 事件，不生产领域事件)。
-
----
-
-## 4. 代码模板 (AI 参照标准)
-
-请 AI 在生成代码时严格参照以下模板：
-
-```typescript
-import { AggregateRoot } from '@memoflow/utils';
-// 1. 引入 Contract 定义的 DTO
-import type { UserClientDTO } from '@memoflow/contracts/user';
-// 2. 引入 Shared 中的值对象
-import { UserId, Email, UserStatus } from '@memoflow/domain-shared/user';
-
-export class User extends AggregateRoot<UserId> {
-  // ================= 状态定义 =================
-  private _email: Email;
-  private _status: UserStatus;
-  private _nickname: string | null;
-  private _avatarUrl: string | null;
-
-  public readonly createdAt: Date;
-
-  // ================= 构造函数 =================
-  private constructor(dto: UserClientDTO) {
-    super(UserId.of(dto.id));
-    
-    // 还原值对象
-    this._email = Email.fromDTO(dto.email);
-    this._status = UserStatus.of(dto.status);
-    this._nickname = dto.nickname ?? null;
-    this._avatarUrl = dto.avatarUrl ?? null;
-    
-    this.createdAt = new Date(dto.createdAt);
-  }
-
-  // ================= 工厂方法 =================
-  public static fromClientDTO(dto: UserClientDTO): User {
-    return new User(dto);
-  }
-
-  public static createDefault(id: string, emailStr: string): User {
-    return new User({
-      id,
-      email: Email.create(emailStr).toDTO(),
-      status: UserStatus.PENDING,
-      nickname: null,
-      avatarUrl: null,
-      createdAt: Date.now(),
-    });
-  }
-
-  // ================= Getters (基础数据) =================
-  get email(): Email { return this._email; }
-  get status(): UserStatus { return this._status; }
-  get nickname(): string | null { return this._nickname; }
-  get avatarUrl(): string | null { return this._avatarUrl; }
-
-  // ================= Computed Properties (UI 逻辑核心) =================
-  
-  /**
-   * UI 展示名称逻辑：有昵称显示昵称，没有显示脱敏邮箱
-   */
-  get displayName(): string {
-    return this._nickname || this._email.getMasked();
-  }
-
-  /**
-   * UI 头像逻辑：有头像显示头像，没有显示默认图
-   */
-  get displayAvatar(): string {
-    return this._avatarUrl || '/assets/default-avatar.png';
-  }
-
-  get isActive(): boolean {
-    return this._status === UserStatus.ACTIVE;
-  }
-
-  // ================= 序列化 =================
-  public toClientDTO(): UserClientDTO {
-    return {
-      id: this.id.toString(),
-      email: this._email.toDTO(),
-      status: this._status,
-      nickname: this._nickname,
-      avatarUrl: this._avatarUrl,
-      createdAt: this.createdAt.getTime(),
-    };
-  }
+if (!result.ok) {
+  state.value = { status: 'failed', failure: result.error };
+  return;
 }
 
+switch (result.data.kind) {
+  case 'authenticated':
+    navigateToWorkspace();
+    break;
+  case 'email_verification_required':
+    scene.value = 'verify-email';
+    break;
+  default:
+    assertNever(result.data);
+}
 ```
 
----
+禁止把 normal outcome当作 error code：
 
-## 5. 常见误区检查清单 (Checklist)
+```ts
+if (result.error.code === 'EMAIL_NOT_VERIFIED') { ... }
+```
 
-在提交代码或生成代码前，请检查：
+## 7. Public Failure Consumption
 
-* [ ] **是否引用了服务端运行时代码？** (客户端领域层不得依赖 Node-only/Express/数据库实现)
-* [ ] **是否包含了 `create` 方法？** (Client 端不应该负责生成 ID 和初始状态)
-* [ ] **是否包含了 `update` / `save` 方法？** (Client 模型应该是纯内存对象，不负责 I/O)
-* [ ] **是否使用了 `addDomainEvent`？** (Client 模型不产生领域事件)
-* [ ] **构造函数是否为 private？** (强制使用 `fromClientDTO`)
-* [ ] **是否复用了 `domain-shared` 里的值对象？** (不要在 Client 端重写一遍 Email 校验逻辑)
+### 7.1 保存稳定语义
+
+```ts
+const failure = ref<AuthFailure | null>(null);
+
+const failureMessage = computed(() =>
+  failure.value ? translateAuthFailure(failure.value, t) : null,
+);
+```
+
+不要只保存最终 message：
+
+```ts
+const errorMessage = ref(result.error.message);
+```
+
+原因：message无法重新本地化、无法可靠 recovery、可能泄漏 provider detail，也不能被编译器穷尽。
+
+### 7.2 Recovery 与 Message 分离
+
+```ts
+const recovery = computed(() => (failure.value ? authRecovery(failure.value) : null));
+```
+
+Message registry负责文案；Recovery registry负责 focus、retry、navigation、disable、reauthenticate。
+不要通过文本推断动作。
+
+### 7.3 HTTP status
+
+客户端可以将 401/403 等用于 transport/session通用处理，但具体业务原因仍依赖 public failure code/outcome。
+
+```text
+401 + AUTH_INVALID_CREDENTIALS -> 留在登录页
+401 + AUTH_SESSION_EXPIRED     -> 清理会话并重新登录
+```
+
+不得只看 status就推断业务 scene。
+
+## 8. i18n
+
+- 每个 public failure code 必须有所有支持 locale 的 key；
+- translation mapping使用 `satisfies Record<FailureCode, string>`；
+- params经过schema allowlist；
+- locale变化时computed message立即变化；
+- provider/server raw message不作为生产fallback；
+- 文案测试与业务code测试分层。
+
+## 9. Optimistic State
+
+允许客户端有 optimistic projection，但必须明确：
+
+1. server command仍是authoritative；
+2. optimistic item带client mutation ID/idempotency key；
+3. server outcome成功后reconcile；
+4. public failure后rollback或显示conflict resolution；
+5. 不在客户端重新执行复杂domain validation；
+6. offline queue使用versioned command contract和durable receipt，不保存UI-only object。
+
+## 10. Draft、Dirty 与 Busy
+
+Draft是presentation/application state，不是server aggregate。
+
+- draft可以包含未提交输入；
+- dirty比较基于canonical form state；
+- busy表示operation不能安全中断；
+- shell/navigation通过surface status registry询问能否离开；
+- draft持久化不得包含token/password/provider error；
+  -提交时通过contract schema构造command。
+
+## 11. Durable Failure Receipt
+
+可持久化：
+
+- public failure code/category；
+- safe params；
+- retry directive；
+- operation；
+- requestId/traceId reference；
+- failedAt；
+- version。
+
+禁止持久化：
+
+- `Error` instance、stack、cause；
+- arbitrary server/provider message；
+- password/reset token/OAuth code；
+- cookies/headers；
+- unfiltered context。
+
+Receipt恢复后重新根据当前locale投影文案。
+
+## 12. View Model
+
+View model是纯函数或只读class：
+
+- 输入snapshot/current locale/presentation preference；
+- 输出label、formatted value、visibility、semantic action descriptor；
+- 不发请求；
+- 不修改server state；
+- 不持有provider/transport object；
+- 不把UI文案写回domain/contract；
+- 可被unit test独立验证。
+
+避免 `toClientDTO()` 循环序列化。Snapshot本身已经是contract；view model不是另一个public transport DTO。
+
+## 13. Host-specific Adapter
+
+Web和Desktop可分别实现：
+
+- browser redirect/deep link；
+- Electron native dialog/filesystem bridge；
+- platform notification；
+- secure credential storage；
+- network/offline detection。
+
+Host adapter消费/实现Port，不复制application state machine和failure mapping。
+
+例如 Auth：
+
+```text
+shared Auth application semantics
+  -> Web redirect adapter
+  -> Desktop device authorization adapter
+```
+
+不同presentation不等于不同错误协议。
+
+## 14. Global Error Boundary
+
+区分两种错误：
+
+1. Public operation failure：由feature state owner渲染可恢复UI；
+2. Programmer/render crash：由global error boundary捕获，显示safe generic fallback并记录diagnostic。
+
+GlobalErrorBoundary不应把任意 `err.message` 原样展示给用户。
+
+## 15. 测试规范
+
+### State/composable tests
+
+- pending/success/normal outcome/failure/cancel；
+- stale request和并发提交；
+- retry/recovery；
+- unmount/remount receipt；
+- locale live retranslation；
+- unknown failure safe fallback。
+
+### View model tests
+
+- snapshot → formatted display；
+- locale/timezone；
+- empty/edge values；
+- 无I/O/side effect。
+
+### Security negative tests
+
+- provider raw message不渲染；
+- password/token不进store/localStorage/log；
+- arbitrary context不持久化；
+- Error/stack不进IPC/HTTP UI receipt。
+
+### E2E
+
+- fixture通过API/DB/global setup准备；
+- helper不根据UI message修改数据库；
+- 文案只在专门i18n contract场景断言；
+- user journey断言stable state/testid/behavior；
+- suite开始校验build revision。
+
+## 16. 禁止模式
+
+```ts
+// 禁止：provider code进入UI
+if (error.code === 'EMAIL_NOT_VERIFIED') { ... }
+
+// 禁止：raw message成为state
+errorMessage.value = result.error.message;
+
+// 禁止：message驱动recovery
+if (message.includes('not found')) createFixture();
+
+// 禁止：复制server aggregate
+class ClientTask extends AggregateRoot<TaskId> {
+  complete() { /* duplicated business rule */ }
+}
+
+// 禁止：用wire DTO约束view model
+class TaskCard implements TaskSnapshot { ... }
+```
+
+## 17. Legacy 迁移
+
+现有“Client Domain Aggregate”不要求一次删除。迁移顺序：
+
+1. 确认对象是snapshot wrapper、view model还是duplicated domain；
+2. 纯展示逻辑迁为view model；
+3. operation state迁入单一state owner；
+4. duplicated business rule删除，改为server command/outcome；
+5. raw message迁为typed failure；
+6. 去掉不必要的AggregateRoot/Entity继承；
+7. 保留compatibility adapter直到调用方更新；
+8. 添加surface和behavior tests后删除旧轨。
+
+## 18. Code Review Checklist
+
+- [ ] 这是snapshot、application state还是view model？
+- [ ] 是否复制了server domain rule？
+- [ ] 是否深路径import server/infra/provider？
+- [ ] operation是否只有一个state owner？
+- [ ] normal state是否使用outcome？
+- [ ] failure是否保留code/category/params而非message？
+- [ ] recovery是否和translation分离？
+- [ ] locale变化是否无需重新请求？
+- [ ] receipt是否只持久化safe fields？
+- [ ] Web/Desktop差异是否封装在host adapter？
+- [ ] tests是否不依赖UI文案准备fixture？
+
+## 19. 结论
+
+客户端的“领域性”体现在正确消费业务语义和维护交互状态，而不是复制服务端aggregate。
+
+```text
+Server/domain owns business truth
+Contracts carry stable snapshots/outcomes/failures
+Client state owns interaction lifecycle
+View model owns presentation projection
+Host adapter owns platform behavior
+```
+
+这样Web和Desktop可以有不同界面，却不会产生两套业务规则和错误协议。

--- a/docs/standards/domain-server-spec.md
+++ b/docs/standards/domain-server-spec.md
@@ -1,194 +1,522 @@
 ---
-tags: [standard, domain/server]
+tags:
+  - standard
+  - domain
+  - server
+description: 服务端领域模型、领域故障、领域事件与边界映射规范
+created: 2026-02-03T00:00:00
+updated: 2026-08-17T00:00:00+09:00
 ---
 
-# 服务端领域开发规范：聚合根与实体（垂直模块包）
+# 服务端领域开发规范：模型、故障与边界
 
-**版本**: 1.0
-**适用范围**: `packages/{domain}/` 内的服务端领域层代码（原 `packages/domain-server` 已收敛为按业务域垂直切分）
-**读者**: 开发人员, AI 助手
+**适用范围**：`packages/<feature>/src/server/domain/**` 及同等 feature-owned 领域代码。
+**依据**：ADR-049、`failure-and-outcome-contracts.md`、`architecture.md`。
+**读者**：开发人员、代码审查者、AI Agent。
 
-## 1. 核心设计理念
+## 1. 领域层的职责
 
-Server 端的领域模型是业务逻辑的核心心脏。它是 **"Rich Domain Model" (充血模型)**。
-它不仅仅是数据的容器，更是**业务规则的守护者**。
+领域层拥有业务含义和不变量，不拥有网络、数据库、UI 或日志协议。
 
-**核心职责**:
+领域层负责：
 
-1. **Enforce Invariants (强制不变量)**: 确保对象随时处于合法状态（例如：余额不能小于0，已冻结账户不能交易）。
-2. **State Mutation (状态变更)**: 所有的状态修改必须通过类的方法（Methods）进行，禁止外部直接修改属性。
-3. **Domain Events (领域事件)**: 当重要状态变更发生时，必须发出事件通知其他聚合根或模块。
-4. **No Infrastructure (无基础设施)**: 领域模型不应包含 SQL、HTTP 请求或任何框架特定的代码。
+1. 聚合、实体和值对象；
+2. 状态转换及不变量；
+3. 领域服务和 policy；
+4. feature-owned Domain Fault；
+5. 领域事实和待发布事件的业务内容；
+6. 领域需要的 Port 抽象。
 
----
+领域层不负责：
+
+- HTTP status、header、cookie、Express；
+- IPC channel、Electron event；
+- Zod/OpenAPI wire validation；
+- Vue/Pinia/i18n/toast；
+- Prisma、PowerSync、SQL、filesystem、SDK；
+- provider error code/message；
+- public API failure code 的 transport 投影；
+- stack、trace、requestId、operationId、日志格式；
+- client DTO 或 persistence DTO 的最终 shape。
 
 ## 2. 依赖规则
 
-服务端领域层处于架构核心，依赖必须极其严格：
+### 2.1 允许依赖
 
-* ✅ **允许依赖**:
-* `@memoflow/utils` (AggregateRoot 基类, Entity 基类)
-* `@memoflow/contracts` (DTO 定义, 事件 Map)
-* `@memoflow/domain-shared` (值对象, 枚举, 纯业务逻辑)
+- feature 内部纯 domain module；
+- `@memoflow/domain-shared` 中真正跨 bounded context 且语义一致的值对象；
+- `@memoflow/utils` 中不带 transport/runtime 语义的纯基类或算法；
+- 少量 serialization-neutral primitives；
+- TypeScript 标准库和纯计算依赖。
 
+### 2.2 有条件依赖 contracts
 
-* ❌ **禁止依赖**:
-* 其他业务域包中的具体基础设施实现（禁止跨域耦合）
-* `@memoflow/infrastructure` (禁止！Repository 的实现不应出现在这里)
-* API 层代码 (Controller, Resolver)
-* 外部 I/O 库 (fs, axios, prisma, typeorm)
+领域层不应为了实现 wire DTO 而依赖 `@memoflow/contracts`。只有以下情形允许 type-only 依赖：
 
+1. 领域事件的 canonical business fact 已明确同时是跨边界 durable contract，且不存在额外 transport 字段；
+2. 共享 ID/时间 primitive 的语义在 domain 与 transfer 边界完全一致；
+3. 已有迁移期 compatibility contract，且有 owner/retireBy。
 
+即使允许依赖，领域类也不应 `implements` request/response/snapshot interface。
 
----
+### 2.3 禁止依赖
 
-## 3. 代码结构规范
+- `@memoflow/database`、Prisma client/generated row；
+- `@memoflow/http-client`、Axios、fetch adapter；
+- IPC/client/UI packages；
+- 其他 feature 的 infrastructure/application implementation；
+- host app/runtime composer；
+- provider SDK；
+- `@memoflow/utils/errors` 中携带 HTTP/日志职责的 legacy `DomainError`。
 
-### 3.1 类定义
+跨 feature 业务校验使用 consumer-owned Port，由 application/host 注入；领域不直接调用对方 concrete service。
 
-* 必须继承自 `AggregateRoot<TId>` 或 `Entity<TId>`。
-* 必须实现 `contracts` 中定义的 Server 接口（如 `AccountServer`）。
-* 聚合根标识类型必须使用强类型 `xxId`；禁止 `xxUuid` 类型和字段命名。
-* 当前项目中 `Account` 与 `Identity` 聚合根的主标识字段统一为 `identityId`。
+## 3. 领域模型不是 Wire DTO
 
-### 3.2 状态管理 (State)
+领域模型是业务行为和不变量的 source of truth；contracts 中的 request、snapshot、event 和 public failure
+是边界投影。
 
-* **Private Fields**: 所有状态必须是 `private` 的。
-* **Value Objects**: 极度推荐使用 `domain-shared` 中的值对象来封装状态（如 `Email`, `PhoneNumber`），而不是 `string`。
-* **Readonly Getters**: 通过 `public get` 暴露状态，确保外部只读。
+禁止：
 
-### 3.3 构造与工厂 (Construction)
+```ts
+export class Task implements TaskServerDTO {
+  // 领域类被 wire shape 约束
+}
+```
 
-* **Constructor**: 必须为 `private`。禁止外部 `new Account(...)`。
-* **Static create(...)**: 业务工厂。用于创建**新**实体。负责生成 ID、默认值、初始校验。
-* **Static fromPersistenceDTO(...)**: 重建工厂。用于从数据库**恢复**实体。不应包含业务校验。
+推荐：
 
-### 3.4 业务方法 (Business Methods)
+```text
+CreateTaskCommand contract
+  -> application mapper
+  -> Task.create(domain input)
 
-* **命名**: 使用**业务动词** (e.g., `close()`, `changePassword()`, `verifyEmail()`)，而不是 `setStatus()`, `setReason()`。
-* **流程**:
-1. **Check**: 检查业务规则（如果不满足，抛出 Error）。
-2. **Act**: 修改内部私有状态。
-3. **Event**: 调用 `this.addDomainEvent(...)`，且 payload 类型必须来自 `@memoflow/contracts` 中的 `protocol/*-event-map.ts`。
+Task aggregate
+  -> application mapper
+  -> TaskSnapshot contract
 
+TaskDomainFault
+  -> application mapper
+  -> TaskFailure contract
+```
 
+领域对象不提供 `toClientDTO()`。也不强制提供 `toPersistenceDTO()`；持久化 shape 属于 infrastructure mapper。
 
-### 3.5 序列化 (Serialization)
+## 4. 聚合、实体和值对象
 
-* **必须包含**: `toPersistenceDTO()`，用于 Repository 持久化。
-* **禁止包含**: `toClientDTO()`。Server 模型不应关心前端如何展示数据。
+### 4.1 状态封装
 
----
+- 状态默认 private；
+- 外部通过只读 getter 或明确 snapshot 访问；
+- 状态变化只通过业务动词方法；
+- 禁止通用 `setStatus()`、`setField()` 绕过规则；
+- 对集合返回 readonly view 或复制，避免外部直接 mutation。
 
-## 4. 代码模板 (AI 参照标准)
+### 4.2 构造
 
-请 AI 在生成代码时严格参照以下模板：
+推荐区分：
 
-```typescript
-import { AggregateRoot } from '@memoflow/utils';
-// 1. 引入 Contract 定义 (DTO 和 Events)
-import type { UserPersistenceDTO, UserServerDTO } from '@memoflow/contracts/user';
-import type { UserEventMap } from '@memoflow/contracts/user';
-// 2. 引入 Shared 值对象
-import { UserId, Email, UserStatus } from '@memoflow/domain-shared/user';
+- `create(...)`：新建，执行创建不变量，产生创建事实；
+- `rehydrate(...)`：从 domain state 重建，不执行会改变历史含义的新业务动作；
+- infrastructure mapper：Prisma/PowerSync row ↔ domain state；
+- application mapper：contract command/snapshot ↔ domain input/output。
 
-export class User extends AggregateRoot<UserId> {
-  // ================= 内部状态 =================
-  private _email: Email;
-  private _status: UserStatus;
-  private _updatedAt: Date;
+不要把 Prisma row 或 public DTO 直接作为 aggregate constructor props。
 
-  // ================= 构造函数 =================
-  private constructor(props: UserServerDTO) {
-    super(UserId.of(props.id));
-    this._email = Email.create(props.email); // 使用值对象工厂
-    this._status = UserStatus.of(props.status);
-    this._updatedAt = new Date(props.updatedAt);
-  }
+### 4.3 ID 和时间
 
-  // ================= Getters =================
-  get email(): Email { return this._email; }
-  get status(): UserStatus { return this._status; }
-  get updatedAt(): Date { return this._updatedAt; }
+- ID 使用 feature/domain-owned value object；
+- 字段命名使用 `*Id`；
+- domain time 使用项目时间体系中的 domain primitive；
+- wire timestamp/date 由 mapper 转换；
+- 不在领域方法中直接调用 `new Date()`/`Date.now()` 作为不可替换全局依赖，优先显式传入 `now`/clock。
 
-  // ================= 工厂方法 =================
-  
-  // 1. 创建新用户 (业务入口)
-  public static create(emailStr: string): User {
-    // 业务规则：初始创建逻辑
-    const user = new User({
-      id: UserId.generate().toString(),
-      email: { address: emailStr, isVerified: false }, // 构造 DTO
-      status: UserStatus.PENDING,
-      updatedAt: Date.now()
-    });
-    
-    // 发出创建事件
-    user.addDomainEvent<UserEventMap['user:registered']>('user:registered', {
-      email: emailStr
-    });
-    
-    return user;
-  }
+## 5. Domain Fault
 
-  // 2. 从数据库恢复 (持久化入口)
-  public static fromPersistenceDTO(dto: UserPersistenceDTO): User {
-    return new User({
-      id: dto.id,
-      email: dto.email, // 假设结构匹配
-      status: dto.status,
-      updatedAt: dto.updatedAt.getTime()
-    });
-  }
+### 5.1 定义位置
 
-  // ================= 业务行为 =================
+```text
+packages/<feature>/src/server/domain/faults/**
+```
 
-  /**
-   * 激活用户
-   */
-  public activate(): void {
-    // 1. 规则校验
-    if (this._status === UserStatus.ACTIVE) {
-      return; // 幂等处理
+Domain Fault 表达业务规则为什么拒绝，不等同于 HTTP error 或 UI message。
+
+推荐 discriminated union：
+
+```ts
+export type TaskDomainFault =
+  | {
+      readonly kind: 'TaskAlreadyCompleted';
+      readonly taskId: TaskId;
     }
-    if (this._status === UserStatus.BANNED) {
-      throw new Error('Cannot activate banned user');
+  | {
+      readonly kind: 'TaskArchived';
+      readonly taskId: TaskId;
     }
+  | {
+      readonly kind: 'TaskHierarchyCycle';
+      readonly parentId: TaskId;
+    };
+```
 
-    // 2. 状态变更
-    this._status = UserStatus.ACTIVE;
-    this._updatedAt = new Date();
+### 5.2 Domain Fault 禁止字段
 
-    // 3. 发出事件
-    this.addDomainEvent<UserEventMap['user:activated']>('user:activated', {
-      userId: this.id.toString(),
-      timestamp: Date.now()
-    });
+- HTTP status；
+- public failure code（除非二者经决策明确完全同一语义，默认不是）；
+- i18n key / 用户文案；
+- provider code/status/message；
+- Error cause/stack；
+- requestId/traceId/timestamp；
+- arbitrary `context: Record<string, unknown>`。
+
+### 5.3 Fault、Decision 与异常
+
+领域方法可以采用两种方式：
+
+#### 显式 decision
+
+适合预期拒绝和需要调用方穷尽处理的动作：
+
+```ts
+export type CompleteTaskDecision =
+  | { readonly ok: true; readonly transition: TaskCompletedTransition }
+  | { readonly ok: false; readonly fault: TaskDomainFault };
+```
+
+#### feature-local fault exception
+
+适合深层调用需要中断控制流时：
+
+```ts
+export class TaskDomainFaultError extends Error {
+  constructor(readonly fault: TaskDomainFault) {
+    super(fault.kind);
+    this.name = 'TaskDomainFaultError';
+  }
+}
+```
+
+该异常只在 feature 内部使用，不实现 `toJSON()`，不携带 HTTP status，不直接出 application boundary。
+
+### 5.4 Programmer Error
+
+非法构造、穷尽 switch 缺失、无法到达状态属于 programmer/invariant error，不要伪装为用户可修复 Domain Fault。
+它们应 fail closed，由 observer 记录，边界返回 safe internal failure。
+
+## 6. Domain Outcome 与 Application Outcome
+
+领域方法可返回领域 decision/transition；跨边界的正常分支由 application 定义 Operation Outcome。
+
+例如领域只知道：
+
+```ts
+{
+  kind: 'CredentialsAcceptedButIdentityUnverified';
+}
+```
+
+Application 决定公开为：
+
+```ts
+{
+  kind: ('email_verification_required', email);
+}
+```
+
+不要让领域层知道 Web scene、toast、HTTP 403 或 BetterAuth code。
+
+## 7. 领域行为模板
+
+```ts
+export type RenameGoalFault =
+  | { readonly kind: 'GoalArchived'; readonly goalId: GoalId }
+  | { readonly kind: 'GoalNameUnchanged'; readonly goalId: GoalId };
+
+export type RenameGoalDecision =
+  | {
+      readonly ok: true;
+      readonly transition: {
+        readonly previousName: GoalName;
+        readonly nextName: GoalName;
+      };
+    }
+  | { readonly ok: false; readonly fault: RenameGoalFault };
+
+export class Goal extends AggregateRoot<GoalId> {
+  private nameValue: GoalName;
+  private statusValue: GoalStatus;
+  private updatedAtValue: Instant;
+
+  private constructor(state: GoalState) {
+    super(state.id);
+    this.nameValue = state.name;
+    this.statusValue = state.status;
+    this.updatedAtValue = state.updatedAt;
   }
 
-  // ================= 序列化 =================
-  public toPersistenceDTO(): UserPersistenceDTO {
+  static create(input: CreateGoalDomainInput): Goal {
+    const goal = new Goal({
+      id: input.id,
+      name: input.name,
+      status: GoalStatus.Active,
+      updatedAt: input.now,
+    });
+
+    goal.recordDomainFact({
+      kind: 'GoalCreated',
+      goalId: goal.id,
+      occurredAt: input.now,
+    });
+
+    return goal;
+  }
+
+  static rehydrate(state: GoalState): Goal {
+    return new Goal(state);
+  }
+
+  rename(nextName: GoalName, now: Instant): RenameGoalDecision {
+    if (this.statusValue.isArchived()) {
+      return {
+        ok: false,
+        fault: { kind: 'GoalArchived', goalId: this.id },
+      };
+    }
+
+    if (this.nameValue.equals(nextName)) {
+      return {
+        ok: false,
+        fault: { kind: 'GoalNameUnchanged', goalId: this.id },
+      };
+    }
+
+    const previousName = this.nameValue;
+    this.nameValue = nextName;
+    this.updatedAtValue = now;
+
+    this.recordDomainFact({
+      kind: 'GoalRenamed',
+      goalId: this.id,
+      previousName,
+      nextName,
+      occurredAt: now,
+    });
+
     return {
-      id: this.id,
-      email: this._email.toPersistenceDTO(),
-      status: this._status,
-      updatedAt: this._updatedAt
+      ok: true,
+      transition: { previousName, nextName },
     };
   }
 }
-
 ```
 
----
+上例没有：
 
-## 5. 常见误区检查清单 (Checklist)
+- `409`；
+- `GOAL_RENAME_REJECTED`；
+- 中文/英文文案；
+- Prisma row；
+- provider error；
+- requestId/traceId；
+- API DTO。
 
-在提交代码或生成代码前，请检查：
+这些由外层 mapper 和 adapter 负责。
 
-* [ ] **是否实现了 `toClientDTO`？** (如果有，请删除。Server 模型不负责 API 格式化)
-* [ ] **是否使用了 `public` 属性？** (除了 `readonly` 的 getter，属性必须为 private)
-* [ ] **是否在 `fromPersistenceDTO` 里做了业务校验？** (恢复工厂不应抛出业务错误，相信数据库的数据是合法的)
-* [ ] **事件 Key 与 Payload 类型是否匹配 Contracts？** (确保 `addDomainEvent<EventMap['domain:event']>(...)` 使用 `protocol/*-event-map.ts` 中定义的类型，而不是本地 payload 类型)
-* [ ] **标识字段是否全部为 `*Id` 命名？** (禁止 `*Uuid`，`Account/Identity` 聚合根统一 `identityId`)
-* [ ] **是否引用了具体的 Repository 实现？** (Entity/Aggregate 不应该知道 Repository 的存在)
-* [ ] **时间更新是否自动化？** (修改状态的方法里，记得更新 `updatedAt`)
+## 8. Application Mapper
+
+Application mapper 是领域语义转 public contract 的 owner：
+
+```ts
+export function mapRenameGoalFault(fault: RenameGoalFault): RenameGoalFailure {
+  switch (fault.kind) {
+    case 'GoalArchived':
+      return {
+        code: 'GOAL_RENAME_REJECTED',
+        category: 'conflict',
+        params: { reason: 'archived' },
+        retry: { kind: 'never' },
+      };
+
+    case 'GoalNameUnchanged':
+      return {
+        code: 'GOAL_RENAME_REJECTED',
+        category: 'conflict',
+        params: { reason: 'unchanged' },
+        retry: { kind: 'never' },
+      };
+
+    default:
+      return assertNever(fault);
+  }
+}
+```
+
+Mapper 必须：
+
+- operation-specific；
+- exhaustive；
+- 不解析 message；
+- 不读取 HTTP status；
+- 只产生 JSON-safe params；
+- 由 table-driven tests 锁定。
+
+## 9. Persistence Mapping
+
+持久化 mapper 位于 infrastructure：
+
+```ts
+export function toGoalRow(goal: Goal): GoalPersistenceData { ... }
+export function fromGoalRow(row: GoalRow): Goal { ... }
+```
+
+规则：
+
+- domain 不 import Prisma/PowerSync；
+- mapper 负责 enum、nullable、Decimal、timestamp、ID 转换；
+- mapper 不执行业务决策；
+- rehydrate 不产生新领域事件；
+- persistence error 在 adapter 中映射 technical failure，再由 application 映射 public semantics；
+- domain 不提供面向某一数据库的 `toPersistenceDTO()`。
+
+允许 aggregate 暴露一个纯 domain state snapshot，前提是它不包含 persistence-specific 字段和策略。
+
+## 10. 领域事件与 Durable Event
+
+### 10.1 Domain Fact
+
+领域对象记录业务事实：
+
+```ts
+{
+  kind: ('TaskCompleted', taskId, transitionVersion, occurredAt);
+}
+```
+
+该事实属于 feature domain，可使用 domain value object。
+
+### 10.2 Public/Durable Event
+
+Application/outbox mapper 将 Domain Fact 投影为 contracts 中的 versioned durable event：
+
+```text
+Domain Fact
+  -> application event mapper
+  -> task:completed@v1 contract payload
+  -> outbox
+```
+
+原因：durable event 需要 serialization、schema version、correlation/causation/message metadata，这些不应反向污染 aggregate。
+
+如果现有实现直接使用 contracts event payload，迁移期允许保留，但新增事件优先按上述边界设计。
+
+### 10.3 禁止
+
+- domain 直接发送 EventBus/HTTP/IPC；
+- domain 知道 outbox row；
+- domain event payload 含 provider/transport object；
+- 发布失败被日志吞掉后清空 event buffer；
+- 未版本化的跨进程 durable event。
+
+## 11. Domain-owned Port
+
+领域需要读取业务事实时，可以定义最小 Port：
+
+```ts
+export interface GoalBindingPolicyPort {
+  inspectTarget(input: GoalBindingTarget): Promise<GoalBindingFacts>;
+}
+```
+
+Port 规则：
+
+- consumer-owned；
+- 使用 domain/application neutral input/output；
+- 不返回 Prisma/provider type；
+- 不暴露 HTTP Result；
+- implementation 位于 infrastructure/host adapter；
+- 跨 feature 由 host composer 注入；
+- 不建立万能 repository/service。
+
+纯 repository Port 可以位于 feature domain，但 transaction/orchestration policy通常由 application 组织。
+
+## 12. 测试规范
+
+### Domain tests 只验证
+
+- invariant；
+- state transition；
+- Domain Fault kind/value；
+- idempotency；
+- domain fact；
+- time/ID/value object semantics。
+
+### Domain tests 不验证
+
+- HTTP status；
+- response envelope；
+- i18n 文案；
+- provider message/code；
+- Prisma error code；
+- Vue/Pinia scene；
+- logging output。
+
+Application mapper、transport、provider adapter 和 UI 分别在各自层测试。
+
+## 13. 代码审查 Checklist
+
+### 模型
+
+- [ ] 状态是否通过业务方法变化？
+- [ ] 不变量是否在 owning aggregate/policy 中？
+- [ ] 时间和 ID 是否使用 domain primitive？
+- [ ] `rehydrate` 是否不产生新业务事实？
+
+### Fault
+
+- [ ] 业务拒绝是否使用 typed Domain Fault？
+- [ ] Fault 是否无 HTTP/i18n/provider/trace 字段？
+- [ ] programmer error 是否没有伪装成用户错误？
+- [ ] application mapper 是否 exhaustive？
+
+### 边界
+
+- [ ] 领域类是否错误地 implements wire DTO？
+- [ ] 是否存在 `toClientDTO()` 或 persistence-specific serialization？
+- [ ] 是否 import Prisma/HTTP/UI/provider SDK？
+- [ ] Domain Fact 与 durable event 是否有明确 mapper？
+
+### 测试
+
+- [ ] Domain test 是否只断言 domain semantics？
+- [ ] 新 Fault 是否触发 mapper compile/test 更新？
+- [ ] 没有通过 message snapshot 固化业务协议？
+
+## 14. Legacy 迁移
+
+现有代码中的以下模式按 active architecture plan 分阶段退役：
+
+- `extends DomainError`；
+- domain 返回 generic `ResultError`；
+- domain class `implements` contracts Server DTO；
+- aggregate `toPersistenceDTO()` 绑定数据库 shape；
+- domain method `throw new Error('business message')`；
+- domain 直接使用 public failure/HTTP code；
+- domain 直接发布 raw event bus。
+
+迁移一个 operation 时应同时闭合：Domain Fault → Application Outcome/Failure → Contract → Transport → UI/Test。
+不得只替换 Error class 而保留 message-based protocol。
+
+## 15. 结论
+
+服务端领域层的纯度不是“没有 import Prisma”这么简单。真正的边界是：
+
+```text
+Domain owns business truth and rejection reasons
+Application owns use-case meaning and caller next step
+Contracts own stable boundary representation
+Infrastructure owns technical translation
+Transport owns protocol projection
+```
+
+领域模型越少知道边界细节，MemoFlow 的 Web、Desktop、API、PowerSync 和 provider 才越能共享同一业务语义，
+而不是共享同一批偶然的数据结构。

--- a/docs/standards/failure-and-outcome-contracts.md
+++ b/docs/standards/failure-and-outcome-contracts.md
@@ -1,0 +1,950 @@
+---
+tags:
+  - standards
+  - architecture
+  - contracts
+  - error-handling
+  - outcomes
+description: MemoFlow 领域故障、应用结果、公开失败、provider 映射、传输和 UI 的强制规范
+created: 2026-08-17T00:00:00+09:00
+updated: 2026-08-17T00:00:00+09:00
+---
+
+# Failure and Outcome Contracts / 失败与结果契约规范
+
+## 1. 适用范围
+
+本规范适用于：
+
+- feature domain/application/infrastructure/transport；
+- HTTP、IPC、SSE、PowerSync、durable message；
+- Web/Desktop presentation；
+- BetterAuth、Prisma、GitHub、AI provider 等第三方适配；
+- Result envelope、错误本地化、retry hint、operation retry、recovery、日志与 tracing；
+- unit/integration/parity/E2E tests；
+- 新增或修改任何 machine-readable failure code。
+
+本规范实现 ADR-049。与旧文档冲突时，以 ADR-049 和本文为准。库选型、协议标准和开源实现依据见
+[失败契约库与开源实现研究](../analysis/2026-08-17-failure-contract-library-and-open-source-study.md)。
+
+## 2. 术语
+
+| 术语                    | 定义                                   | 示例                            |
+| ----------------------- | -------------------------------------- | ------------------------------- |
+| Domain Fault            | 领域规则拒绝或不变量失败               | `TaskHierarchyCycle`            |
+| Operation Outcome       | 用例正常结束的分支，包括需下一步的状态 | `email_verification_required`   |
+| Public Failure          | 调用方可稳定处理的失败                 | `AUTH_INVALID_CREDENTIALS`      |
+| Failure Category        | transport-neutral 通用分类             | `conflict`、`unavailable`       |
+| Provider Failure        | 第三方/数据库/SDK 的实现错误           | BetterAuth `EMAIL_NOT_VERIFIED` |
+| Transport Projection    | public failure 到 HTTP/IPC/SSE 的投影  | `conflict -> 409`               |
+| Presentation Projection | code/details 到文案与 recovery 的投影  | 登录页错误 banner               |
+| Diagnostic Failure      | 内部 cause/stack/provider detail       | trace attributes                |
+
+## 3. 快速决策表
+
+遇到一个“错误”时按下表归类：
+
+| 问题                                                 | 是                               | 否                                |
+| ---------------------------------------------------- | -------------------------------- | --------------------------------- |
+| 这是业务上可预期、需要调用方继续下一步的正常状态吗？ | `OperationOutcome`               | 继续                              |
+| 这是领域不变量或状态转换拒绝吗？                     | feature `DomainFault`            | 继续                              |
+| 这是跨边界调用方必须稳定处理的失败吗？               | feature `PublicFailure`          | 继续                              |
+| 这是第三方/DB/SDK/网络细节吗？                       | adapter-private provider failure | 继续                              |
+| 这是 HTTP/IPC/SSE 表达选择吗？                       | transport projection             | 继续                              |
+| 这是排障信息吗？                                     | diagnostic only                  | programmer bug / invariant breach |
+
+不得因为“前端要显示”就把 provider code 放入 contracts；不得因为“两个包都用”就把 domain type
+自动移入 contracts。
+
+## 4. 通用 Public Failure primitive
+
+目标 primitive 应保持 JSON-safe：
+
+```ts
+export const FailureCategories = {
+  Validation: 'validation',
+  Unauthenticated: 'unauthenticated',
+  Permission: 'permission',
+  NotFound: 'not_found',
+  Conflict: 'conflict',
+  RateLimited: 'rate_limited',
+  Unavailable: 'unavailable',
+  Timeout: 'timeout',
+  Canceled: 'canceled',
+  Internal: 'internal',
+} as const;
+
+export type FailureCategory = (typeof FailureCategories)[keyof typeof FailureCategories];
+
+export interface ValidationIssue {
+  readonly path: readonly (string | number)[];
+  readonly code: string;
+  readonly params?: Readonly<Record<string, JsonValue>>;
+}
+
+export type FailureRetryHint =
+  | { readonly kind: 'not_retryable' }
+  | { readonly kind: 'transient' }
+  | { readonly kind: 'after'; readonly afterMs: number };
+
+export interface FailureReference {
+  readonly requestId?: string;
+  readonly traceId?: string;
+}
+
+export interface PublicFailure<Code extends string = string, Details = never> {
+  readonly code: Code;
+  readonly category: FailureCategory;
+  readonly details?: Details;
+  readonly retryHint?: FailureRetryHint;
+  readonly reference?: FailureReference;
+}
+
+export interface OperationRetryPolicy {
+  readonly mode: 'never' | 'safe_read' | 'idempotent_write' | 'transaction' | 'workflow_step';
+  readonly maxAttempts: number;
+  readonly requiresIdempotencyKey: boolean;
+  readonly backoff: BackoffPolicy;
+}
+
+export type RecoveryAction =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'reauthenticate' }
+  | { readonly kind: 'verify_email'; readonly email: string }
+  | { readonly kind: 'correct_input'; readonly fields?: readonly string[] }
+  | { readonly kind: 'resolve_conflict'; readonly resource: string }
+  | { readonly kind: 'retry_manually' };
+```
+
+### 4.1 Zod strict schema requirement
+
+所有 public failure `details` object schema 必须使用 strict mode。Zod 默认会剥离未知键，这不足以
+防止 token、provider body 或任意 context 静默进入后续处理。Registry builder 必须使用 MemoFlow-owned
+strict-object helper，并为 secret/provider-field 添加负向测试。禁止依赖 Zod 未导出的内部类型。
+
+### 4.1 Public Failure 禁止字段
+
+禁止在 canonical public failure 中加入：
+
+- `cause: unknown`；
+- `stack`；
+- Error instance；
+- provider response body；
+- SQL/query；
+- access token、reset token、password；
+- request headers/cookies；
+- arbitrary `context: Record<string, unknown>`；
+- HTTP status；
+- 已翻译 UI 文案。
+
+### 4.2 兼容期 `message`
+
+现有 Result envelope 仍包含 `message`。兼容期规则：
+
+1. message 必须由 MemoFlow 自己的 safe allowlist 生成；
+2. 不允许直接使用 provider/DB/SDK exception message；
+3. UI 不根据 message 分支；
+4. UI 优先按 code/typed details 本地化；
+5. durable receipt 不持久化任意 message；
+6. 新 contract 不把 message 视为稳定字段；
+7. 最终迁移为 optional `fallbackMessage` 或移出 canonical public failure。
+
+### 4.3 Retry hint、operation policy 与 recovery action 必须分离
+
+`FailureRetryHint` 只表达失败的暂态事实，不表达是否安全自动重放业务命令。
+自动 retry 必须由 `OperationRetryPolicy` 结合以下条件决定：
+
+- operation 是 read、idempotent write、transaction 还是 workflow step；
+- 是否存在稳定 idempotency key；
+- 是否已经产生 durable receipt 或部分副作用；
+- attempt budget、deadline、backoff/jitter；
+- cancellation、account closure 和 host lifecycle。
+
+`RecoveryAction` 由 application/presentation 推导，例如 reauthenticate、verify email、correct input 或
+resolve conflict。禁止把 `reauthenticate`、`show_dialog` 等 UI action 塞入 public failure retry hint。
+
+最终允许自动 retry 的条件是：
+
+```text
+failure retry hint
+  ∩ operation retry policy
+  ∩ idempotency/transaction state
+  ∩ attempt budget/deadline
+  ∩ cancellation state
+```
+
+## 5. Feature Public Failure registry
+
+每个 feature 必须拥有自己的 registry，而不是修改全局巨型 enum。
+
+示例：
+
+```ts
+export const AuthFailureCodes = {
+  InvalidCredentials: 'AUTH_INVALID_CREDENTIALS',
+  UserAlreadyExists: 'AUTH_USER_ALREADY_EXISTS',
+  AccountClosed: 'AUTH_ACCOUNT_CLOSED',
+  RateLimited: 'AUTH_RATE_LIMITED',
+  ProviderUnavailable: 'AUTH_PROVIDER_UNAVAILABLE',
+} as const;
+
+export type AuthFailureCode = (typeof AuthFailureCodes)[keyof typeof AuthFailureCodes];
+
+export type AuthFailure =
+  | PublicFailure<'AUTH_INVALID_CREDENTIALS'>
+  | PublicFailure<'AUTH_USER_ALREADY_EXISTS'>
+  | PublicFailure<'AUTH_ACCOUNT_CLOSED'>
+  | PublicFailure<'AUTH_RATE_LIMITED', { retryAfterMs?: number }>
+  | PublicFailure<'AUTH_PROVIDER_UNAVAILABLE'>;
+```
+
+### 5.1 Registry 必须声明的 metadata
+
+机器可读 registry 最终应覆盖：
+
+| 字段              | 含义                                      |
+| ----------------- | ----------------------------------------- |
+| `code`            | wire-stable code                          |
+| `category`        | transport-neutral category                |
+| `operations`      | 哪些 operation 可返回                     |
+| `detailsSchema`   | 该 code 可出 wire 的 typed details        |
+| `retryHint`       | 失败暂态事实，不代表自动执行              |
+| `operationPolicy` | operation-owned retry policy reference    |
+| `recoveryPolicy`  | application/presentation policy reference |
+| `http`            | HTTP adapter override（可选）             |
+| `i18n`            | 必须覆盖的 locale key                     |
+| `telemetry`       | metric/error class，不含敏感数据          |
+| `introducedIn`    | contract version/commit                   |
+| `deprecatedBy`    | 替代 code（可选）                         |
+
+### 5.2 Code 命名
+
+- public failure code 使用 `<FEATURE>_<SEMANTIC>`；
+- 不使用 provider 名：禁止 `BETTER_AUTH_*`、`PRISMA_*`、`GITHUB_HTTP_422`；
+- 不把 HTTP status 写进 code：禁止 `TASK_404`；
+- 不把 UI action 写进 code：禁止 `SHOW_LOGIN_DIALOG`；
+- code 表达稳定业务语义：`TASK_VERSION_CONFLICT`；
+- 一个 code 不能在不同 operation 中表达不同含义；
+- 删除/重命名 public code 必须有显式 migration 和 compatibility fixture。
+
+## 6. Domain Fault 规范
+
+### 6.1 所有权
+
+Domain Fault 定义在 owning feature domain，不定义在 `@memoflow/contracts` 或 `@memoflow/utils`。
+
+```text
+packages/task/src/server/domain/faults/task-domain-fault.ts
+packages/goal/src/server/domain/faults/goal-domain-fault.ts
+```
+
+### 6.2 推荐写法
+
+优先使用 discriminated union：
+
+```ts
+export type GoalDomainFault =
+  | {
+      readonly kind: 'GoalArchived';
+      readonly goalId: GoalId;
+    }
+  | {
+      readonly kind: 'KeyResultWeightExceeded';
+      readonly totalWeight: Weight;
+    }
+  | {
+      readonly kind: 'GoalInvalidDateRange';
+      readonly start: Ymd;
+      readonly target: Ymd;
+    };
+```
+
+需要异常控制流时，可以使用 feature-local wrapper：
+
+```ts
+export class GoalDomainFaultError extends Error {
+  constructor(readonly fault: GoalDomainFault) {
+    super(fault.kind);
+    this.name = 'GoalDomainFaultError';
+  }
+}
+```
+
+wrapper 只用于内部控制流，不实现 `toJSON`，不携带 HTTP status。
+
+### 6.3 Domain Fault 禁止项
+
+```ts
+// 禁止：领域层知道 HTTP 和 UI 文案
+class GoalArchivedError extends DomainError {
+  constructor() {
+    super('GOAL_ARCHIVED', '目标已归档', {}, 409);
+  }
+}
+```
+
+禁止：
+
+- extends 一个提供 HTTP/API/logging 的全局基类；
+- import Express、Axios、Electron、Vue、i18n；
+- 保存 requestId/traceId/timestamp；
+- 保存 provider code/status；
+- 返回已本地化字符串；
+- 用 arbitrary string 代替 discriminator。
+
+### 6.4 Domain validation 与 programmer error
+
+- 用户输入 shape validation：contract/Zod/transport；
+- 业务不变量：domain fault；
+- repository/provider failure：infrastructure failure；
+- “代码不可能到达”的 invariant breach：可以抛 generic programmer error，但必须 fail closed，
+  不能转成用户可处理的 domain failure。
+
+## 7. Application Outcome 规范
+
+### 7.1 正常替代状态使用 outcome
+
+```ts
+export type BeginCloudConnectionOutcome =
+  | {
+      readonly kind: 'connected';
+      readonly profile: CloudProfileSnapshot;
+    }
+  | {
+      readonly kind: 'awaiting_authorization';
+      readonly userCode: string;
+      readonly verificationUrl: string;
+      readonly expiresAt: string;
+    };
+```
+
+不应写成：
+
+```ts
+fail({ code: 'AUTHORIZATION_REQUIRED', message: '...' });
+```
+
+判断依据：如果该状态是产品流程中的预期节点，并且用户/系统有明确下一步，它通常是 outcome。
+
+### 7.2 Operation contract 要具体
+
+推荐：
+
+```ts
+export type SignInResult = Result<SignInOutcome, AuthSignInFailure>;
+export type CompleteTaskResult = Result<CompleteTaskOutcome, CompleteTaskFailure>;
+```
+
+不推荐：
+
+```ts
+Promise<Result<CloudAuthResponse>>;
+Promise<Result<TaskDTO>>;
+```
+
+后者允许任何 string code，调用方无法穷尽处理。
+
+### 7.3 Application mapper
+
+Application 是 domain semantics 到 public semantics 的 owner：
+
+```ts
+export function mapTaskFaultToCompleteFailure(fault: TaskDomainFault): CompleteTaskFailure {
+  switch (fault.kind) {
+    case 'TaskArchived':
+      return {
+        code: 'TASK_COMPLETION_REJECTED',
+        category: 'conflict',
+        details: { reason: 'archived' },
+        retryHint: { kind: 'not_retryable' },
+      };
+    case 'TaskAlreadyCompleted':
+      return assertNever(fault, 'TaskAlreadyCompleted must be represented as an outcome');
+    default:
+      return assertNever(fault);
+  }
+}
+```
+
+Mapper 必须穷尽；新增 domain fault 时编译或测试应失败。
+
+## 8. Provider/Infrastructure Anti-Corruption Layer
+
+### 8.1 Provider code 止于 adapter
+
+```ts
+function mapBetterAuthSignInResponse(
+  response: BetterAuthResponse,
+): Result<SignInOutcome, AuthSignInFailure> {
+  if (response.ok && response.token) {
+    return ok({ kind: 'authenticated', account: ..., session: ... });
+  }
+
+  if (response.status === 403 && response.code === 'EMAIL_NOT_VERIFIED') {
+    return ok({ kind: 'email_verification_required', email: response.email });
+  }
+
+  if (response.code === 'INVALID_EMAIL_OR_PASSWORD') {
+    return fail({
+      code: 'AUTH_INVALID_CREDENTIALS',
+      category: 'unauthenticated',
+      retryHint: { kind: 'not_retryable' },
+    });
+  }
+
+  return fail({
+    code: 'AUTH_PROVIDER_UNAVAILABLE',
+    category: 'unavailable',
+    retryHint: { kind: 'after', afterMs: 1000 },
+  });
+}
+```
+
+Adapter 外禁止出现 `EMAIL_NOT_VERIFIED` 和 `INVALID_EMAIL_OR_PASSWORD`。
+
+### 8.2 Provider diagnostic
+
+需要排障时：
+
+```ts
+observer.recordFailure({
+  operation: 'auth.signIn',
+  provider: 'better-auth',
+  providerCode: payload.code,
+  cause,
+  attributes: { status: response.status },
+});
+```
+
+不得把该对象合并进 `PublicFailure.context`。
+
+### 8.3 Provider status 不能进入 application
+
+禁止：
+
+```ts
+if (error.status === 404) return fail({ code: 'NOT_FOUND', ... });
+```
+
+出现在 application service。
+
+允许：同样代码出现在 GitHub adapter 内，并返回 operation-specific repository failure。
+
+### 8.4 Prisma mapping
+
+Prisma global mapper只能提供最低层 technical classification；最终 public code 必须由 operation context 决定。
+
+例如 P2002：
+
+```text
+create account email unique -> AUTH_USER_ALREADY_EXISTS
+create task occurrence unique -> TASK_OCCURRENCE_ALREADY_EXISTS / idempotent outcome
+create relation unique -> RELATION_ALREADY_EXISTS
+```
+
+不能只因为都是 P2002 就全部返回 generic `CONFLICT`。
+
+## 9. Transport Projection 规范
+
+### 9.1 Shared category default
+
+HTTP adapter 可提供默认映射：
+
+| Category        |          默认 HTTP |
+| --------------- | -----------------: |
+| validation      |                422 |
+| unauthenticated |                401 |
+| permission      |                403 |
+| not_found       |                404 |
+| conflict        |                409 |
+| rate_limited    |                429 |
+| unavailable     |                503 |
+| timeout         |                504 |
+| canceled        | 499 或 host policy |
+| internal        |                500 |
+
+Operation/code 可覆盖，但映射文件属于 HTTP transport，不属于 domain/shared contracts。
+
+### 9.2 HTTP registry
+
+```ts
+export const AuthFailureHttpPolicy = {
+  AUTH_INVALID_CREDENTIALS: { status: 401 },
+  AUTH_USER_ALREADY_EXISTS: { status: 409 },
+  AUTH_ACCOUNT_CLOSED: { status: 403 },
+  AUTH_RATE_LIMITED: { status: 429, retryAfter: true },
+  AUTH_PROVIDER_UNAVAILABLE: { status: 503 },
+} satisfies FailureHttpPolicy<AuthFailureCode>;
+```
+
+`satisfies` 必须让缺失 code 在编译时失败。
+
+### 9.3 IPC/SSE
+
+- IPC 不携带 HTTP status；
+- HTTP 和 IPC 返回相同 outcome/failure code/category/typed details/retryHint；
+- SSE terminal failure event 使用同一 public failure schema；
+- streaming partial content 与 terminal failure 分开；
+- transport parity fixture 必须覆盖 success、normal outcome、public failure 三类。
+
+### 9.4 Unknown failure
+
+未知异常：
+
+- 对用户返回 safe `*_INTERNAL` 或 shared internal category；
+- 对 observer 记录真实 cause；
+- 不把 `error.message` 作为 public fallback；
+- 不猜测 feature code；
+- 不将未知 feature code静默映射成业务 200/400。
+
+## 10. Presentation 与 i18n 规范
+
+### 10.1 State 保存语义，不保存文案
+
+```ts
+const failure = ref<AuthFailure | null>(null);
+const failureMessage = computed(() =>
+  failure.value ? translateAuthFailure(failure.value, t) : null,
+);
+```
+
+禁止：
+
+```ts
+const errorMessage = ref(result.error.message);
+```
+
+### 10.2 Translation registry
+
+```ts
+const AuthFailureMessageKeys = {
+  AUTH_INVALID_CREDENTIALS: 'auth.errors.invalidCredentials',
+  AUTH_USER_ALREADY_EXISTS: 'auth.errors.userAlreadyExists',
+  AUTH_ACCOUNT_CLOSED: 'auth.errors.accountClosed',
+  AUTH_RATE_LIMITED: 'auth.errors.rateLimited',
+  AUTH_PROVIDER_UNAVAILABLE: 'auth.errors.providerUnavailable',
+} satisfies Record<AuthFailureCode, string>;
+```
+
+每个支持 locale 必须覆盖全部 code。缺失 key 是 CI failure，不回退 provider message。
+
+### 10.3 Recovery registry
+
+UI action 与文案分开：
+
+```ts
+function authRecovery(failure: AuthFailure): AuthRecovery {
+  switch (failure.code) {
+    case 'AUTH_INVALID_CREDENTIALS':
+      return { kind: 'stay_on_login', focus: 'password' };
+    case 'AUTH_USER_ALREADY_EXISTS':
+      return { kind: 'offer_sign_in' };
+    case 'AUTH_RATE_LIMITED':
+      return { kind: 'disable_submit', until: ... };
+    case 'AUTH_ACCOUNT_CLOSED':
+      return { kind: 'account_unavailable' };
+    case 'AUTH_PROVIDER_UNAVAILABLE':
+      return { kind: 'retry' };
+  }
+}
+```
+
+不要根据 translated message 决定 recovery。
+
+### 10.4 Durable UI receipt
+
+可持久化：
+
+- public code；
+- safe typed details；
+- failure retry hint；
+- evaluated operation retry state；
+- requestId/traceId reference；
+- operation；
+- timestamp。
+
+禁止持久化：
+
+- password/token；
+- raw message；
+- provider body；
+- Error/cause/stack；
+- arbitrary context。
+
+## 11. Observability 与安全
+
+### 11.1 Public 与 internal 日志分离
+
+日志最少包含：
+
+- operation；
+- public failure code/category；
+- requestId/traceId；
+- provider/providerCode（仅 internal）；
+- retry attempt；
+- outcome kind；
+- safe entity reference。
+
+不得记录 password、token、cookie、OAuth secret、完整 email body、provider response 中的敏感字段。
+
+已被内部 retry/handle 且 operation 最终正常完成的 exception 不应计入该 operation 的 error rate；
+同一个 exception 只在最终负责的 instrumentation boundary 记录一次。`error.type`/failure attributes 必须
+低基数，禁止使用 raw message。Expected outcome 使用 `memoflow.outcome.kind`，不标记 span error。
+
+### 11.2 Metrics
+
+建议统一指标：
+
+```text
+operation_outcome_total{feature,operation,outcome}
+operation_failure_total{feature,operation,code,category}
+provider_failure_total{provider,operation,provider_code}
+operation_retry_total{feature,operation,reason}
+```
+
+业务正常 outcome 不计入 error rate，例如 `email_verification_required`、`waiting_approval`。
+
+### 11.3 用户枚举安全
+
+公开 code 是否暴露资源存在性必须由 feature security policy 决定。例如：
+
+- 登录中的“不存在账号”和“密码错误”统一为 `AUTH_INVALID_CREDENTIALS`；
+- 注册是否返回 `AUTH_USER_ALREADY_EXISTS` 是明确产品/安全决策；
+- password reset 始终返回中性 accepted outcome；
+- webhook signature failure 不返回内部签名细节。
+
+## 12. 库使用边界
+
+### 12.1 默认基础
+
+默认使用 TypeScript discriminated union、`switch + assertNever` 和 Zod boundary schema。
+库不能成为 Domain Fault、Public Failure code、wire schema 或 durable fact 的 owner。
+
+### 12.2 `ts-pattern`
+
+ACR-R02 显示 `ts-pattern` 在小型 mapper 中减少了行数，但 isolated median typecheck 比 native switch
+高约 44%，而 exhaustiveness 能力可由 `switch + assertNever` 获得。因此本轮不加入依赖。
+未来仅当 bounded mapper benchmark 证明显著可读性收益且 affected typecheck 成本可接受时，才可通过
+独立 ADR/PR 提出；禁止机械替换简单分支。
+
+### 12.3 XState
+
+Auth 使用 feature-owned typed reducer，不引入 XState。ACR-R02 中 reducer 与 XState 源码规模相近，
+XState isolated median typecheck 高约 63%，且会引入第二套 actor/snapshot lifecycle。
+未来只有 nested/parallel state、invoked actors、durable resume 等复杂 workflow 才可经独立 ADR/spike 提出；
+XState snapshot 永远不替代 durable receipt/approval/session ledger。
+
+### 12.4 不采用的全局 runtime
+
+本轮不引入 `neverthrow`、Effect、Connect 或 Temporal 作为全仓基础。可借鉴其 API/协议/重试思想，
+但不能形成第二套 Result、schema、DI、transport 或 durable runtime。MemoFlow 可在现有 Result 上增加
+少量自有 combinator，但公共签名仍使用 `@memoflow/contracts/result`。
+
+## 13. 禁止模式
+
+### 13.1 Message branching
+
+```ts
+// 禁止
+if (error.message.includes('Account not found')) { ... }
+if (/timeout/i.test(error.message)) { ... }
+```
+
+允许的唯一例外：无法获得结构化 provider code 的 infrastructure parser，并已在治理 allowlist 登记 owner 和退役日期。
+
+### 13.2 Raw message rethrow
+
+```ts
+// 禁止：丢 code/meta/cause classification
+throw new Error(result.error.message);
+```
+
+替代：
+
+```ts
+throw toPublicFailureException(result.error, result.meta);
+```
+
+或继续返回 typed Result，不从 Result 切换回 generic throw。
+
+### 13.3 UI raw message
+
+```ts
+// 禁止
+errorMessage.value = result.error.message;
+```
+
+替代：保存 typed failure，computed translation。
+
+### 13.4 Domain HTTP status
+
+```ts
+// 禁止
+new GoalArchivedError(..., 409)
+```
+
+HTTP status 由 HTTP adapter 决定。
+
+### 13.5 Provider code leakage
+
+```ts
+// 禁止在 UI/application
+if (error.code === 'EMAIL_NOT_VERIFIED') { ... }
+```
+
+替代：adapter 输出 `email_verification_required` outcome。
+
+### 13.6 Stringly typed status/error
+
+```ts
+// 禁止
+Promise<{ status: 'failed'; error?: string }>;
+```
+
+替代：
+
+```ts
+Promise<TurnOutcome>;
+// completed | aborted | waiting_approval | failed:{ failure: TurnFailure }
+```
+
+### 13.7 Arbitrary public context
+
+```ts
+// 禁止
+fail({ code, message, context: providerResponse as Record<string, unknown> });
+```
+
+替代：为每个 code 定义 typed details schema，并用 secret-negative fixture 验证。
+
+## 14. 测试规范
+
+### 14.1 Domain tests
+
+断言：
+
+- fault `kind`；
+- domain value；
+- state transition；
+- invariant。
+
+不断言 HTTP status、i18n 文案或 provider message。
+
+### 14.2 Application tests
+
+表驱动测试：
+
+```text
+domain fault / port failure
+  -> operation outcome or public failure code/category/details/retryHint
+```
+
+必须覆盖每个 union member，并使用 exhaustive assertions。
+
+### 14.3 Provider adapter tests
+
+使用 provider fixture 测试：
+
+```text
+provider code/status/body
+  -> MemoFlow outcome/failure
+```
+
+断言 provider code/message 不出现在 public payload。
+
+### 14.4 Transport parity tests
+
+同一 canonical fixture 通过 HTTP/IPC：
+
+- data/outcome 相同；
+- public code/category/typed details/retryHint 相同；
+- HTTP status 仅 HTTP projection；
+- unknown/internal failure safe；
+- validation details 相同。
+
+### 14.5 Presentation tests
+
+- code → locale message；
+- locale 切换无需重新请求；
+- code → recovery action；
+- raw message 不渲染；
+- persisted receipt 无 secret/provider content；
+- normal outcome 切换正确 scene/state。
+
+### 14.6 E2E fixture
+
+- fixture 通过 API/DB/global setup 建立；
+- login helper 不自动注册；
+- 不根据可见文案决定数据库动作；
+- signup/login/verification/recovery 分开测试；
+- build revision 在 suite 前校验。
+
+## 15. 文件位置与 export
+
+### 15.1 Feature package
+
+```text
+server/domain/faults/**
+server/application/failures/**
+server/application/outcomes/**
+server/infrastructure/adapters/<provider>/**failure*.ts
+server/transport/http/**failure-http*.ts
+```
+
+### 15.2 Contracts
+
+```text
+modules/<feature>/api/**
+modules/<feature>/failures.ts
+modules/<feature>/outcomes.ts
+modules/<feature>/events/**
+result/public-failure.ts
+result/failure-category.ts
+result/retry-directive.ts
+```
+
+### 15.3 Export policy
+
+- feature root 可以导出 public application/client ports 和 contract-facing types；
+- provider mapper/concrete error 不从 root 导出；
+- domain fault 只在需要 application mapping 时包内导出；
+- contracts subpath 导出 public wire types；
+- 不通过 `@memoflow/utils/errors` 汇总 feature semantics。
+
+## 16. 迁移规则
+
+### 16.1 新代码
+
+从本规范生效起：
+
+- 禁止新增 `DomainError` subclass；
+- 禁止新增 message branching；
+- 禁止新增 provider code 跨 adapter 使用；
+- 新 public operation 必须 typed failure/outcome；
+- 新 feature code 必须注册 i18n/transport/test metadata。
+
+### 16.2 旧代码
+
+迁移一个 operation 时必须完整闭合：
+
+```text
+provider/domain source
+  -> application mapping
+  -> contracts
+  -> HTTP/IPC
+  -> client
+  -> presentation/i18n
+  -> tests/governance
+```
+
+禁止只改其中一层并留下 alias dual-track。
+
+### 16.3 兼容 alias
+
+确需兼容旧 code：
+
+```ts
+const LegacyAuthFailureAliases = {
+  UNAUTHORIZED: 'AUTH_INVALID_CREDENTIALS',
+} as const;
+```
+
+必须有：
+
+- owner；
+- reason；
+- source consumers；
+- removal condition；
+- retire date；
+- compatibility test。
+
+## 17. Code Review Checklist
+
+### Ownership
+
+- [ ] 这是 Domain Fault、Outcome、Public Failure、Provider Failure、Transport 或 Diagnostic 中的哪一种？
+- [ ] 类型位于正确的 owning feature/contract/adapter 吗？
+- [ ] 是否错误地放进 shared/utils/contracts？
+
+### Semantics
+
+- [ ] 正常下一步是否被建模为 outcome，而不是 error？
+- [ ] public code 是否为 MemoFlow-owned，且 operation-specific？
+- [ ] category、retryHint、operation retry policy 与 recovery action 是否分别明确？
+- [ ] code 是否可能泄漏资源存在性或敏感信息？
+
+### Boundary
+
+- [ ] provider code/status/message 是否止于 adapter？
+- [ ] HTTP status 是否只在 transport mapping？
+- [ ] public payload 是否 JSON-safe、无 cause/stack/token？
+- [ ] HTTP/IPC 是否保持 parity？
+
+### Presentation
+
+- [ ] UI 是否保存 code/outcome 而非 message？
+- [ ] 所有 locale 是否覆盖？
+- [ ] locale 切换是否可重新翻译？
+- [ ] recovery 是否基于 code/outcome/typed details，而不是 message 或 retry hint？
+
+### Verification
+
+- [ ] domain/application/adapter/transport/UI tests 是否各自只验证自己的责任？
+- [ ] 是否新增或更新 registry/governance fixture？
+- [ ] 是否避免 raw message snapshot 成为 contract？
+- [ ] compatibility alias 是否有退役条件？
+- [ ] 新库是否通过 approved spike，且没有成为 contract owner？
+- [ ] 自动 retry 是否同时验证了 idempotency、attempt budget 与 durable side-effect state？
+
+## 18. 最小示例：完整垂直链路
+
+```ts
+// 1. Domain
+export type RenameGoalFault =
+  { kind: 'GoalArchived'; goalId: GoalId } | { kind: 'GoalNameTooLong'; maxLength: number };
+
+// 2. Contracts
+export type RenameGoalFailure =
+  | PublicFailure<'GOAL_RENAME_REJECTED', { reason: 'archived' }>
+  | PublicFailure<'GOAL_NAME_INVALID', { maxLength: number }>;
+
+export type RenameGoalOutcome = {
+  kind: 'renamed';
+  goal: GoalSnapshot;
+};
+
+// 3. Application mapper
+export function mapRenameGoalFault(fault: RenameGoalFault): RenameGoalFailure {
+  switch (fault.kind) {
+    case 'GoalArchived':
+      return {
+        code: 'GOAL_RENAME_REJECTED',
+        category: 'conflict',
+        details: { reason: 'archived' },
+        retryHint: { kind: 'not_retryable' },
+      };
+    case 'GoalNameTooLong':
+      return {
+        code: 'GOAL_NAME_INVALID',
+        category: 'validation',
+        details: { maxLength: fault.maxLength },
+        retryHint: { kind: 'not_retryable' },
+      };
+  }
+}
+
+// 4. HTTP
+export const RenameGoalHttpPolicy = {
+  GOAL_RENAME_REJECTED: { status: 409 },
+  GOAL_NAME_INVALID: { status: 422 },
+} satisfies FailureHttpPolicy<RenameGoalFailure['code']>;
+
+// 5. UI
+const messageKey = {
+  GOAL_RENAME_REJECTED: 'goal.errors.renameRejected',
+  GOAL_NAME_INVALID: 'goal.errors.nameInvalid',
+} satisfies Record<RenameGoalFailure['code'], string>;
+```
+
+这条链路中，domain 不知道 HTTP，contracts 不知道 provider，HTTP 不决定业务 code，UI 不读取 raw
+message，observer 仍可记录内部 cause。该结构是 MemoFlow 后续所有 operation 的目标模板。


### PR DESCRIPTION
## Summary

- add the full-application failure/outcome architecture audit and execution-ready refactor plan
- add ADR-049 and supersede/amend the earlier absolute-centralization/error-handling decisions
- compare TypeScript/Zod, ts-pattern, neverthrow, XState, Effect, RFC/AIP/Connect/Temporal, and mature open-source implementations
- record executed ACR-R02 spike evidence and complete ACR-R03 design gate
- freeze the implementation choice: native discriminated unions + switch/assertNever + Zod strict single-source registry; no new Result/state-machine runtime

## Protected contracts

This PR changes documentation only. It does not modify production code, dependencies, lockfiles, routes, HTTP/IPC envelopes, durable receipts, database schemas, Docker configuration, or deployment entry points.

## Validation

- `git diff --check`
- `pnpm exec prettier --check <changed markdown files>`
- `pnpm nx run memoflow:docs-check --skip-nx-cache`
- `pnpm nx run memoflow:governance-check --skip-nx-cache`
- isolated TypeScript/Zod/ts-pattern/neverthrow/XState spikes recorded in `docs/analysis/2026-08-17-failure-contract-spike-evidence.md`
