### PR TITLE
refactor(acr-032): eliminate mobile presentation raw-message ownership

### DIFF
--- a/docs/analysis/2026-08-18-acr-032-presentation-mobile-batchB-review.md
+++ b/docs/analysis/2026-08-18-acr-032-presentation-mobile-batchB-review.md
@@ -1,0 +1,67 @@
+# ACR-032 Batch B — Mobile (app-react) Presentation Raw-Message Ownership Review Evidence
+
+> Date: 2026-08-18
+> Branch: `refactor/acr-032-presentation-mobile`
+> Base: `961a1cf52` (main, after PR #235)
+> Scope: mobile presentation layer (`packages/app-react`) + shared `presentErrorMessage`.
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review outcome
+
+Eliminates all 62 mobile `UI_RAW_RESULT_MESSAGE` findings by introducing a
+framework-free `presentErrorMessage(error)` in `@memoflow/http-client` and routing every
+mobile `setError(x.error.message)` through it. Mobile (React Native / Expo) has no i18n host,
+so this is a deterministic code→stable-message mapper rather than the vue-i18n-backed
+`translateResultError` used on Web/Desktop (Batch A).
+
+Inventory moves **138 → 76**:
+
+| Rule                         | Before | After | Delta |
+| ---------------------------- | -----: | ----: | ----: |
+| `UI_RAW_RESULT_MESSAGE`      |     63 |     1 |   -62 |
+| `RAW_RESULT_MESSAGE_RETHROW` |     20 |    20 |     0 |
+| `DOMAIN_ERROR_SUBCLASS`      |     47 |    47 |     0 |
+| `FAILURE_MESSAGE_BRANCH`     |      8 |     8 |     0 |
+| **Total**                    | **138** | **76** | **-62** |
+
+Scanner: `passed (no new or expired production findings)`. 87 stale baseline entries await the
+next baseline rewrite.
+
+## 2. Shared helper
+
+`presentErrorMessage(error, fallbackMessage?)` in `packages/http-client/src/result-error.ts`:
+- `normalizeResultError` → code → `getDefaultResultErrorMessage(code)` (stable zh-CN for
+  BAD_REQUEST/UNAUTHORIZED/FORBIDDEN/NOT_FOUND/CONFLICT/VALIDATION_ERROR/RATE_LIMITED/
+  INTERNAL_ERROR/SERVICE_UNAVAILABLE/TIMEOUT/CANCELED/UNKNOWN).
+- fallbackMessage honored only when code unknown; else `'操作失败'`.
+- **Never reads the raw provider message.** 7 unit tests cover code resolution, unknown-code
+  fallback, PublicFailure shape, and fallbackMessage override.
+
+## 3. app-react replacements (62 → 0)
+
+- **14 hooks + 1 provider** (`app-session-provider.tsx`, 3 sites): uniform
+  `setError(presentErrorMessage(<same expression>.error))` — receiver expression preserved.
+- **12 screens** incl. non-`setError` setters: `setActionError`, `setSubmitError`,
+  `setConflictError`, `setFormError`, `setLastError`.
+- `useAIWorkspace` read `error.message` on a narrowed JS `Error` (a ResultErrorException from
+  `unwrap`) → `presentErrorMessage(error)`.
+
+## 4. Intentional leave
+
+- `apps/desktop/src/renderer/main.ts:17` — the single remaining `UI_RAW_RESULT_MESSAGE`.
+  Startup crash `formatError` (`error.stack ?? error.message`) is the documented internal
+  developer surface from Batch A; not an app-react finding and correctly outside this batch.
+
+## 5. Validation evidence
+
+- Inventory: `passed`; summary
+  `{"DOMAIN_ERROR_SUBCLASS":47,"FAILURE_MESSAGE_BRANCH":8,"RAW_RESULT_MESSAGE_RETHROW":20,"UI_RAW_RESULT_MESSAGE":1}`.
+- http-client vitest: `present-error-message.test.ts` 7/7; full suite 11 passed
+  (orchestrator re-run: 7/7 confirmed).
+- app-react `tsc --noEmit`: exit 0, no errors (orchestrator re-run of scanner passed).
+
+## 6. Gate
+
+Review passes. ACR-032 presentation raw-message ownership is now complete across
+Web/Desktop/app-vue (Batch A) and mobile/app-react (Batch B): `UI_RAW_RESULT_MESSAGE = 1`
+(documented internal dev surface). Proceed to push + CI.

--- a/packages/app-react/src/hooks/useAIWorkspace.ts
+++ b/packages/app-react/src/hooks/useAIWorkspace.ts
@@ -9,12 +9,13 @@ import {
   type SendMessageReq,
 } from '@memoflow/contracts/ai';
 import { unwrap } from '@memoflow/contracts/result';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useAIService } from './useAIService';
 
 function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : 'AI request failed';
+  return error instanceof Error ? presentErrorMessage(error) : 'AI request failed';
 }
 
 /**

--- a/packages/app-react/src/hooks/useAccountProfile.ts
+++ b/packages/app-react/src/hooks/useAccountProfile.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import type { AccountClientDTO } from '@memoflow/contracts/account';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useAccountService } from './useAccountService';
@@ -26,7 +27,7 @@ export function useAccountProfile() {
     const result = await service.getMyProfile();
     if (!result.ok) {
       setAccount(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useGoalDetail.ts
+++ b/packages/app-react/src/hooks/useGoalDetail.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { useAppSession } from './useAppSession';
 import { mapGoalDetail, type GoalDetail } from './useGoals';
 import { useGoalService } from './useGoalService';
@@ -35,7 +37,7 @@ export function useGoalDetail(goalId: string | null) {
 
       if (!goalResult.ok) {
         setGoal(null);
-        setError(goalResult.error.message);
+        setError(presentErrorMessage(goalResult.error));
         setIsLoading(false);
         return;
       }
@@ -61,7 +63,7 @@ export function useGoalDetail(goalId: string | null) {
 
     if (!goalResult.ok) {
       setGoal(null);
-      setError(goalResult.error.message);
+      setError(presentErrorMessage(goalResult.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useGoalReviews.ts
+++ b/packages/app-react/src/hooks/useGoalReviews.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import type { GoalReviewClientDTO } from '@memoflow/contracts/goal';
+import { presentErrorMessage } from '@memoflow/http-client';
 import { useAppSession } from './useAppSession';
 import { useGoalService } from './useGoalService';
 
@@ -53,7 +54,7 @@ export function useGoalReviews(goalId: string | null) {
     const result = await service.getGoalAggregateView(goalId);
     if (!result.ok) {
       setReviews([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useGoals.ts
+++ b/packages/app-react/src/hooks/useGoals.ts
@@ -8,6 +8,7 @@ import type {
 } from '@memoflow/contracts/goal';
 import type { ImportanceLevel } from '@memoflow/contracts/shared';
 import type { Goal } from '@memoflow/goal/client';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useGoalService } from './useGoalService';
@@ -162,7 +163,7 @@ export function useGoals() {
 
       if (!result.ok) {
         setGoals([]);
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }
@@ -192,7 +193,7 @@ export function useGoals() {
 
     if (!result.ok) {
       setGoals([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useNotifications.ts
+++ b/packages/app-react/src/hooks/useNotifications.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import type { NotificationClientDTO } from '@memoflow/contracts/notification';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useNotificationService } from './useNotificationService';
@@ -33,7 +34,7 @@ export function useNotifications() {
     if (!listResult.ok) {
       setNotifications([]);
       setUnreadCount(0);
-      setError(listResult.error.message);
+      setError(presentErrorMessage(listResult.error));
       setIsLoading(false);
       return;
     }
@@ -41,7 +42,7 @@ export function useNotifications() {
     if (!unreadResult.ok) {
       setNotifications(listResult.data.notifications);
       setUnreadCount(0);
-      setError(unreadResult.error.message);
+      setError(presentErrorMessage(unreadResult.error));
       setIsLoading(false);
       return;
     }
@@ -62,7 +63,7 @@ export function useNotifications() {
   async function markAsRead(id: string) {
     const result = await service.markAsRead(id);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 
@@ -73,7 +74,7 @@ export function useNotifications() {
   async function markAllAsRead() {
     const result = await service.markAllAsRead();
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 

--- a/packages/app-react/src/hooks/useReminders.ts
+++ b/packages/app-react/src/hooks/useReminders.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import type { ReminderTemplateClientDTO, ReminderTodayScheduleItem } from '@memoflow/contracts/reminder';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useReminderService } from './useReminderService';
@@ -33,7 +34,7 @@ export function useReminders() {
     if (!templateResult.ok) {
       setTemplates([]);
       setTodaySchedule([]);
-      setError(templateResult.error.message);
+      setError(presentErrorMessage(templateResult.error));
       setIsLoading(false);
       return;
     }
@@ -41,7 +42,7 @@ export function useReminders() {
     if (!scheduleResult.ok) {
       setTemplates(templateResult.data);
       setTodaySchedule([]);
-      setError(scheduleResult.error.message);
+      setError(presentErrorMessage(scheduleResult.error));
       setIsLoading(false);
       return;
     }
@@ -62,7 +63,7 @@ export function useReminders() {
   async function toggleTemplateEnabled(id: string) {
     const result = await service.toggleTemplateEnabled(id);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 

--- a/packages/app-react/src/hooks/useScheduleAgenda.ts
+++ b/packages/app-react/src/hooks/useScheduleAgenda.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import type { CalendarEntryClientDTO } from '@memoflow/contracts/schedule';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useScheduleService } from './useScheduleService';
@@ -140,7 +141,7 @@ export function useScheduleAgenda(options: ScheduleAgendaOptions = {}) {
 
     if (!result.ok) {
       setEntries([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useScheduleTasks.ts
+++ b/packages/app-react/src/hooks/useScheduleTasks.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import type { ScheduleTaskStatus, SourceModule, TaskPriority } from '@memoflow/contracts/schedule';
 import type { ScheduleTask } from '@memoflow/schedule/client';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useScheduleService } from './useScheduleService';
@@ -77,7 +78,7 @@ export function useScheduleTasks() {
 
       if (!result.ok) {
         setTasks([]);
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }
@@ -102,7 +103,7 @@ export function useScheduleTasks() {
     const result = await service.getTasks();
     if (!result.ok) {
       setTasks([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useSettings.ts
+++ b/packages/app-react/src/hooks/useSettings.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import type { PreferenceCategory, UserSettingClientDTO } from '@memoflow/contracts/setting';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useSettingService } from './useSettingService';
@@ -27,7 +28,7 @@ export function useSettings() {
     const result = await service.getUserSettings();
     if (!result.ok) {
       setSettings(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -52,7 +53,7 @@ export function useSettings() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 
@@ -68,7 +69,7 @@ export function useSettings() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 

--- a/packages/app-react/src/hooks/useTaskDependencies.ts
+++ b/packages/app-react/src/hooks/useTaskDependencies.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import type { DependencyChainClientDTO } from '@memoflow/contracts/task';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useTaskService } from './useTaskService';
@@ -44,7 +45,7 @@ export function useTaskDependencies(taskId: string | null) {
     ]);
 
     if (!depsResult.ok) {
-      setError(depsResult.error.message);
+      setError(presentErrorMessage(depsResult.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useTaskInstances.ts
+++ b/packages/app-react/src/hooks/useTaskInstances.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import type { TaskInstanceStatus, TaskTimeConfigDTO } from '@memoflow/contracts/task';
 import type { TaskInstance } from '@memoflow/task/client';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useTaskService } from './useTaskService';
@@ -56,7 +57,7 @@ export function useTaskInstances(taskId: string | null) {
     const result = await service.listInstances({ templateId: taskId, limit: 20 });
     if (!result.ok) {
       setInstances([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -79,7 +80,7 @@ export function useTaskInstances(taskId: string | null) {
   async function startInstance(id: string) {
     const result = await service.startInstance(id);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 
@@ -90,7 +91,7 @@ export function useTaskInstances(taskId: string | null) {
   async function completeInstance(id: string) {
     const result = await service.completeInstance(id);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 
@@ -101,7 +102,7 @@ export function useTaskInstances(taskId: string | null) {
   async function skipInstance(id: string) {
     const result = await service.skipInstance(id);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return false;
     }
 

--- a/packages/app-react/src/hooks/useTaskTemplateDetail.ts
+++ b/packages/app-react/src/hooks/useTaskTemplateDetail.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { useAppSession } from './useAppSession';
 import { mapTaskTemplateDetail, type TaskTemplateDetail } from './useTaskTemplates';
 import { useTaskService } from './useTaskService';
@@ -34,7 +36,7 @@ export function useTaskTemplateDetail(taskId: string | null) {
 
       if (!result.ok) {
         setTemplate(null);
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }
@@ -59,7 +61,7 @@ export function useTaskTemplateDetail(taskId: string | null) {
     const result = await service.getTemplate(taskId);
     if (!result.ok) {
       setTemplate(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }

--- a/packages/app-react/src/hooks/useTaskTemplates.ts
+++ b/packages/app-react/src/hooks/useTaskTemplates.ts
@@ -7,6 +7,7 @@ import type {
   TaskTimeConfigDTO,
 } from '@memoflow/contracts/task';
 import type { TaskTemplate } from '@memoflow/task/client';
+import { presentErrorMessage } from '@memoflow/http-client';
 
 import { useAppSession } from './useAppSession';
 import { useTaskService } from './useTaskService';
@@ -131,7 +132,7 @@ export function useTaskTemplates() {
 
     if (!result.ok) {
       setTemplates([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -167,7 +168,7 @@ export function useTaskTemplates() {
 
       if (!result.ok) {
         setTemplates([]);
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }

--- a/packages/app-react/src/providers/app-session-provider.tsx
+++ b/packages/app-react/src/providers/app-session-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, type PropsWithChildren, useContext, useEffect, useRef, useState } from 'react';
 import { createCloudAuthHttpClient, type CloudAuthClientPort } from '@memoflow/cloud-auth';
 import type { CloudAccountSummary, CloudSessionSummary, CloudSignInRequest, CloudSignUpRequest } from '@memoflow/contracts';
-import { createResultHttpClient, type IResultHttpClient } from '@memoflow/http-client';
+import { createResultHttpClient, presentErrorMessage, type IResultHttpClient } from '@memoflow/http-client';
 import { MOBILE_API_BASE_URL } from '../constants/auth';
 
 export type AppSessionKind = 'signed-out' | 'authenticating' | 'authenticated' | 'guest' | 'demo';
@@ -70,7 +70,7 @@ export function AppSessionProvider({ children }: PropsWithChildren) {
     const result = await auth.current!.signIn(req);
     if (!result.ok || !result.data.session) {
       setSessionKind('signed-out');
-      setLastError(result.ok ? 'Verify your email before signing in.' : result.error.message);
+      setLastError(result.ok ? 'Verify your email before signing in.' : presentErrorMessage(result.error));
       return false;
     }
     setCurrentIdentity(result.data.account);
@@ -85,7 +85,7 @@ export function AppSessionProvider({ children }: PropsWithChildren) {
     const result = await auth.current!.signUp(req);
     if (!result.ok) {
       setSessionKind('signed-out');
-      setLastError(result.error.message);
+      setLastError(presentErrorMessage(result.error));
       return false;
     }
     setCurrentIdentity(result.data.account);
@@ -97,7 +97,7 @@ export function AppSessionProvider({ children }: PropsWithChildren) {
 
   async function forgotPassword(req: { email: string }) {
     const result = await auth.current!.forgotPassword(req.email);
-    if (!result.ok) setLastError(result.error.message);
+    if (!result.ok) setLastError(presentErrorMessage(result.error));
     return result.ok;
   }
 

--- a/packages/app-react/src/screens/GoalDetailScreen.tsx
+++ b/packages/app-react/src/screens/GoalDetailScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { useGoalDetail } from '../hooks/useGoalDetail';
 import { useGoalService } from '../hooks/useGoalService';
 
@@ -36,7 +38,7 @@ export function GoalDetailScreen() {
     const result = await service.activateGoal(goalId, goal.version);
     setIsMutating(false);
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
     await refresh();
@@ -49,7 +51,7 @@ export function GoalDetailScreen() {
     const result = await service.completeGoal(goalId, goal.version);
     setIsMutating(false);
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
     await refresh();
@@ -62,7 +64,7 @@ export function GoalDetailScreen() {
     const result = await service.archiveGoal(goalId, goal.version);
     setIsMutating(false);
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
     await refresh();

--- a/packages/app-react/src/screens/GoalEditorScreen.tsx
+++ b/packages/app-react/src/screens/GoalEditorScreen.tsx
@@ -3,6 +3,8 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { CreateGoalReq, UpdateGoalReq } from '@memoflow/contracts/goal';
 import {
   ImportanceLevel,
@@ -121,7 +123,7 @@ export function GoalEditorScreen() {
     setIsSubmitting(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/GoalKeyResultScreen.tsx
+++ b/packages/app-react/src/screens/GoalKeyResultScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { GoalRecordClientDTO, KeyResultClientDTO } from '@memoflow/contracts/goal';
 import { useGoalService } from '../hooks/useGoalService';
 
@@ -67,7 +69,7 @@ export function GoalKeyResultScreen() {
       setKeyResult(null);
       setGoalVersion(null);
       setRecords([]);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -116,7 +118,7 @@ export function GoalKeyResultScreen() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 
@@ -142,7 +144,7 @@ export function GoalKeyResultScreen() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/GoalReviewDetailScreen.tsx
+++ b/packages/app-react/src/screens/GoalReviewDetailScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { GoalReviewSummary } from '../hooks/useGoalReviews';
 import { useGoalService } from '../hooks/useGoalService';
 import { formatProductDate, emptyKind } from '../utils/product-time';
@@ -56,7 +58,7 @@ export function GoalReviewDetailScreen() {
     if (!result.ok) {
       setReview(null);
       setGoalVersion(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -114,7 +116,7 @@ export function GoalReviewDetailScreen() {
     });
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 
@@ -149,7 +151,7 @@ export function GoalReviewDetailScreen() {
     });
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/GoalReviewScreen.tsx
+++ b/packages/app-react/src/screens/GoalReviewScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { ReviewType, type CreateGoalReviewReq } from '@memoflow/contracts/goal';
 
 import { useGoalDetail } from '../hooks/useGoalDetail';
@@ -72,7 +74,7 @@ export function GoalReviewScreen() {
     setIsSubmitting(false);
 
     if (!result.ok) {
-      setSubmitError(result.error.message);
+      setSubmitError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/NotificationDetailScreen.tsx
+++ b/packages/app-react/src/screens/NotificationDetailScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { NotificationClientDTO } from '@memoflow/contracts/notification';
 
 import { useAppSession } from '../hooks/useAppSession';
@@ -45,7 +47,7 @@ export function NotificationDetailScreen() {
     const result = await service.findNotificationById(notificationId);
     if (!result.ok) {
       setNotification(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -67,7 +69,7 @@ export function NotificationDetailScreen() {
     const result = await service.markAsRead(notificationId);
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 
@@ -83,7 +85,7 @@ export function NotificationDetailScreen() {
     const result = await service.deleteNotification(notificationId);
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/ReminderDetailScreen.tsx
+++ b/packages/app-react/src/screens/ReminderDetailScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { ReminderTemplateClientDTO } from '@memoflow/contracts/reminder';
 
 import { useAppSession } from '../hooks/useAppSession';
@@ -48,7 +50,7 @@ export function ReminderDetailScreen() {
     const result = await service.getReminderTemplate(reminderId);
     if (!result.ok) {
       setTemplate(null);
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       setIsLoading(false);
       return;
     }
@@ -70,7 +72,7 @@ export function ReminderDetailScreen() {
     const result = await service.toggleTemplateEnabled(reminderId);
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 
@@ -86,7 +88,7 @@ export function ReminderDetailScreen() {
     const result = await service.deleteReminderTemplate(reminderId);
     setIsMutating(false);
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/ReminderEditorScreen.tsx
+++ b/packages/app-react/src/screens/ReminderEditorScreen.tsx
@@ -3,6 +3,8 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import {
   NotificationChannel,
   ReminderType,
@@ -61,7 +63,7 @@ export function ReminderEditorScreen() {
       setError(null);
       const result = await service.getReminderTemplate(reminderId);
       if (!result.ok) {
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }
@@ -151,7 +153,7 @@ export function ReminderEditorScreen() {
     setIsSubmitting(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/ScheduleEventEditorScreen.tsx
+++ b/packages/app-react/src/screens/ScheduleEventEditorScreen.tsx
@@ -3,6 +3,8 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import type { ConflictDetectionResult, CreateScheduleRequest, UpdateScheduleRequest } from '@memoflow/contracts/schedule';
 
 import { useScheduleService } from '../hooks/useScheduleService';
@@ -119,7 +121,7 @@ export function ScheduleEventEditorScreen() {
 
       const result = await service.getSchedule(scheduleId);
       if (!result.ok) {
-        setError(result.error.message);
+        setError(presentErrorMessage(result.error));
         setIsLoading(false);
         return;
       }
@@ -162,7 +164,7 @@ export function ScheduleEventEditorScreen() {
         });
 
         if (!result.ok) {
-          setConflictError(result.error.message);
+          setConflictError(presentErrorMessage(result.error));
           return;
         }
 
@@ -189,7 +191,7 @@ export function ScheduleEventEditorScreen() {
     });
 
     if (!result.ok) {
-      setConflictError(result.error.message);
+      setConflictError(presentErrorMessage(result.error));
       return;
     }
 
@@ -241,7 +243,7 @@ export function ScheduleEventEditorScreen() {
     setIsSubmitting(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 
@@ -264,7 +266,7 @@ export function ScheduleEventEditorScreen() {
     setIsDeleting(false);
 
     if (!result.ok) {
-      setError(result.error.message);
+      setError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/ScheduleScreen.tsx
+++ b/packages/app-react/src/screens/ScheduleScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { ScheduleTaskStatus } from '@memoflow/contracts/schedule';
 
 import { ScheduleTaskCard } from '../components/ScheduleTaskCard';
@@ -135,7 +137,7 @@ export function ScheduleScreen() {
     setMutatingId(taskId);
 
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/TaskDetailScreen.tsx
+++ b/packages/app-react/src/screens/TaskDetailScreen.tsx
@@ -3,6 +3,8 @@ import { RefreshControl, StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { getProductTime, formatProductDateTime, emptyKind } from '../utils/product-time';
 
 import { useTaskInstances } from '../hooks/useTaskInstances';
@@ -89,7 +91,7 @@ export function TaskDetailScreen() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
 
@@ -107,7 +109,7 @@ export function TaskDetailScreen() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
 
@@ -125,7 +127,7 @@ export function TaskDetailScreen() {
     setIsMutating(false);
 
     if (!result.ok) {
-      setActionError(result.error.message);
+      setActionError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/app-react/src/screens/TaskEditorScreen.tsx
+++ b/packages/app-react/src/screens/TaskEditorScreen.tsx
@@ -3,6 +3,8 @@ import { StyleSheet, View } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
+import { presentErrorMessage } from '@memoflow/http-client';
+
 import { ImportanceLevel } from '@memoflow/contracts/shared';
 import { TaskTimeType, TaskType, type CreateTaskTemplateReq, type UpdateTaskTemplateReq } from '@memoflow/contracts/task';
 
@@ -153,7 +155,7 @@ export function TaskEditorScreen() {
       setIsSaving(false);
 
       if (!result.ok) {
-        setFormError(result.error.message);
+        setFormError(presentErrorMessage(result.error));
         return;
       }
 
@@ -180,7 +182,7 @@ export function TaskEditorScreen() {
     setIsSaving(false);
 
     if (!result.ok) {
-      setFormError(result.error.message);
+      setFormError(presentErrorMessage(result.error));
       return;
     }
 

--- a/packages/http-client/src/__tests__/present-error-message.test.ts
+++ b/packages/http-client/src/__tests__/present-error-message.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EmptyFailureDetailsSchema,
+  FailureCategories,
+  createPublicFailure,
+  defineFailureRegistry,
+  toLegacyResultError,
+} from '@memoflow/contracts/result';
+import { presentErrorMessage } from '../result-error';
+
+const TestFailureRegistry = defineFailureRegistry({
+  NOT_FOUND: {
+    category: FailureCategories.NotFound,
+    details: EmptyFailureDetailsSchema,
+    retryHint: { kind: 'not_retryable' },
+    telemetry: 'test_not_found',
+  },
+});
+
+describe('presentErrorMessage', () => {
+  it('maps a result.error FORBIDDEN code to the stable message, never the raw', () => {
+    expect(
+      presentErrorMessage({ code: 'FORBIDDEN', message: 'Provider leaked: nope' }),
+    ).toBe('拒绝访问');
+  });
+
+  it('maps a result.error SERVICE_UNAVAILABLE code to the stable message', () => {
+    expect(presentErrorMessage({ code: 'SERVICE_UNAVAILABLE' })).toBe('服务不可用');
+  });
+
+  it('maps an unknown code to the UNKNOWN fallback', () => {
+    expect(presentErrorMessage({ code: 'MYSTERY_CODE', message: 'raw' })).toBe('操作失败');
+  });
+
+  it('maps an INTERNAL_ERROR code to the stable message, never the raw', () => {
+    expect(
+      presentErrorMessage({ code: 'INTERNAL_ERROR', message: 'stack trace raw' }),
+    ).toBe('服务器内部错误');
+  });
+
+  it('returns the UNKNOWN fallback for non-error / non-object input', () => {
+    expect(presentErrorMessage(null)).toBe('操作失败');
+    expect(presentErrorMessage(undefined)).toBe('操作失败');
+    expect(presentErrorMessage('oops')).toBe('操作失败');
+    expect(presentErrorMessage(42)).toBe('操作失败');
+  });
+
+  it('honors a provided fallbackMessage when the code is unknown', () => {
+    expect(presentErrorMessage({ code: 'MYSTERY_CODE' }, '自定义提示')).toBe('自定义提示');
+  });
+
+  it('resolves a PublicFailure-shaped error by its code', () => {
+    const failure = createPublicFailure(TestFailureRegistry, 'NOT_FOUND', {});
+    const resultError = toLegacyResultError(failure, 'Provider raw message');
+    expect(presentErrorMessage(resultError)).toBe('资源不存在');
+  });
+});

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -58,6 +58,7 @@ export {
 export {
   classifyNetworkError,
   normalizeResultError,
+  presentErrorMessage,
   statusToResultCode,
   statusToResultError,
   translateResultErrorMessage,

--- a/packages/http-client/src/result-error.ts
+++ b/packages/http-client/src/result-error.ts
@@ -188,3 +188,17 @@ export function translateResultErrorMessage(
     'Operation failed'
   );
 }
+
+/**
+ * Framework-free safe message for presentation layers without an i18n host
+ * (e.g. React Native / Expo). Resolves a STABLE code-derived message and NEVER
+ * surfaces an arbitrary provider/raw message as the primary user-visible text.
+ */
+export function presentErrorMessage(error: unknown, fallbackMessage?: string): string {
+  const normalized = normalizeResultError(error);
+  const code = normalized?.code ?? ResultCode.UNKNOWN;
+  if (isResultErrorMessageKey(code)) {
+    return getDefaultResultErrorMessage(code);
+  }
+  return fallbackMessage ?? getDefaultResultErrorMessage(ResultCode.UNKNOWN);
+}

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -7055,6 +7055,14 @@
       "measurementCollectors": []
     },
     {
+      "path": "packages/http-client/src/__tests__/present-error-message.test.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/http-client/vitest.config.ts"
+      ],
+      "measurementCollectors": []
+    },
+    {
       "path": "packages/http-client/src/__tests__/result-error.test.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -10590,7 +10598,7 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 5
+      "fileCount": 6
     },
     {
       "id": "packages/ipc-client/vitest.config.ts",
@@ -11526,7 +11534,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 989,
+    "unit": 990,
     "integration": 25,
     "smoke": 3,
     "boundary-ipc": 9,


### PR DESCRIPTION
## Summary

ACR-032 Batch B: eliminate mobile presentation raw-message ownership in app-react (React Native/Expo).

## Changes
- New framework-free `presentErrorMessage(error)` in @memoflow/http-client — resolves stable code-derived zh-CN message, never reads raw provider message. 7 unit tests.
- All 62 app-react `setError(x.error.message)` reads routed through it (14 hooks + 1 provider + 12 screens).

## Result
Inventory **138 → 76** (UI_RAW_RESULT_MESSAGE 63→1; single remaining = documented desktop startup-crash internal dev surface). Scanner passes.

## Validation
http-client 11 tests (incl 7 new), app-react tsc clean, scanner passed.