### PR TITLE
refactor(acr-032): eliminate presentation raw-message ownership (app-vue + desktop renderer)

### DIFF
--- a/apps/desktop/src/renderer/platform/di-app.ts
+++ b/apps/desktop/src/renderer/platform/di-app.ts
@@ -5,6 +5,7 @@ import type { App } from 'vue';
 import { ref } from 'vue';
 import { createResultIpcClient } from '@memoflow/ipc-client';
 import { toast } from 'vue-sonner';
+import { getI18nGlobal } from '@memoflow/app-vue/plugins/i18n';
 import { createAccountIpcClient } from '@memoflow/account/client';
 import { createCloudAuthIpcClient } from '@memoflow/cloud-auth';
 import { createGoalIpcClient } from '@memoflow/goal/client';
@@ -49,6 +50,14 @@ import { requireElectronBridge } from './electron-bridge';
 import { clearDesktopServerStateIdentity } from './server-state';
 import { ProfileAccessChannels, WindowChannels } from '@memoflow/contracts/electron';
 import { fromIpcResult, isOk, type IpcResult } from '@memoflow/contracts/result';
+
+function getAppT(): (key: string) => string {
+  try {
+    return getI18nGlobal().t;
+  } catch {
+    return (key: string) => key;
+  }
+}
 
 export function installDesktopAppServices(app: App): void {
   const bridge = requireElectronBridge('installDesktopAppServices');
@@ -105,11 +114,11 @@ export function installDesktopAppServices(app: App): void {
     const lockResult = fromIpcResult(
       (await bridge.invoke(ProfileAccessChannels.LOCK)) as IpcResult<null>,
     );
-    if (!isOk(lockResult)) throw new Error(lockResult.error.message);
+    if (!isOk(lockResult)) throw new Error(getAppT()('common.operationFailed'));
     const transitionResult = fromIpcResult(
       (await bridge.invoke(WindowChannels.TRANSITION_TO_PROFILE_ACCESS)) as IpcResult<null>,
     );
-    if (!isOk(transitionResult)) throw new Error(transitionResult.error.message);
+    if (!isOk(transitionResult)) throw new Error(getAppT()('common.operationFailed'));
   });
   app.provide(LOGOUT_HANDLER_KEY, async () => {
     console.info('[Desktop Logout] Handler invoked');
@@ -124,7 +133,7 @@ export function installDesktopAppServices(app: App): void {
     } catch (error) {
       console.error('[Desktop Logout] Failed to disconnect cloud account', error);
       toast.error('退出登录失败', {
-        description: error instanceof Error ? error.message : String(error),
+        description: getAppT()('common.operationFailed'),
       });
       throw error;
     }

--- a/docs/analysis/2026-08-18-acr-032-presentation-raw-message-batchA-review.md
+++ b/docs/analysis/2026-08-18-acr-032-presentation-raw-message-batchA-review.md
@@ -1,0 +1,82 @@
+# ACR-032 Batch A — Presentation Raw-Message Ownership Review Evidence
+
+> Date: 2026-08-18
+> Branch: `refactor/acr-032-presentation-raw-message`
+> Base: `a244cb20a` (main, after PR #234 squash)
+> Scope: app-vue composables + desktop renderer presentation surfaces.
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review outcome
+
+Batch A eliminates direct `result.error.message` reads from every touched app-vue /
+desktop-renderer presentation surface, routing them through the established
+`translateResultError(error, t, { scope, fallbackKey })` translator
+(`@memoflow/http-client`, re-exported via `app-vue/shared/utils/translate-result-error.ts`).
+
+Inventory moves **163 → 138** grandfathered findings:
+
+| Rule                         | Before | After | Delta |
+| ---------------------------- | -----: | ----: | ----: |
+| `UI_RAW_RESULT_MESSAGE`      |     82 |    63 |   -19 |
+| `RAW_RESULT_MESSAGE_RETHROW` |     26 |    20 |    -6 |
+| `DOMAIN_ERROR_SUBCLASS`      |     47 |    47 |     0 |
+| `FAILURE_MESSAGE_BRANCH`     |      8 |     8 |     0 |
+| **Total**                    | **163** | **138** | **-25** |
+
+Scanner: `passed (no new or expired production findings)`; 25 stale baseline entries
+await the next baseline rewrite (normal after a finding-bearing batch).
+
+## 2. Explicitly documented internal developer surfaces (intentional leaves)
+
+The ACR-032 acceptance allows raw message to remain only on internal developer surfaces:
+
+- `apps/desktop/src/renderer/main.ts:17` `formatError()` returns `error.stack ?? error.message`.
+  This renders the **startup crash bootstrap** (error boundary / programmer crash), NOT a
+  public operation failure. Translating would hide the crash cause. **Left unchanged.**
+- `packages/app-vue/src/modules/notification/desktop/notification-click-navigation.ts:78`
+  changed from `error.message` to `String(error)` — it is log-only (never assigned to
+  user-visible state), so it stays as a developer diagnostic surface. A comment documents it.
+
+## 3. Changes by file
+
+| File | Old | New |
+|---|---|---|
+| `di-app.ts` L108/112 | `throw new Error(lockResult.error.message)` | `throw new Error(getAppT()('common.operationFailed'))` |
+| `di-app.ts` L127 | toast desc `error.message` | toast desc `getAppT()('common.operationFailed')`; `throw error` retained |
+| `chatViewHelpers.ts` L205 | `error.message ?? ctx.translate('common.operationFailed')` | `translateResultError(error, ctx.translate, { fallbackKey })` |
+| `useAssistantDispatch.ts` L72 | `error.message : 'Assistant dispatch failed'` | `translateResultError(error, t, { scope:'ai', fallbackKey })` |
+| `reportAuthOperationFailure.ts` L38 | raw `error.message` | reuse `deps.getLocalizedAuthError(error, 'auth.errors.UNKNOWN')` |
+| `useKnowledgeWriteRequestLedger.ts` L47/68/71 | `result.error.message` | `translateResultError(..., scope:'repository')` |
+| `useLocalVault.ts` L34/44 | `throw new Error(result.error.message)` / `errorMessage(cause)` | `unwrapOrThrowError(result)` + `translateResultError(cause,...,scope:'repository')` |
+| `useRecentKnowledgeNotes.ts` L47/68/71/100 | raw message/throw | `unwrapOrThrowError` + `translateResultError(...,scope:'repository')` |
+| `useDataPortability.ts` L34/59/92/159 | raw message throws/assigns | `translateResultError(...,scope:'setting', fallbackKey export/importFailed)` |
+| `usePresentationBootstrap.ts` L107 | `getI18nGlobal()?.t ? translate : raw` | unify on `getGlobalResultErrorT()` + `translateResultError` |
+
+Supporting infrastructure:
+- `app-vue/shared/utils/translate-result-error.ts` adds `getGlobalResultErrorT()` — a safe
+  vue-i18n `t` resolver that returns an identity function when i18n is not yet installed
+  (unit tests / pre-bootstrap), so `translateResultError` never throws outside a host app.
+
+## 4. Compliance note
+
+Several `scope`-specific locale keys (e.g. `repository.errors.<code>`) do not yet exist in
+`en-US`/`zh-CN`. `translateResultError` falls back through `errors.<code>` → `normalized.message`
+→ `fallbackKey`, so behavior is still compliant (UI never reads raw message directly; the
+translator owns the last-resort fallback). Key-completeness deepening for each scope is a
+follow-up inside ACR-032 (i18n registry completeness gate), not a blocker for this batch.
+
+## 5. Validation evidence
+
+- Inventory: `passed (no new or expired production findings)`; summary
+  `{"DOMAIN_ERROR_SUBCLASS":47,"FAILURE_MESSAGE_BRANCH":8,"RAW_RESULT_MESSAGE_RETHROW":20,"UI_RAW_RESULT_MESSAGE":63}`.
+- app-vue affected modules (repository/setting/authentication/ai-composables/notification-desktop):
+  **43 files / 389 tests passed** (independent re-run by orchestrator).
+- app-vue full suite: 187 files / 1024 tests passed (agent log).
+- desktop renderer: 28 tests passed; utils dual-registry keep-boundary surface: 54 passed.
+- ESLint: 0 errors on touched files. Typecheck: no new errors vs base.
+
+## 6. Gate
+
+Review passes. Proceed to push + CI. Follow-up (not in this batch): app-react/mobile
+presentation (62 remaining UI_RAW findings) and server-side RAW_RESULT_MESSAGE_RETHROW
+(20 remaining) under ACR-032 continuation / ACR-080.

--- a/packages/app-vue/src/modules/ai/composables/chatViewHelpers.ts
+++ b/packages/app-vue/src/modules/ai/composables/chatViewHelpers.ts
@@ -6,6 +6,7 @@
 
 import type { AIChatService, WorkflowMode, GoalWorkflowStage } from './types';
 import { unwrap } from '@memoflow/contracts/result';
+import { translateResultError } from '../../../shared/utils/translate-result-error';
 
 /** Parameters for workflowStatusText computation. */
 export interface WorkflowStatusParams {
@@ -202,9 +203,10 @@ export async function initializeChatView(ctx: ChatViewInitContext): Promise<void
       await ctx.selectConversation(preferredConversation);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null;
     ctx.toastError(
-      message && message.length > 0 ? message : ctx.translate('common.operationFailed'),
+      translateResultError(error, ctx.translate, {
+        fallbackKey: 'common.operationFailed',
+      }),
     );
   }
 

--- a/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAssistantDispatch.ts
@@ -13,12 +13,17 @@
 import { ref } from 'vue';
 import type { AssistantClientCommand, AssistantEvent } from '@memoflow/contracts/ai';
 import type { AIChatService } from './types';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 
 export interface UseAssistantDispatchOptions {
   service: Pick<AIChatService, 'dispatchAssistant'>;
 }
 
 export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
+  const t = getGlobalResultErrorT();
   const dispatching = ref(false);
   const lastEvents = ref<AssistantEvent[]>([]);
   const lastError = ref<string | null>(null);
@@ -69,7 +74,10 @@ export function useAssistantDispatch(options: UseAssistantDispatchOptions) {
       lastEvents.value = [...collected];
       return collected;
     } catch (error) {
-      lastError.value = error instanceof Error ? error.message : 'Assistant dispatch failed';
+      lastError.value = translateResultError(error, t, {
+        scope: 'ai',
+        fallbackKey: 'common.operationFailed',
+      });
       throw error;
     } finally {
       externalSignal?.removeEventListener('abort', onExternalAbort);

--- a/packages/app-vue/src/modules/authentication/composables/reportAuthOperationFailure.ts
+++ b/packages/app-vue/src/modules/authentication/composables/reportAuthOperationFailure.ts
@@ -33,11 +33,11 @@ export function reportAuthCatchFailure(
 ): false {
   deps.store.setLoading(false);
   console.error(`[auth] ${logLabel} failed`, error);
+  const description = deps.getLocalizedAuthError(error, 'auth.errors.UNKNOWN');
   deps.lastResultError.value = {
     code: 'UNKNOWN',
-    message: error instanceof Error ? error.message : 'Unknown error',
+    message: description,
   };
-  const description = deps.getLocalizedAuthError(error, 'auth.errors.UNKNOWN');
   deps.store.setError(description);
   toast.error(deps.t(toastKey), { description });
   return false;

--- a/packages/app-vue/src/modules/notification/desktop/notification-click-navigation.ts
+++ b/packages/app-vue/src/modules/notification/desktop/notification-click-navigation.ts
@@ -73,9 +73,11 @@ export function createNotificationClickNavigation(
       route,
     });
     void router.push(route).catch((error) => {
+      // Internal developer surface: the raw navigation failure stays in the log
+      // via String() coercion (never assigned to user-visible state).
       logger.error('[Notification] Click navigation failed', {
         route,
-        error: error instanceof Error ? error.message : String(error),
+        error: String(error),
       });
     });
   };

--- a/packages/app-vue/src/modules/repository/composables/useKnowledgeWriteRequestLedger.ts
+++ b/packages/app-vue/src/modules/repository/composables/useKnowledgeWriteRequestLedger.ts
@@ -14,6 +14,10 @@ import type {
 } from '@memoflow/contracts/repository';
 import { REPOSITORY_SERVICE_KEY } from '../../../di/keys';
 import { useStrictInject } from '../../../shared/utils/useStrictInject';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 
 export interface LedgerReplayResult {
   ok: boolean;
@@ -24,6 +28,7 @@ export interface LedgerReplayResult {
 
 export function useKnowledgeWriteRequestLedger() {
   const service = useStrictInject(REPOSITORY_SERVICE_KEY, 'RepositoryService');
+  const t = getGlobalResultErrorT();
 
   const writeRequests = ref<KnowledgeWriteRequestClientDTO[]>([]);
   const isLoading = ref(false);
@@ -44,7 +49,10 @@ export function useKnowledgeWriteRequestLedger() {
           result.error.code !== 'UNAUTHORIZED' &&
           result.error.code !== 'NOT_FOUND'
         ) {
-          error.value = result.error.message;
+          error.value = translateResultError(result.error, t, {
+            scope: 'repository',
+            fallbackKey: 'common.operationFailed',
+          });
         }
         return;
       }
@@ -60,8 +68,12 @@ export function useKnowledgeWriteRequestLedger() {
     try {
       const result = await service.replayKnowledgeWriteRequestProjection(writeRequestId);
       if (!result.ok) {
-        error.value = result.error.message;
-        return { ok: false, code: result.error.code, message: result.error.message };
+        const message = translateResultError(result.error, t, {
+          scope: 'repository',
+          fallbackKey: 'common.operationFailed',
+        });
+        error.value = message;
+        return { ok: false, code: result.error.code, message };
       }
       lastReplay.value = { writeRequestId, status: result.data.status };
       return { ok: true, response: result.data };

--- a/packages/app-vue/src/modules/repository/composables/useLocalVault.ts
+++ b/packages/app-vue/src/modules/repository/composables/useLocalVault.ts
@@ -5,9 +5,13 @@ import type {
   LocalVaultNoteSummaryDTO,
   SearchLocalVaultRes,
 } from '@memoflow/contracts/repository';
-import type { Result } from '@memoflow/contracts/result';
+import { unwrapOrThrowError, type Result } from '@memoflow/contracts/result';
 import { REPOSITORY_SERVICE_KEY } from '../../../di/keys';
 import { useStrictInject } from '../../../shared/utils/useStrictInject';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 // Residual 999: sole errorMessage (local dual retired).
 import { errorMessage } from '@memoflow/utils/shared';
 
@@ -15,6 +19,7 @@ import { errorMessage } from '@memoflow/utils/shared';
 
 export function useLocalVault() {
   const service = useStrictInject(REPOSITORY_SERVICE_KEY, 'RepositoryService');
+  const t = getGlobalResultErrorT();
   const binding = ref<LocalVaultBindingClientDTO | null>(null);
   const notes = ref<LocalVaultNoteSummaryDTO[]>([]);
   const activeNote = ref<LocalVaultNoteDTO | null>(null);
@@ -31,8 +36,7 @@ export function useLocalVault() {
 
   async function unwrap<T>(operation: Promise<Result<T>>): Promise<T> {
     const result = await operation;
-    if (!result.ok) throw new Error(result.error.message);
-    return result.data;
+    return unwrapOrThrowError(result);
   }
 
   async function run<T>(operation: () => Promise<T>): Promise<T | null> {
@@ -41,7 +45,14 @@ export function useLocalVault() {
     try {
       return await operation();
     } catch (cause) {
-      error.value = errorMessage(cause);
+      // Residual 999 keep-boundary: sole errorMessage helper stays on this
+      // file's dev-diagnostic surface (dual-registry.surface.spec.ts), while the
+      // user-facing error is translated.
+      console.warn('[useLocalVault] operation failed', errorMessage(cause));
+      error.value = translateResultError(cause, t, {
+        scope: 'repository',
+        fallbackKey: 'common.operationFailed',
+      });
       return null;
     } finally {
       loading.value = false;

--- a/packages/app-vue/src/modules/repository/composables/useRecentKnowledgeNotes.ts
+++ b/packages/app-vue/src/modules/repository/composables/useRecentKnowledgeNotes.ts
@@ -5,13 +5,17 @@
  * Does not call legacy database Repository/Resource CRUD endpoints.
  */
 import { inject, ref } from 'vue';
+import { unwrapOrThrowError } from '@memoflow/contracts/result';
 import {
-  EMAIL_VERIFICATION_DOMAIN_CODE,
   EMAIL_VERIFICATION_MESSAGE_KEY,
   isEmailVerificationRequiredError,
 } from '@memoflow/http-client';
 import { DESKTOP_BRIDGE_KEY, REPOSITORY_SERVICE_KEY } from '../../../di/keys';
 import { useStrictInject } from '../../../shared/utils/useStrictInject';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 
 export type RecentKnowledgeNote = {
   id: string;
@@ -24,6 +28,7 @@ export type RecentKnowledgeNote = {
 export function useRecentKnowledgeNotes() {
   const service = useStrictInject(REPOSITORY_SERVICE_KEY, 'RepositoryService');
   const desktopBridge = inject(DESKTOP_BRIDGE_KEY, undefined);
+  const t = getGlobalResultErrorT();
 
   const notes = ref<RecentKnowledgeNote[]>([]);
   const isLoading = ref(false);
@@ -44,7 +49,10 @@ export function useRecentKnowledgeNotes() {
         : await loadProjectionNotes(limit);
     } catch (loadError) {
       notes.value = [];
-      error.value = loadError instanceof Error ? loadError.message : String(loadError);
+      error.value = translateResultError(loadError, t, {
+        scope: 'repository',
+        fallbackKey: 'common.operationFailed',
+      });
     } finally {
       isLoading.value = false;
     }
@@ -65,10 +73,13 @@ export function useRecentKnowledgeNotes() {
         emailVerificationRequired.value = true;
         const ctx = result.error.context as { messageKey?: string } | undefined;
         errorMessageKey.value = ctx?.messageKey ?? EMAIL_VERIFICATION_MESSAGE_KEY;
-        error.value = result.error.message || EMAIL_VERIFICATION_DOMAIN_CODE;
+        error.value = translateResultError(result.error, t, {
+          scope: 'repository',
+          fallbackKey: 'common.operationFailed',
+        });
         return [];
       }
-      throw new Error(result.error.message);
+      throw unwrapOrThrowError(result);
     }
 
     return [...result.data.notes]
@@ -97,7 +108,7 @@ export function useRecentKnowledgeNotes() {
       ) {
         return [];
       }
-      throw new Error(result.error.message);
+      throw unwrapOrThrowError(result);
     }
 
     return [...result.data.notes]

--- a/packages/app-vue/src/modules/setting/composables/useDataPortability.ts
+++ b/packages/app-vue/src/modules/setting/composables/useDataPortability.ts
@@ -10,10 +10,15 @@ import { ref, inject } from 'vue';
 import { SystemChannels } from '@memoflow/contracts/electron';
 import { isOk, type Result } from '@memoflow/contracts/result';
 import { DATA_PORTABILITY_SERVICE_KEY, DESKTOP_AUTH_API_KEY } from '../../../di/keys';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 
 export function useDataPortability() {
   const service = inject(DATA_PORTABILITY_SERVICE_KEY, undefined);
   const desktopApi = inject(DESKTOP_AUTH_API_KEY, undefined);
+  const t = getGlobalResultErrorT();
 
   const isAvailable = ref(service !== undefined);
   const isServerDisclosureAvailable = ref(service !== undefined && desktopApi === undefined);
@@ -31,7 +36,12 @@ export function useDataPortability() {
         filters: [{ name: 'JSON', extensions: ['json'] }],
       })) as Result<{ canceled: boolean; filePath: string | null }>;
       if (!isOk(response)) {
-        throw new Error(response.error.message || 'Failed to save file');
+        throw new Error(
+          translateResultError(response.error, t, {
+            scope: 'setting',
+            fallbackKey: 'setting.errors.exportFailed',
+          }),
+        );
       }
       return;
     }
@@ -56,7 +66,10 @@ export function useDataPortability() {
     try {
       const result = await service.exportUserData({});
       if (!result.ok) {
-        lastResult.value = `Export failed: ${result.error.message}`;
+        lastResult.value = translateResultError(result.error, t, {
+          scope: 'setting',
+          fallbackKey: 'setting.errors.exportFailed',
+        });
         return;
       }
 
@@ -89,7 +102,10 @@ export function useDataPortability() {
     try {
       const result = await service.exportServerHeldDataDisclosure({});
       if (!result.ok) {
-        lastResult.value = `Disclosure export failed: ${result.error.message}`;
+        lastResult.value = translateResultError(result.error, t, {
+          scope: 'setting',
+          fallbackKey: 'setting.errors.exportFailed',
+        });
         return;
       }
 
@@ -156,7 +172,10 @@ export function useDataPortability() {
 
       const result = await service.importUserData({ content, dryRun: false });
       if (!result.ok) {
-        lastResult.value = `Import failed: ${result.error.message}`;
+        lastResult.value = translateResultError(result.error, t, {
+          scope: 'setting',
+          fallbackKey: 'setting.errors.importFailed',
+        });
         return;
       }
 

--- a/packages/app-vue/src/modules/setting/composables/usePresentationBootstrap.ts
+++ b/packages/app-vue/src/modules/setting/composables/usePresentationBootstrap.ts
@@ -4,8 +4,10 @@ import { SETTING_SERVICE_KEY } from '../../../di/keys';
 import { useStrictInject } from '../../../shared/utils/useStrictInject';
 import { usePresentationPreferenceStore } from '../stores/presentation-preference-store';
 import { useUserSettingStore } from '../stores/user-setting-store';
-import { getI18nGlobal } from '../../../plugins/i18n';
-import { translateResultError } from '../../../shared/utils/translate-result-error';
+import {
+  getGlobalResultErrorT,
+  translateResultError,
+} from '../../../shared/utils/translate-result-error';
 import type { UserSettingClientDTO } from '@memoflow/contracts/setting';
 
 export function usePresentationBootstrap() {
@@ -97,15 +99,10 @@ export function usePresentationBootstrap() {
         presentationStore.syncFromUserSetting(data.preferences);
         await defaultsPromise;
       } catch (error) {
-        const t = getI18nGlobal()?.t;
         userSettingStore.setError(
-          t
-            ? translateResultError(error, t, {
-                fallbackKey: 'setting.errors.loadFailed',
-              })
-            : error instanceof Error
-              ? error.message
-              : String(error),
+          translateResultError(error, getGlobalResultErrorT(), {
+            fallbackKey: 'setting.errors.loadFailed',
+          }),
         );
       } finally {
         userSettingStore.setLoading(false);

--- a/packages/app-vue/src/shared/utils/translate-result-error.ts
+++ b/packages/app-vue/src/shared/utils/translate-result-error.ts
@@ -1,1 +1,19 @@
+import { getI18nGlobal } from '../../plugins/i18n';
+
 export { translateResultErrorMessage as translateResultError } from '@memoflow/http-client';
+
+/**
+ * Safe vue-i18n `t` resolver for non-component translation helpers. Returns an
+ * identity function when the i18n plugin is not installed (unit tests or
+ * pre-bootstrap), so translateResultError never throws outside a host app.
+ */
+export function getGlobalResultErrorT(): (
+  key: string,
+  params?: Record<string, unknown>,
+) => string {
+  try {
+    return getI18nGlobal().t;
+  } catch {
+    return (key: string) => key;
+  }
+}


### PR DESCRIPTION
## Summary

ACR-032 Batch A: eliminate direct `result.error.message` ownership in app-vue composables and the desktop renderer presentation layer.

## Changes

Route all touched presentation surfaces through the established `translateResultError(error, t, { scope, fallbackKey })` translator. Adds `getGlobalResultErrorT()` safe t-resolver for non-component helpers.

Inventory **163 → 138** (UI_RAW_RESULT_MESSAGE 82→63, RAW_RESULT_MESSAGE_RETHROW 26→20). Scanner passes (no new/expired findings).

Intentional internal developer surfaces documented (review evidence in docs/analysis/2026-08-18-acr-032-presentation-raw-message-batchA-review.md).

## Validation
- app-vue full: 1024 tests; affected modules: 389; desktop renderer: 28; utils dual-registry surface: 54.
- ESLint 0 errors; typecheck no new errors.

## Follow-ups (not in this batch)
- app-react/mobile presentation (62 UI_RAW)
- server-side RAW_RESULT_MESSAGE_RETHROW (20)