### PR TITLE
fix(local-validation): harden MagicDNS and scheduler takeover

### DIFF
--- a/apps/web/e2e/dashboard/dashboard-overview.spec.ts
+++ b/apps/web/e2e/dashboard/dashboard-overview.spec.ts
@@ -8,12 +8,12 @@
  *   business context remains in BusinessPanel tabs
  */
 import { test, expect } from '@playwright/test';
-import { login } from '../helpers/testHelpers';
-import { WEB_CONFIG, TIMEOUT_CONFIG, TEST_USERS } from '../config';
+import { registerAndLogin } from '../helpers/testHelpers';
+import { WEB_CONFIG, TIMEOUT_CONFIG } from '../config';
 
 test.describe('Dashboard retirement (V2 shell)', () => {
   test.beforeEach(async ({ page }) => {
-    await login(page, TEST_USERS.MAIN.username, TEST_USERS.MAIN.password);
+    await registerAndLogin(page);
   });
 
   test('[P0] should redirect /dashboard to the AI workspace ground', async ({ page }) => {

--- a/apps/web/e2e/helpers/run-local-docker-playwright.mjs
+++ b/apps/web/e2e/helpers/run-local-docker-playwright.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import {
   createLocalComposeRuntimeEnv,
   localComposeArgs,
+  resolveLocalDockerBrowserValidationOrigins,
 } from '../../../../tools/docker/local-compose.mjs';
 import {
   collectBrowserProbeEvidence,
@@ -19,11 +20,16 @@ const evidencePath = resolve(evidenceDir, 'local-docker-playwright-evidence.json
 
 process.chdir(workspaceRoot);
 const env = createLocalComposeRuntimeEnv({ quiet: true });
-env.E2E_WEB_BASE_URL = `http://127.0.0.1:${env.WEB_HOST_PORT}`;
-env.E2E_API_BASE_URL = `http://127.0.0.1:${env.API_HOST_PORT}`;
+const validationOrigins = resolveLocalDockerBrowserValidationOrigins({
+  apiHostPort: env.API_HOST_PORT,
+  webHostPort: env.WEB_HOST_PORT,
+  authBaseUrl: env.AUTH_BASE_URL,
+  webUrl: env.MEMOFLOW_WEB_URL,
+});
+env.E2E_WEB_BASE_URL = validationOrigins.webOrigin;
+env.E2E_API_BASE_URL = validationOrigins.apiOrigin;
 env.E2E_API_FULL_URL = `${env.E2E_API_BASE_URL}/api/v1`;
-env.E2E_LOCAL_DOCKER_PROBE_TOKEN =
-  `pm-local-docker-browser-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+env.E2E_LOCAL_DOCKER_PROBE_TOKEN = `pm-local-docker-browser-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 const runtimeEvidence = await collectLocalDockerRuntimeEvidence({
   workspace: workspaceRoot,

--- a/apps/web/e2e/user-settings/persistence.spec.ts
+++ b/apps/web/e2e/user-settings/persistence.spec.ts
@@ -98,15 +98,20 @@ async function openNotificationsSettings(page: Page) {
 }
 
 async function selectTheme(page: Page, theme: 'light' | 'dark' | 'auto') {
+  const trigger = themeTrigger(page);
+  const option = page.getByTestId(`appearance-theme-option-${theme}`);
+  await expect(trigger).toBeVisible({ timeout: TIMEOUT_CONFIG.ELEMENT_WAIT });
+  await expect(trigger).toBeEnabled({ timeout: TIMEOUT_CONFIG.ELEMENT_WAIT });
+  await trigger.click();
+  await expect(option).toBeVisible({ timeout: TIMEOUT_CONFIG.ELEMENT_WAIT });
+
   const patchResponse = page.waitForResponse(
     (response) =>
       response.url().endsWith('/api/v1/settings/appearance') &&
       response.request().method() === 'PATCH' &&
       response.ok(),
   );
-
-  await themeTrigger(page).click();
-  await page.getByTestId(`appearance-theme-option-${theme}`).click();
+  await option.click();
   await patchResponse;
 }
 
@@ -134,10 +139,17 @@ async function resetSettings(page: Page) {
   }, API_CONFIG.API_PREFIX);
   await resetResponse;
 
+  const hydratedSettings = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/api/v1/settings') &&
+      response.request().method() === 'GET' &&
+      response.ok(),
+  );
   await page.goto('/settings', {
     waitUntil: 'domcontentloaded',
     timeout: TIMEOUT_CONFIG.NAVIGATION,
   });
+  await hydratedSettings;
 }
 
 async function toggleSwitch(page: Page, locator: Locator) {

--- a/apps/web/playwright.local-docker.config.ts
+++ b/apps/web/playwright.local-docker.config.ts
@@ -11,7 +11,13 @@ if (!webOrigin || !apiOrigin) {
 
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['**/local-docker/core-product-phase-*.spec.ts'],
+  testMatch: [
+    '**/authentication/auth-flow.spec.ts',
+    '**/authentication/auth-login.spec.ts',
+    '**/authentication/auth-password.spec.ts',
+    '**/authentication/auth-register.spec.ts',
+    '**/local-docker/core-product-phase-*.spec.ts',
+  ],
   globalSetup: './e2e/local-docker/global-setup.ts',
   timeout: 5 * 60 * 1000,
   expect: { timeout: 15 * 1000 },

--- a/apps/web/playwright.server.ts
+++ b/apps/web/playwright.server.ts
@@ -233,7 +233,7 @@ export function createWebServer(url = `${getE2EWebOrigin()}/auth`) {
   return {
     // Call the Vite entrypoint through the current Node binary so Playwright can
     // tear the dev server down cleanly on Windows without leaving a pnpm/cmd tree behind.
-    command: `${quoteShellArgument(process.execPath)} ${quoteShellArgument(VITE_BIN_PATH)} --config vite.config.ts --host ${webServer.host} --port ${webServer.port}`,
+    command: `${quoteShellArgument(process.execPath)} ${quoteShellArgument(VITE_BIN_PATH)} --config vite.config.ts --host ${webServer.host} --port ${webServer.port} --strictPort`,
     cwd: '.',
     url,
     env: {

--- a/apps/web/src/playwright.server.spec.ts
+++ b/apps/web/src/playwright.server.spec.ts
@@ -72,9 +72,8 @@ describe('playwright.server', () => {
     delete process.env.E2E_API_FULL_URL;
     delete process.env.CORS_ORIGIN;
 
-    const { createApiServer, createWebServer, getE2EWebOrigin } = await import(
-      '../playwright.server'
-    );
+    const { createApiServer, createWebServer, getE2EWebOrigin } =
+      await import('../playwright.server');
 
     const apiServer = createApiServer();
     const webServer = createWebServer();
@@ -86,7 +85,7 @@ describe('playwright.server', () => {
     expect(webServer.url).toBe('http://localhost:4173/auth');
     expect(getE2EWebOrigin()).toBe('http://localhost:4173');
     expect(webServer.command).toBe(
-      `"${process.execPath}" "${resolve(workspaceRoot, 'node_modules/vite/bin/vite.js')}" --config vite.config.ts --host localhost --port 4173`,
+      `"${process.execPath}" "${resolve(workspaceRoot, 'node_modules/vite/bin/vite.js')}" --config vite.config.ts --host localhost --port 4173 --strictPort`,
     );
     expect(webServer.env?.PROXY_TARGET_URL).toBe('http://127.0.0.1:3001');
     expect(process.env.E2E_API_FULL_URL).toBe('http://127.0.0.1:3001/api/v1');

--- a/docs/plan/active/2026-08-18-oracle2-hermes-local-validation-hardening.md
+++ b/docs/plan/active/2026-08-18-oracle2-hermes-local-validation-hardening.md
@@ -1,0 +1,137 @@
+# Oracle2 / Hermes2 本地部署与产品流验证加固计划
+
+> 状态：实施中  
+> 日期：2026-08-18  
+> 基线：`def2b2cd88c73c880f9f2c2fcf55c109a8728103`  
+> 范围：Test System V2、local-docker prod-like 验收、Tailscale MagicDNS 公网面配置。  
+> 非范围：ADR-049 全应用 219 个历史 failure-contract finding 的本轮清零；该工作继续由 application-contract-refactor 主计划负责。
+
+## 1. 目标
+
+在开发主机迁回 Oracle2 / Hermes2 后，建立一条可重复、可审计的验证链：
+
+1. 代码级 Auth / HTTP / Web / governance 验证先于人工验收；
+2. required Web Flow 覆盖真实注册、邮箱验证、登出、再次登录、错误密码与密码恢复；
+3. prod-like Docker 验收继续验证业务主旅程，并显式加入关键 Auth 产品流；
+4. local-docker 的公开 Web、API/Auth、PowerSync URL 可通过 `.env.local` 切换到 Tailscale MagicDNS；
+5. API BetterAuth trusted origins 与 AI CORS 自动包含公开 Web origin；
+6. Docker Playwright 使用实际公开 URL，而不是无条件回退 `127.0.0.1`，从而验证用户最终访问的网络路径；
+7. 验收镜像必须来自 clean Git revision，并通过 `validate-local-deploy` 证据收集。
+
+## 2. 审计基线
+
+### 2.1 已确认有效
+
+- Test System V2 inventory / ruleset / Oracle 聚合均可运行；
+- `main` required checks 包含 Governance / Validate / Boundary / Integration / Web Flow / Coverage / Performance / Delivery Observation Oracle；
+- Web Flow 共 74 个测试，Auth required specs 覆盖注册、验证、登录、错误密码、OAuth 入口、密码重置；
+- local-docker A-E 产品旅程使用真实 UI 注册 + 捕获验证链接 + authenticated shell；
+- Docker API/Web/AI/PowerSync 已绑定主机端口，Oracle2 MagicDNS 可到达现有 Web/API 端口。
+
+### 2.2 本轮必须修复的缺口
+
+1. `MEMOFLOW_WEB_URL` 的 MagicDNS origin 未自动加入 API/AI allowlist；
+2. 机器级 `POWERSYNC_URL` 会被 local-compose 强制覆盖回 `localhost`；
+3. local-docker Playwright 无条件使用 `127.0.0.1`，没有验证公开 URL 路径；
+4. prod-like Docker suite 没有显式跑 logout/re-login、wrong-password、password-reset 等 Auth 关键流；
+5. required Dashboard Web Flow 仍通过通用 `login()` 的 UI-message fallback 隐式注册测试用户，fixture 前置条件不够确定；
+6. Oracle2 单 worker 全量 Web Flow 暴露 scheduler crash-leftover lease：宿主首次抢占失败后永久停留 read-model，无法在 lease 到期后自动接管；
+7. Settings 主题持久化测试在长时间套件中可能在 settings hydration 完成前打开 Select，造成瞬时关闭与假失败；
+8. Vite 端口被其他网卡/容器占用时会自动漂移到下一端口，而 Playwright 继续等待原端口，失败反馈过慢。
+
+### 2.3 本轮不假装完成的结构性债务
+
+ADR-049 仍在实施。当前 failure-contract inventory 仍有 219 个历史 finding：
+
+- 51 `DOMAIN_ERROR_SUBCLASS`
+- 54 `FAILURE_MESSAGE_BRANCH`
+- 6 `PROVIDER_CODE_LEAKAGE`
+- 26 `RAW_RESULT_MESSAGE_RETHROW`
+- 82 `UI_RAW_RESULT_MESSAGE`
+
+治理已对“新增 finding” fail closed，但历史 finding 尚未清零，因此不能宣称全应用错误契约重构完成。
+
+## 3. 实施批次
+
+### O2V-01 — Machine-public URL closure
+
+- 保留显式机器级 `POWERSYNC_URL`；
+- 将 `MEMOFLOW_WEB_URL` 规范化为 origin，并加入 API/AI allowlist；
+- 提供纯函数测试 MagicDNS URL、默认 localhost 与 browser validation origins。
+
+验收：Node governance tests 全绿，MagicDNS 模拟 env 输出与预期一致。
+
+### O2V-02 — Prod-like browser path
+
+- local-docker Playwright 的 Web origin 使用 `MEMOFLOW_WEB_URL`；
+- API origin 从 `AUTH_BASE_URL` 取 origin；
+- 默认无机器覆盖时行为保持 localhost/隔离端口兼容。
+
+验收：Playwright 实际访问 URL 与容器 public runtime config 一致。
+
+### O2V-03 — Auth Docker acceptance
+
+在 local-docker 配置中加入：
+
+- `authentication/auth-flow.spec.ts`
+- `authentication/auth-login.spec.ts`
+- `authentication/auth-register.spec.ts`
+- `authentication/auth-password.spec.ts`
+
+同时 required Dashboard flow 改为显式 `registerAndLogin()`，不再依赖 UI message 猜测 fixture 是否存在。
+
+验收：本地 Docker Auth + A-E 产品流全绿。
+
+### O2V-03B — Long-suite determinism
+
+- Vite WebServer 使用 `--strictPort`，端口冲突立即失败；
+- Schedule standby host 在 lease 未获取时周期重试，并在 crash-leftover lease 到期后自动 promotion；
+- Prisma lease 唯一约束竞争 `P2002` 按正常 `not acquired` 处理，不作为基础设施异常；
+- Settings persistence 测试在 reset 后等待 settings GET hydration，再进行 Select 交互。
+
+验收：Schedule lease/runtime 单测、Settings focused E2E 与 required Web Flow 全绿。
+
+### O2V-04 — Oracle2 deployment evidence
+
+Oracle2 `.env.local` 使用：
+
+- `AUTH_BASE_URL=http://oracle.taile92a8e.ts.net:<api>/api/auth`
+- `MEMOFLOW_WEB_URL=http://oracle.taile92a8e.ts.net:<web>`
+- `POWERSYNC_URL=http://oracle.taile92a8e.ts.net:<powersync>`
+
+然后：
+
+1. clean revision 重建 Docker；
+2. 校验所有容器 healthy；
+3. 校验 OCI revision == Git HEAD；
+4. 运行 local-docker Playwright；
+5. 运行 `validate-local-deploy`；
+6. 从 MagicDNS URL 发起浏览器注册 / 验证 / 登录产品流；
+7. 保留 stack 供人工验收。
+
+### O2V-05 — Hermes2 parity
+
+在 Hermes2 连接可用后重复 O2V-04，不复用 Oracle2 的端口假设或环境文件。
+
+阻塞条件：Hermes2 必须出现在可用控制通道或 Tailnet/SSH 可达节点中。当前 Oracle2 的 `tailscale status` 与 SSH 配置均未发现 Hermes2，因此本批次在连接恢复前不得伪造为已验证。
+
+## 4. 验证矩阵
+
+| 层级                 | 命令 / 证据                                                  | Gate                    |
+| -------------------- | ------------------------------------------------------------ | ----------------------- |
+| Failure governance   | `pnpm nx run memoflow:governance-check --skip-nx-cache`      | PASS                    |
+| Auth unit            | `pnpm nx run cloud-auth:test --skip-nx-cache`                | PASS                    |
+| Web unit             | `pnpm nx run web:test --skip-nx-cache`                       | PASS                    |
+| Required Web Flow    | `pnpm exec playwright test --config=playwright.config.ts`    | 74/74                   |
+| Local compose tests  | `node --test tools/docker/local-compose.env-shadow.spec.mjs` | PASS                    |
+| Local Docker runtime | `pnpm docker:local:ps`                                       | all healthy             |
+| Docker product/Auth  | `pnpm nx run web:e2e:local-docker`                           | PASS                    |
+| Deployment evidence  | validate-local-deploy skill runner                           | PASS                    |
+| MagicDNS             | Browser + HTTP probes to `oracle.taile92a8e.ts.net`          | PASS                    |
+| Hermes2              | same matrix on Hermes2                                       | BLOCKED until reachable |
+
+## 5. 回滚
+
+- `.env.local` / `.env.test.local` 均为机器文件，不提交；删除即可恢复默认 localhost；
+- source change 保持纯配置解析与测试范围，不改 DB schema、Auth storage 或业务 API；
+- Docker 回滚使用上一个 clean image revision，禁止保留 `-dirty` 镜像作为验收证据。

--- a/docs/plan/active/README.md
+++ b/docs/plan/active/README.md
@@ -75,3 +75,5 @@ updated: 2026-08-17T00:00:00+09:00
 - 新计划默认放这里
 - 文件名使用 `YYYY-MM-DD-topic-slug.md`
 - 计划完成、终止或只保留历史参考价值后，移动到 `../archive`
+
+- [Oracle2 / Hermes2 本地部署与产品流验证加固计划](./2026-08-18-oracle2-hermes-local-validation-hardening.md)

--- a/packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.spec.ts
+++ b/packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createScheduleLeasePrismaRepository } from './schedule-lease.repository';
+
+function request() {
+  const now = Date.now();
+  return {
+    leaseKey: 'schedule-host',
+    ownerToken: 'owner-a',
+    now,
+    expiresAt: now + 60_000,
+  };
+}
+
+describe('createScheduleLeasePrismaRepository', () => {
+  it('projects a concurrent P2002 lease race to not-acquired', async () => {
+    const transactionLease = {
+      deleteMany: vi.fn(async () => ({ count: 0 })),
+      create: vi.fn(async () => {
+        throw Object.assign(new Error('unique lease race'), { code: 'P2002' });
+      }),
+    };
+    const db = {
+      $transaction: vi.fn(async (work: (tx: unknown) => Promise<unknown>) =>
+        work({ scheduleLease: transactionLease }),
+      ),
+    };
+
+    const repository = createScheduleLeasePrismaRepository(db as never);
+
+    await expect(repository.tryAcquire(request())).resolves.toBe(false);
+  });
+
+  it('does not hide unexpected lease repository failures', async () => {
+    const failure = new Error('database unavailable');
+    const db = {
+      $transaction: vi.fn(async () => {
+        throw failure;
+      }),
+    };
+    const repository = createScheduleLeasePrismaRepository(db as never);
+
+    await expect(repository.tryAcquire(request())).rejects.toBe(failure);
+  });
+});

--- a/packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.ts
+++ b/packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.ts
@@ -7,22 +7,37 @@ export function createScheduleLeasePrismaRepository(
   return {
     async tryAcquire(request): Promise<boolean> {
       const now = new Date(request.now);
-      await db.$transaction(async (tx) => {
-        // 1) 清掉已过期的旧租约（原子抢占前提）。
-        await tx.scheduleLease.deleteMany({
-          where: { leaseKey: request.leaseKey, expiresAt: { lte: now } },
+      try {
+        await db.$transaction(async (tx) => {
+          // 1) 清掉已过期的旧租约（原子抢占前提）。
+          await tx.scheduleLease.deleteMany({
+            where: { leaseKey: request.leaseKey, expiresAt: { lte: now } },
+          });
+          // 2) 抢占：键不存在才创建（并发下只有一个成功）。
+          await tx.scheduleLease.create({
+            data: {
+              id: `${request.leaseKey}:${request.ownerToken}`,
+              leaseKey: request.leaseKey,
+              ownerToken: request.ownerToken,
+              expiresAt: new Date(request.expiresAt),
+            },
+          });
         });
-        // 2) 抢占：键不存在才创建（并发下只有一个成功）。
-        await tx.scheduleLease.create({
-          data: {
-            id: `${request.leaseKey}:${request.ownerToken}`,
-            leaseKey: request.leaseKey,
-            ownerToken: request.ownerToken,
-            expiresAt: new Date(request.expiresAt),
-          },
-        });
-      });
-      return true;
+        return true;
+      } catch (error) {
+        // `tryAcquire` 的并发 loser 是正常的租约竞争结果，不是基础设施故障。
+        // Prisma 用 P2002 表示 lease_key 唯一约束冲突；与 PowerSync adapter
+        // 一致，将它投影为 false，让 coordinator 可以进入 standby/retry。
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          (error as { code?: unknown }).code === 'P2002'
+        ) {
+          return false;
+        }
+        throw error;
+      }
     },
 
     async renew(request): Promise<boolean> {
@@ -71,10 +86,10 @@ export function createScheduleLeasePowerSyncRepository(
       const expiresIso = new Date(request.expiresAt).toISOString();
       const id = `${request.leaseKey}:${request.ownerToken}`;
 
-      await db.execute(
-        'DELETE FROM schedule_leases WHERE lease_key = ? AND expires_at <= ?',
-        [request.leaseKey, nowIso],
-      );
+      await db.execute('DELETE FROM schedule_leases WHERE lease_key = ? AND expires_at <= ?', [
+        request.leaseKey,
+        nowIso,
+      ]);
 
       try {
         await db.execute(
@@ -100,10 +115,10 @@ export function createScheduleLeasePowerSyncRepository(
 
     async release(leaseKey, ownerToken): Promise<void> {
       await ensureTable();
-      await db.execute(
-        'DELETE FROM schedule_leases WHERE lease_key = ? AND owner_token = ?',
-        [leaseKey, ownerToken],
-      );
+      await db.execute('DELETE FROM schedule_leases WHERE lease_key = ? AND owner_token = ?', [
+        leaseKey,
+        ownerToken,
+      ]);
     },
   };
 }

--- a/packages/schedule/src/server/infrastructure/runtime/schedule.runtime.spec.ts
+++ b/packages/schedule/src/server/infrastructure/runtime/schedule.runtime.spec.ts
@@ -7,7 +7,12 @@ import {
 } from '@memoflow/contracts/schedule';
 import { ScheduleTask } from '../../domain/aggregates/schedule-task';
 import type { IScheduleTaskRepository } from '../../domain/repositories/i-schedule-task-repository';
-import { ExecutionInfo, RetryPolicy, ScheduleConfig, ScheduleTaskMetadata } from '../../domain/value-objects';
+import {
+  ExecutionInfo,
+  RetryPolicy,
+  ScheduleConfig,
+  ScheduleTaskMetadata,
+} from '../../domain/value-objects';
 import { ScheduleTaskId } from '../../domain/value-objects/schedule-task-id';
 
 const mocked = vi.hoisted(() => {
@@ -91,8 +96,7 @@ vi.mock('../../application/scheduler/schedule-task-queue', () => {
     start(): Promise<void> {
       this.startPromise = (async () => {
         const taskLoader = this.config.taskLoader as
-          | { loadActiveTasks(): Promise<unknown[]> }
-          | undefined;
+          { loadActiveTasks(): Promise<unknown[]> } | undefined;
         this.loadedItems = taskLoader ? await taskLoader.loadActiveTasks() : [];
       })();
 
@@ -245,7 +249,8 @@ async function flushAsyncWork(): Promise<void> {
 }
 
 function getLastQueue(): MockQueueInstance {
-  const queue = mocked.queueInstances[mocked.queueInstances.length - 1] as MockQueueInstance | undefined;
+  const queue = mocked.queueInstances[mocked.queueInstances.length - 1] as
+    MockQueueInstance | undefined;
   if (!queue) {
     throw new Error('Expected a mocked queue instance');
   }
@@ -312,6 +317,79 @@ describe('createScheduleRuntimeContribution', () => {
     expect(mocked.loggerInfo).toHaveBeenCalledWith('[Schedule] Runtime contribution started');
   });
 
+  it('promotes a standby host after the scheduler lease becomes available', async () => {
+    vi.useFakeTimers();
+    try {
+      const repository = createRepositoryMock();
+      repository.findEnabled.mockResolvedValue([]);
+      const leaseCoordinator = {
+        acquire: vi
+          .fn()
+          .mockResolvedValueOnce({ acquired: false })
+          .mockResolvedValueOnce({ acquired: true, ownerToken: 'standby-owner' }),
+        release: vi.fn(async () => undefined),
+      };
+      const runtime = createScheduleRuntimeContribution({
+        scheduleTaskRepository: repository,
+        sourceExecutor: { execute: vi.fn(async () => undefined) },
+        leaseCoordinator: leaseCoordinator as never,
+        leaseRetryIntervalMs: 250,
+      });
+
+      await runtime.start();
+      const queue = getLastQueue();
+      expect(leaseCoordinator.acquire).toHaveBeenCalledTimes(1);
+      expect(queue.startPromise).toBeNull();
+      expect(mocked.eventBus.on).toHaveBeenCalledTimes(9);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await flushAsyncWork();
+
+      expect(leaseCoordinator.acquire).toHaveBeenCalledTimes(2);
+      expect(queue.startPromise).not.toBeNull();
+      expect(repository.findEnabled).toHaveBeenCalledTimes(1);
+      expect(mocked.eventBus.on).toHaveBeenCalledTimes(9);
+      expect(mocked.loggerInfo).toHaveBeenCalledWith(
+        '[Schedule] Standby host promoted to scheduler (lease held)',
+      );
+
+      await runtime.stop();
+      expect(leaseCoordinator.release).toHaveBeenCalledWith('schedule-host', 'standby-owner');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels standby lease retries when the runtime stops before promotion', async () => {
+    vi.useFakeTimers();
+    try {
+      const repository = createRepositoryMock();
+      const leaseCoordinator = {
+        acquire: vi.fn(async () => ({ acquired: false })),
+        release: vi.fn(async () => undefined),
+      };
+      const runtime = createScheduleRuntimeContribution({
+        scheduleTaskRepository: repository,
+        sourceExecutor: { execute: vi.fn(async () => undefined) },
+        leaseCoordinator: leaseCoordinator as never,
+        leaseRetryIntervalMs: 250,
+      });
+
+      await runtime.start();
+      expect(leaseCoordinator.acquire).toHaveBeenCalledTimes(1);
+
+      await runtime.stop();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(leaseCoordinator.acquire).toHaveBeenCalledTimes(1);
+      expect(leaseCoordinator.release).not.toHaveBeenCalled();
+      expect(mocked.eventBus.off).toHaveBeenCalledTimes(9);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('syncs schedulable tasks into the queue for live runtime events', async () => {
     const task = createLoadedTask({ id: 'task-sync', nextRunAt: Date.now() + 120_000 });
     const repository = createRepositoryMock();
@@ -375,7 +453,11 @@ describe('createScheduleRuntimeContribution', () => {
     expect(unhandled).toHaveLength(0);
     expect(mocked.loggerError).toHaveBeenCalledWith(
       '[Schedule] Task sync event handler failed',
-      expect.objectContaining({ event: 'schedule:task-created', taskId: 'task-error', error: 'db unavailable' }),
+      expect.objectContaining({
+        event: 'schedule:task-created',
+        taskId: 'task-error',
+        error: 'db unavailable',
+      }),
     );
   });
 
@@ -569,10 +651,10 @@ describe('createScheduleRuntimeContribution', () => {
 
     queue.config.onExecuteError?.('task-error', error);
 
-    expect(mocked.loggerError).toHaveBeenCalledWith(
-      '[Schedule] Queue execution failed',
-      { taskId: 'task-error', error: 'queue exploded' },
-    );
+    expect(mocked.loggerError).toHaveBeenCalledWith('[Schedule] Queue execution failed', {
+      taskId: 'task-error',
+      error: 'queue exploded',
+    });
   });
 
   it('unsubscribes runtime listeners and stops the queue on stop', async () => {

--- a/packages/schedule/src/server/infrastructure/runtime/schedule.runtime.ts
+++ b/packages/schedule/src/server/infrastructure/runtime/schedule.runtime.ts
@@ -8,7 +8,10 @@ import type {
   ScheduleTaskExecutionResult,
   ScheduleTaskSourceExecutor,
 } from '../../application/source-executors/runtime-contract';
-import { ScheduleTaskQueue, type ScheduledItem } from '../../application/scheduler/schedule-task-queue';
+import {
+  ScheduleTaskQueue,
+  type ScheduledItem,
+} from '../../application/scheduler/schedule-task-queue';
 import { SCHEDULE_LEASE_KEY } from '../lease/schedule-lease-coordinator';
 import type { ScheduleModuleRuntimeContribution } from '../schedule.module';
 
@@ -41,10 +44,13 @@ export interface ScheduleRuntimeDependencies {
   readonly metrics?: import('@memoflow/patterns').BusinessMetricRecorder;
   /**
    * R3a：调度器宿主租约（可选）。提供时，start 先原子 acquire DB lease，
-   * 失败则本宿主不启动执行队列（只作为读模型宿主）；无 repository 的
-   * coordinator（单宿主/测试）直接放行。
+   * 失败则本宿主先作为读模型 standby，并周期重试 lease；原 owner 退出或
+   * crash-leftover lease 到期后自动 promotion。无 repository 的 coordinator
+   *（单宿主/测试）直接放行。
    */
   readonly leaseCoordinator?: import('../lease/schedule-lease-coordinator').ScheduleLeaseCoordinator;
+  /** Standby host retry cadence after another scheduler owns the host lease. */
+  readonly leaseRetryIntervalMs?: number;
 }
 
 function toScheduledItem(task: ScheduleTask): ScheduledItem | null {
@@ -107,11 +113,14 @@ async function syncTask(
   }
 
   if (!(await isTaskAllowed(task, shouldScheduleTask))) {
-    logger.info('[Schedule] Removing task from queue because it does not match runtime auth scope', {
-      taskId,
-      taskName: task.name,
-      identityId: String(task.identityId),
-    });
+    logger.info(
+      '[Schedule] Removing task from queue because it does not match runtime auth scope',
+      {
+        taskId,
+        taskName: task.name,
+        identityId: String(task.identityId),
+      },
+    );
     queue.removeTask(taskId);
     return;
   }
@@ -153,11 +162,14 @@ async function executeScheduledTask(
   }
 
   if (!(await isTaskAllowed(task, shouldScheduleTask))) {
-    logger.info('[Schedule] Scheduled execution skipped because task does not match runtime auth scope', {
-      taskId,
-      taskName: task.name,
-      identityId: String(task.identityId),
-    });
+    logger.info(
+      '[Schedule] Scheduled execution skipped because task does not match runtime auth scope',
+      {
+        taskId,
+        taskName: task.name,
+        identityId: String(task.identityId),
+      },
+    );
     return;
   }
 
@@ -345,8 +357,14 @@ export function createScheduleRuntimeContribution(
     scheduleRuntimeEvents.on('schedule:task-resumed', syncTaskListeners['schedule:task-resumed']);
     scheduleRuntimeEvents.on('schedule:task-executed', syncTaskListeners['schedule:task-executed']);
     scheduleRuntimeEvents.on('schedule:task-paused', removeTaskListeners['schedule:task-paused']);
-    scheduleRuntimeEvents.on('schedule:task-completed', removeTaskListeners['schedule:task-completed']);
-    scheduleRuntimeEvents.on('schedule:task-cancelled', removeTaskListeners['schedule:task-cancelled']);
+    scheduleRuntimeEvents.on(
+      'schedule:task-completed',
+      removeTaskListeners['schedule:task-completed'],
+    );
+    scheduleRuntimeEvents.on(
+      'schedule:task-cancelled',
+      removeTaskListeners['schedule:task-cancelled'],
+    );
     scheduleRuntimeEvents.on('schedule:task-failed', removeTaskListeners['schedule:task-failed']);
     scheduleRuntimeEvents.on('schedule:task-deleted', removeTaskListeners['schedule:task-deleted']);
   };
@@ -358,24 +376,85 @@ export function createScheduleRuntimeContribution(
       syncTaskListeners['schedule:task-schedule-updated'],
     );
     scheduleRuntimeEvents.off('schedule:task-resumed', syncTaskListeners['schedule:task-resumed']);
-    scheduleRuntimeEvents.off('schedule:task-executed', syncTaskListeners['schedule:task-executed']);
+    scheduleRuntimeEvents.off(
+      'schedule:task-executed',
+      syncTaskListeners['schedule:task-executed'],
+    );
     scheduleRuntimeEvents.off('schedule:task-paused', removeTaskListeners['schedule:task-paused']);
-    scheduleRuntimeEvents.off('schedule:task-completed', removeTaskListeners['schedule:task-completed']);
-    scheduleRuntimeEvents.off('schedule:task-cancelled', removeTaskListeners['schedule:task-cancelled']);
+    scheduleRuntimeEvents.off(
+      'schedule:task-completed',
+      removeTaskListeners['schedule:task-completed'],
+    );
+    scheduleRuntimeEvents.off(
+      'schedule:task-cancelled',
+      removeTaskListeners['schedule:task-cancelled'],
+    );
     scheduleRuntimeEvents.off('schedule:task-failed', removeTaskListeners['schedule:task-failed']);
-    scheduleRuntimeEvents.off('schedule:task-deleted', removeTaskListeners['schedule:task-deleted']);
+    scheduleRuntimeEvents.off(
+      'schedule:task-deleted',
+      removeTaskListeners['schedule:task-deleted'],
+    );
   };
 
   let started = false;
   let starting: Promise<void> | null = null;
+  let schedulerStarted = false;
+  let leaseRetryTimer: NodeJS.Timeout | null = null;
+  let leasePromotion: Promise<void> | null = null;
+  const leaseRetryIntervalMs = Math.max(250, deps.leaseRetryIntervalMs ?? 5_000);
   /** R3a：acquire 返回的 owner token（stop 时释放租约）。 */
   let leaseOwnerToken: string | undefined;
 
-  const startScheduler = async (): Promise<void> => {
-    registerListeners();
+  const startScheduler = async ({ register = true } = {}): Promise<void> => {
+    if (register) registerListeners();
     await queue.start();
+    schedulerStarted = true;
     started = true;
     logger.info('[Schedule] Runtime contribution started');
+  };
+
+  const scheduleLeaseRetry = (): void => {
+    if (!started || schedulerStarted || leaseRetryTimer || !deps.leaseCoordinator) return;
+    leaseRetryTimer = setTimeout(() => {
+      leaseRetryTimer = null;
+      void promoteStandbyHost();
+    }, leaseRetryIntervalMs);
+    leaseRetryTimer.unref?.();
+  };
+
+  const promoteStandbyHost = async (): Promise<void> => {
+    if (!started || schedulerStarted || !deps.leaseCoordinator || leasePromotion) return;
+
+    leasePromotion = (async () => {
+      const result = await deps.leaseCoordinator!.acquire(SCHEDULE_LEASE_KEY);
+      if (!started) {
+        if (result.acquired) {
+          await deps.leaseCoordinator!.release(SCHEDULE_LEASE_KEY, result.ownerToken);
+        }
+        return;
+      }
+      if (!result.acquired) {
+        scheduleLeaseRetry();
+        return;
+      }
+
+      leaseOwnerToken = result.ownerToken;
+      try {
+        await startScheduler({ register: false });
+        logger.info('[Schedule] Standby host promoted to scheduler (lease held)');
+      } catch (error) {
+        schedulerStarted = false;
+        await deps.leaseCoordinator!.release(SCHEDULE_LEASE_KEY, leaseOwnerToken);
+        leaseOwnerToken = undefined;
+        logger.error('[Schedule] Standby promotion failed; retrying lease acquisition', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        scheduleLeaseRetry();
+      }
+    })().finally(() => {
+      leasePromotion = null;
+    });
+    await leasePromotion;
   };
 
   return {
@@ -403,11 +482,13 @@ export function createScheduleRuntimeContribution(
           const result = await lease.acquire(SCHEDULE_LEASE_KEY);
           if (!result.acquired) {
             logger.warn(
-              '[Schedule] Lease not acquired; running as read-model host only (no scheduler)',
+              '[Schedule] Lease not acquired; running as read-model host and retrying promotion',
             );
-            // 仍注册事件监听以跟踪任务变化，便于宿主后续可升级为调度宿主。
+            // 仍注册事件监听以跟踪任务变化；后台重试 lease，原 owner 退出或
+            // crash-leftover lease 到期后，本宿主可自动升级为调度宿主。
             registerListeners();
             started = true;
+            scheduleLeaseRetry();
             return;
           }
 
@@ -430,6 +511,13 @@ export function createScheduleRuntimeContribution(
         return;
       }
 
+      started = false;
+      if (leaseRetryTimer) {
+        clearTimeout(leaseRetryTimer);
+        leaseRetryTimer = null;
+      }
+      await leasePromotion;
+
       // R3a：释放租约（仅 owner）；心跳 timer 由 coordinator 一并清理。
       if (leaseOwnerToken !== undefined) {
         await deps.leaseCoordinator?.release(SCHEDULE_LEASE_KEY, leaseOwnerToken);
@@ -438,9 +526,11 @@ export function createScheduleRuntimeContribution(
 
       unregisterListeners();
       // R1-3：先排空（等待进行中的 handler 完成），再停队列。
-      await queue.drain();
-      queue.stop();
-      started = false;
+      if (schedulerStarted) {
+        await queue.drain();
+        queue.stop();
+        schedulerStarted = false;
+      }
       logger.info('[Schedule] Runtime contribution stopped');
     },
   };

--- a/tools/docker/local-compose.env-shadow.spec.mjs
+++ b/tools/docker/local-compose.env-shadow.spec.mjs
@@ -6,7 +6,10 @@ import { detectHostEnvShadowing } from './env-shadow.mjs';
 import {
   createLocalDockerAuthBaseUrl,
   createLocalDockerWebUrl,
+  extractHttpOrigin,
   mergeLocalDockerWebOrigins,
+  resolveLocalDockerBrowserValidationOrigins,
+  resolveLocalDockerPowerSyncUrl,
 } from './local-compose.mjs';
 
 describe('detectHostEnvShadowing', () => {
@@ -52,6 +55,42 @@ describe('mergeLocalDockerWebOrigins', () => {
         ',',
       ),
       ['https://app.example.com', 'http://localhost:12137', 'http://127.0.0.1:12137'],
+    );
+  });
+});
+
+describe('MagicDNS browser-facing local Docker URLs', () => {
+  it('normalizes the public Web URL into an allowlist origin', () => {
+    const publicWebOrigin = extractHttpOrigin('http://oracle.taile92a8e.ts.net:58080/auth');
+    assert.equal(publicWebOrigin, 'http://oracle.taile92a8e.ts.net:58080');
+    assert.equal(
+      mergeLocalDockerWebOrigins('58080', publicWebOrigin).includes(
+        'http://oracle.taile92a8e.ts.net:58080',
+      ),
+      true,
+    );
+  });
+
+  it('preserves an explicit public PowerSync URL instead of forcing localhost', () => {
+    assert.equal(
+      resolveLocalDockerPowerSyncUrl('58081', 'http://oracle.taile92a8e.ts.net:58081'),
+      'http://oracle.taile92a8e.ts.net:58081',
+    );
+    assert.equal(resolveLocalDockerPowerSyncUrl('58081'), 'http://localhost:58081');
+  });
+
+  it('runs browser validation through the configured public Web and API origins', () => {
+    assert.deepEqual(
+      resolveLocalDockerBrowserValidationOrigins({
+        apiHostPort: '53080',
+        webHostPort: '58080',
+        authBaseUrl: 'http://oracle.taile92a8e.ts.net:53080/api/auth',
+        webUrl: 'http://oracle.taile92a8e.ts.net:58080',
+      }),
+      {
+        apiOrigin: 'http://oracle.taile92a8e.ts.net:53080',
+        webOrigin: 'http://oracle.taile92a8e.ts.net:58080',
+      },
     );
   });
 });

--- a/tools/docker/local-compose.mjs
+++ b/tools/docker/local-compose.mjs
@@ -113,6 +113,35 @@ export function createLocalDockerWebUrl(webHostPort) {
   return `http://localhost:${webHostPort}`;
 }
 
+export function extractHttpOrigin(value) {
+  const candidate = String(value ?? '').trim();
+  if (!candidate) return '';
+
+  try {
+    const url = new URL(candidate);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : '';
+  } catch {
+    return '';
+  }
+}
+
+export function resolveLocalDockerPowerSyncUrl(powersyncHostPort, publicUrl) {
+  const configured = String(publicUrl ?? '').trim();
+  return configured || `http://localhost:${powersyncHostPort}`;
+}
+
+export function resolveLocalDockerBrowserValidationOrigins({
+  apiHostPort,
+  webHostPort,
+  authBaseUrl,
+  webUrl,
+}) {
+  return {
+    apiOrigin: extractHttpOrigin(authBaseUrl) || `http://127.0.0.1:${apiHostPort}`,
+    webOrigin: extractHttpOrigin(webUrl) || `http://127.0.0.1:${webHostPort}`,
+  };
+}
+
 /**
  * Force local-docker host ports from SSOT so local stack never steals host-dev/e2e ports.
  * Secrets and service env still come from .env.production.local.
@@ -158,13 +187,15 @@ function applyLocalDockerHostPortIsolation(
 
   // Keep public PowerSync URL aligned with isolated host port when unset or still pointing at classic ports.
   const powersyncHostPort = resolved.forced.POWERSYNC_HOST_PORT ?? '58081';
-  const isolatedPowerSyncUrl = `http://localhost:${powersyncHostPort}`;
+  const machinePowerSyncUrl = allowMachineOverride
+    ? (machineEnvFileMap.get('POWERSYNC_URL')?.trim() ?? '')
+    : '';
   const currentPowerSyncUrl =
-    (allowMachineOverride ? machineEnvFileMap.get('POWERSYNC_URL') : '') ||
-    env.POWERSYNC_URL ||
-    envFileMap.get('POWERSYNC_URL') ||
-    '';
-  if (
+    machinePowerSyncUrl || env.POWERSYNC_URL || envFileMap.get('POWERSYNC_URL') || '';
+  const isolatedPowerSyncUrl = resolveLocalDockerPowerSyncUrl(powersyncHostPort);
+  if (machinePowerSyncUrl) {
+    env.POWERSYNC_URL = resolveLocalDockerPowerSyncUrl(powersyncHostPort, machinePowerSyncUrl);
+  } else if (
     allowMachineOverride ||
     !currentPowerSyncUrl ||
     /localhost:8080\b/u.test(currentPowerSyncUrl) ||
@@ -293,13 +324,16 @@ export function createLocalComposeRuntimeEnv(options = {}) {
   // into isolated overrides, keep browser-facing CORS allowlists aligned with
   // the resolved Web origin or an otherwise healthy stack rejects every API
   // request from the page.
+  const publicWebOrigin = extractHttpOrigin(env.MEMOFLOW_WEB_URL);
   env.LOCAL_DOCKER_CORS_ORIGIN = mergeLocalDockerWebOrigins(
     env.WEB_HOST_PORT,
+    publicWebOrigin,
     env.LOCAL_DOCKER_CORS_ORIGIN,
     envFileMap.get('LOCAL_DOCKER_CORS_ORIGIN'),
   );
   env.ALLOWED_ORIGINS = mergeLocalDockerWebOrigins(
     env.WEB_HOST_PORT,
+    publicWebOrigin,
     env.ALLOWED_ORIGINS,
     envFileMap.get('ALLOWED_ORIGINS'),
   );

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -1126,7 +1126,8 @@
       "path": "apps/web/e2e/authentication/auth-flow.spec.ts",
       "primarySuite": "e2e",
       "collectors": [
-        "apps/web/playwright.config.ts"
+        "apps/web/playwright.config.ts",
+        "apps/web/playwright.local-docker.config.ts"
       ],
       "measurementCollectors": []
     },
@@ -1142,7 +1143,8 @@
       "path": "apps/web/e2e/authentication/auth-login.spec.ts",
       "primarySuite": "e2e",
       "collectors": [
-        "apps/web/playwright.config.ts"
+        "apps/web/playwright.config.ts",
+        "apps/web/playwright.local-docker.config.ts"
       ],
       "measurementCollectors": []
     },
@@ -1174,7 +1176,8 @@
       "path": "apps/web/e2e/authentication/auth-password.spec.ts",
       "primarySuite": "e2e",
       "collectors": [
-        "apps/web/playwright.config.ts"
+        "apps/web/playwright.config.ts",
+        "apps/web/playwright.local-docker.config.ts"
       ],
       "measurementCollectors": []
     },
@@ -1182,7 +1185,8 @@
       "path": "apps/web/e2e/authentication/auth-register.spec.ts",
       "primarySuite": "e2e",
       "collectors": [
-        "apps/web/playwright.config.ts"
+        "apps/web/playwright.config.ts",
+        "apps/web/playwright.local-docker.config.ts"
       ],
       "measurementCollectors": []
     },
@@ -8865,6 +8869,16 @@
       ]
     },
     {
+      "path": "packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/schedule/vitest.config.ts"
+      ],
+      "measurementCollectors": [
+        "packages/schedule/vitest.config.ts"
+      ]
+    },
+    {
       "path": "packages/schedule/src/server/infrastructure/runtime/schedule-runtime-ownership.surface.spec.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -10681,7 +10695,7 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 40
+      "fileCount": 41
     },
     {
       "id": "packages/schedule/vitest.integration.config.ts",
@@ -10695,7 +10709,7 @@
       "type": "measurement",
       "suite": "coverage",
       "runner": "vitest",
-      "fileCount": 40
+      "fileCount": 41
     },
     {
       "id": "packages/schedule/vitest.use-cases.config.ts",
@@ -10877,7 +10891,7 @@
       "type": "primary",
       "suite": "e2e",
       "runner": "playwright",
-      "fileCount": 5
+      "fileCount": 9
     },
     {
       "id": "apps/web/playwright.oauth-real.config.ts",
@@ -11409,6 +11423,7 @@
       "packages/schedule/src/server/infrastructure/adapters/prisma/mappers/prisma-schedule-mapper.spec.ts",
       "packages/schedule/src/server/infrastructure/adapters/prisma/mappers/prisma-schedule-task-mapper.spec.ts",
       "packages/schedule/src/server/infrastructure/lease/schedule-lease-coordinator.spec.ts",
+      "packages/schedule/src/server/infrastructure/lease/schedule-lease.repository.spec.ts",
       "packages/schedule/src/server/infrastructure/runtime/schedule-runtime-ownership.surface.spec.ts",
       "packages/schedule/src/server/infrastructure/runtime/schedule.runtime.spec.ts",
       "packages/setting/src/api/module-lifecycle.spec.ts",
@@ -11511,7 +11526,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 988,
+    "unit": 989,
     "integration": 25,
     "smoke": 3,
     "boundary-ipc": 9,


### PR DESCRIPTION
## Summary

Hardens Oracle2/Hermes local validation before leaving a prod-like Docker stack for manual Tailscale MagicDNS acceptance.

- preserve explicit machine-public PowerSync URL and add public Web origin to API/AI CORS
- run local-docker Playwright through configured public Web/API origins
- add registration/login/password-recovery Auth flows to prod-like Docker acceptance
- remove the required Dashboard flow's hidden UI-message-driven login/register fallback
- make Playwright Vite fail fast on port collisions with `--strictPort`
- treat Prisma P2002 schedule-lease races as normal not-acquired outcomes
- promote a standby schedule host after the active lease expires/releases
- harden long-suite settings hydration before theme selection
- document the Oracle2/Hermes2 validation plan and the remaining ADR-049 debt

## Why

A full single-worker Web Flow run on Oracle2 reached 72/74. All Auth tests passed. The two failures exposed separate long-suite/runtime issues:

1. Reminder→Notification could stay disabled after a previous crashed E2E process left a non-expired `schedule-host` lease. The next API process lost the initial lease race and permanently stayed read-model-only; no retry/promotion existed.
2. Settings theme persistence could interact with the Select before settings hydration completed during a long suite.

Oracle2 also revealed local-docker public URL gaps: `MEMOFLOW_WEB_URL` was not in CORS automatically, an explicit MagicDNS `POWERSYNC_URL` was overwritten by localhost, and the Docker browser proof only used 127.0.0.1.

## Validation performed before CI

- `node --test tools/docker/local-compose.env-shadow.spec.mjs` — 9/9
- `apps/web/src/playwright.server.spec.ts` — 8/8
- Schedule lease/coordinator/runtime focused tests — 25/25
- Test inventory check — 1132 files, no stale inventory
- Prettier + `git diff --check`
- full baseline Web Flow on Oracle2: 72/74; **all Auth flows passed**
- focused Reminder closed-loop on a fresh process: 1/1 pass, confirming crash-leftover lease as the trigger
- focused Settings theme persistence: 1/1 pass, confirming a long-suite interaction race
- local-docker config dry list now contains 15 tests: 8 Auth + 7 core-product

## Architecture status

This PR does **not** claim ADR-049 is complete. Current global failure-contract inventory still has 219 grandfathered findings (51 DomainError subclass, 54 message branching, 6 provider leakage, 26 raw rethrow, 82 UI raw message). Governance remains fail-new while the broader migration continues.

## Hermes2

Hermes2 parity is documented but not claimed here. It is currently absent from Oracle2's Tailscale peer list and SSH configuration; Oracle2 validation will complete first, then the same matrix should run on Hermes2 once the host is reachable.
