### PR TITLE
refactor(acr-049): replace message-text control flow with typed errors (8 branches)

### DIFF
--- a/docs/analysis/2026-08-18-acr-049-message-branches-review.md
+++ b/docs/analysis/2026-08-18-acr-049-message-branches-review.md
@@ -1,0 +1,48 @@
+# ADR-049 — FAILURE_MESSAGE_BRANCH Elimination Review Evidence
+
+> Date: 2026-08-18
+> Branch: `refactor/acr-049-message-branches`
+> Base: `fcb499d14` (main, after PR #236)
+> Scope: eliminate the 8 remaining message-text branch findings.
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review outcome
+
+All 8 `FAILURE_MESSAGE_BRANCH` findings eliminated by upgrading to typed/structured control flow.
+Inventory **76 → 68** (FAILURE_MESSAGE_BRANCH **8 → 0**). Scanner: `passed (no new or expired
+production findings)`, 95 stale baseline entries await the next rewrite.
+
+## 2. Changes per finding
+
+| # | File | Before | After |
+|---|------|--------|-------|
+| 1 | `app-vue/useAIChatSession.ts:131` | `message.includes('abort'\|'cancel')` fallback | removed; keeps structured `name==='AbortError'`/`code==='ABORTED'`/`DOMException` |
+| 2 | `goal/relation.use-cases.ts:40` | `e.message.includes('Unique')` | `isPrismaUniqueConstraintError` (P2002) |
+| 3 | `goal/wallet.use-cases.ts:54` | `e.message === 'ACCOUNT_NOT_FOUND'` | `e instanceof WalletAccountNotFoundError`; repo throws typed error |
+| 4 | `reminder/...calculation-service:214` | `error.message.includes('Invalid or unknown timezone')` | `instanceof InvalidTimezoneError` |
+| 5 | `schedule/schedule-domain-event-publisher:48-49` | `message.includes('lease lost')` | `instanceof ScheduleLeaseLostError` |
+| 6 | `schedule/schedule-rebuild-worker-service:82` | `err.message.toLowerCase().includes(...)` | `instanceof ScheduleLeaseLostError` |
+
+Supporting: 14 schedule lease-lost throws upgraded from `throw new Error('...(lease lost)')` to
+`throw new ScheduleLeaseLostError(...)` in both prisma and powersync repositories;
+`ScheduleLeaseLostError` constructor now accepts an optional message (default unchanged).
+
+## 3. Notes
+
+- `err.message` reads remaining in schedule services (L115/L83) are **diagnostic reporting**
+  (writing the reason into the outbox failed field), not branch control flow — compliant.
+- `isPrismaUniqueConstraintError` in `package/goal/src/server/application/errors/prisma-unique.ts`
+  uses structured Prisma `P2002` (via existing `mapPrismaError`) rather than message text.
+- New typed errors: `wallet-account-not-found-error.ts`, `InvalidTimezoneError` (reminder domain
+  errors), `ScheduleLeaseLostError` usage. Messages preserved (super(message)) so integration
+  asserts `.toThrow('ACCOUNT_NOT_FOUND')` / `/lease lost/` keep passing.
+
+## 4. Validation
+- app-vue composables: 16/288; goal use-cases+domain: 52/329; reminder domain: 18/218;
+  schedule application+prisma+lease: 18/145. All passed (independent re-run of scanner passed).
+- Per-package typecheck: `tsc --noEmit` with `node --stack_size=8192` (Node 26 TS stack-overflow workaround) — clean.
+- Env note: `pnpm nx run *:typecheck` triggers a pnpm install that requires Prisma engines + is
+  not usable here; direct tsc used per the memory note.
+
+## 5. Gate
+Review passes. `FAILURE_MESSAGE_BRANCH = 0`. Proceed to push + CI.

--- a/packages/app-vue/src/modules/ai/composables/useAIChatSession.ts
+++ b/packages/app-vue/src/modules/ai/composables/useAIChatSession.ts
@@ -124,13 +124,8 @@ export function useAIChatSession(options: UseAIChatSessionOptions) {
   function isAbortLikeError(error: unknown): boolean {
     if (error instanceof DOMException && error.name === 'AbortError') return true;
     if (!error || typeof error !== 'object') return false;
-    const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
-    if (candidate.name === 'AbortError' || candidate.code === 'ABORTED') return true;
-    if (typeof candidate.message === 'string') {
-      const message = candidate.message.toLowerCase();
-      return message.includes('abort') || message.includes('cancel');
-    }
-    return false;
+    const candidate = error as { name?: unknown; code?: unknown };
+    return candidate.name === 'AbortError' || candidate.code === 'ABORTED';
   }
 
   function abortActiveStream() {

--- a/packages/goal/src/server/application/errors/prisma-unique.ts
+++ b/packages/goal/src/server/application/errors/prisma-unique.ts
@@ -1,0 +1,13 @@
+/**
+ * Prisma unique-constraint guard (goal application layer).
+ *
+ * Detects a Prisma unique-constraint conflict via the structured Prisma error
+ * mapping (code `P2002` → `CONFLICT`) from `@memoflow/utils/errors`, never by
+ * branching on raw message text.
+ */
+
+import { mapPrismaError } from '@memoflow/utils/errors';
+
+export function isPrismaUniqueConstraintError(err: unknown): boolean {
+  return mapPrismaError(err)?.resultCode === 'CONFLICT';
+}

--- a/packages/goal/src/server/application/errors/wallet-account-not-found-error.ts
+++ b/packages/goal/src/server/application/errors/wallet-account-not-found-error.ts
@@ -1,0 +1,13 @@
+/**
+ * Wallet account not found (goal application layer).
+ *
+ * Typed provider-boundary error thrown by wallet repository implementations when
+ * `recordTransaction` targets a missing account. The message text is preserved
+ * for observability but control flow must use `instanceof`, never message text.
+ */
+export class WalletAccountNotFoundError extends Error {
+  constructor() {
+    super('ACCOUNT_NOT_FOUND');
+    this.name = 'WalletAccountNotFoundError';
+  }
+}

--- a/packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts
+++ b/packages/goal/src/server/application/use-cases/commands/__tests__/wallet.use-cases.spec.ts
@@ -5,6 +5,7 @@ import {
   ListWalletUseCase,
   RecordWalletTransactionUseCase,
 } from '../wallet.use-cases';
+import { WalletAccountNotFoundError } from '../../../errors/wallet-account-not-found-error';
 
 function mockRepo(): IWalletRepository {
   return {
@@ -78,7 +79,7 @@ describe('Wallet use cases (R7)', () => {
   it('maps ACCOUNT_NOT_FOUND to NOT_FOUND', async () => {
     const repo = mockRepo();
     repo.recordTransaction = vi.fn(async () => {
-      throw new Error('ACCOUNT_NOT_FOUND');
+      throw new WalletAccountNotFoundError();
     });
     const useCase = new RecordWalletTransactionUseCase(repo);
 

--- a/packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts
+++ b/packages/goal/src/server/application/use-cases/commands/relation.use-cases.ts
@@ -18,6 +18,7 @@ import type {
   SubjectRef,
 } from '../../../domain';
 import { SubjectTypes } from '../../../domain';
+import { isPrismaUniqueConstraintError } from '../../errors/prisma-unique';
 
 export class CreateRelationUseCase {
   constructor(private readonly repository: IRelationRepository) {}
@@ -36,8 +37,8 @@ export class CreateRelationUseCase {
       const dto = await this.repository.create({ identityId, ...input });
       return ok(dto);
     } catch (e) {
-      // 唯一键冲突 = 关系已存在（幂等）
-      if (e instanceof Error && e.message.includes('Unique')) {
+      // 唯一键冲突 = 关系已存在（幂等）— 结构化 Code P2002，非消息文本
+      if (isPrismaUniqueConstraintError(e)) {
         return error('CONFLICT', 'Relation already exists');
       }
       throw e;

--- a/packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts
+++ b/packages/goal/src/server/application/use-cases/commands/wallet.use-cases.ts
@@ -14,6 +14,7 @@ import type {
   WalletAccountDTO,
   WalletTransactionDTO,
 } from '../../../domain';
+import { WalletAccountNotFoundError } from '../../errors/wallet-account-not-found-error';
 
 export class CreateWalletAccountUseCase {
   constructor(private readonly repository: IWalletRepository) {}
@@ -51,7 +52,7 @@ export class RecordWalletTransactionUseCase {
     try {
       return ok(await this.repository.recordTransaction({ identityId, ...input }));
     } catch (e) {
-      if (e instanceof Error && e.message === 'ACCOUNT_NOT_FOUND') {
+      if (e instanceof WalletAccountNotFoundError) {
         return error('NOT_FOUND', 'Wallet account not found');
       }
       throw e;

--- a/packages/goal/src/server/domain/repositories/i-wallet-repository.ts
+++ b/packages/goal/src/server/domain/repositories/i-wallet-repository.ts
@@ -33,10 +33,12 @@ export interface WalletTransactionDTO {
  * 钱包仓储 Port / Wallet repository Port.
  *
  * @remarks
- * - amount 校验与 `ACCOUNT_NOT_FOUND → NOT_FOUND` 映射由 use case 完成；
- *   本 Port 可抛出原始 `ACCOUNT_NOT_FOUND` 错误。Amount validation and the
- *   `ACCOUNT_NOT_FOUND → NOT_FOUND` mapping happen in the use cases; this Port
- *   may throw the raw `ACCOUNT_NOT_FOUND` error.
+ * - amount 校验与账户缺失映射由 use case 完成；`recordTransaction` 在账户缺失时
+ *   抛出 `WalletAccountNotFoundError`（typed，消息文本仅供观测，控制流必须用
+ *   instanceof）。Amount validation and the account-missing mapping happen in
+ *   the use cases; `recordTransaction` throws `WalletAccountNotFoundError` when
+ *   the account is missing (typed; the message text is observational only, branch
+ *   with instanceof).
  * - `recordTransaction` 由实现保证单事务原子性（余额更新 + 交易写入同生共死）。
  *   Implementations must keep the balance update and the transaction insert
  *   atomic inside one database transaction.

--- a/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.ts
+++ b/packages/goal/src/server/infrastructure/adapters/prisma/wallet-prisma.repository.ts
@@ -5,18 +5,20 @@ import type {
   WalletTransactionDTO,
 } from '../../../domain';
 import { PrismaWalletMapper } from './mappers/prisma-wallet.mapper';
+import { WalletAccountNotFoundError } from '../../../application/errors/wallet-account-not-found-error';
 
 /**
  * Prisma 钱包仓储（R7）/ Prisma wallet repository (R7).
  *
  * 保留默认 currency `CNY`、所有 Decimal 字段 `.toString()`、所有 Date 字段
  * `.getTime()`；`recordTransaction` 保持单个 `db.$transaction`：先按
- * `{ id: accountId, identityId }` 查账户，缺失抛 `ACCOUNT_NOT_FOUND`，
- * 再按 `income/expense/transfer` delta 规则更新余额并创建交易。
+ * `{ id: accountId, identityId }` 查账户，缺失抛 `WalletAccountNotFoundError`
+ * （结构化错误，非裸消息文本），再按 `income/expense/transfer` delta 规则更新
+ * 余额并创建交易。
  * Keeps the default `CNY` currency, `.toString()` on all Decimal fields,
  * `.getTime()` on all Date fields, and `recordTransaction` inside one
  * `db.$transaction`: find the account by `{ id: accountId, identityId }`,
- * throw `ACCOUNT_NOT_FOUND` when missing, then update the balance by the
+ * throw `WalletAccountNotFoundError` when missing, then update the balance by the
  * `income/expense/transfer` delta rule and insert the transaction.
  */
 export class WalletPrismaRepository implements IWalletRepository {
@@ -64,7 +66,7 @@ export class WalletPrismaRepository implements IWalletRepository {
         where: { id: input.accountId, identityId: input.identityId },
       });
       if (!account) {
-        throw new Error('ACCOUNT_NOT_FOUND');
+        throw new WalletAccountNotFoundError();
       }
       const delta =
         input.type === 'income' ? input.amount : `-${input.amount}`;

--- a/packages/reminder/src/server/domain/errors/reminder-errors.ts
+++ b/packages/reminder/src/server/domain/errors/reminder-errors.ts
@@ -54,3 +54,15 @@ export class ReminderTemplateSaveError extends DomainError {
     super('REMINDER_TEMPLATE_SAVE_FAILED', `保存提醒模板失败: ${message}`, context, 500);
   }
 }
+
+/**
+ * 无效时区（fail-fast）
+ * 用于提醒触发时间计算：无效 IANA 时区应立刻失败，而不是被计算逻辑吞掉。
+ * 控制流用 instanceof 判断，不依赖消息文本。
+ */
+export class InvalidTimezoneError extends Error {
+  constructor(timezone: string) {
+    super(`Invalid or unknown timezone: "${timezone}"`);
+    this.name = 'InvalidTimezoneError';
+  }
+}

--- a/packages/reminder/src/server/domain/services/upcoming-reminder-calculation-service.ts
+++ b/packages/reminder/src/server/domain/services/upcoming-reminder-calculation-service.ts
@@ -24,6 +24,7 @@ import type {
   TriggerConfigDTO,
   UpcomingReminderDTO,
 } from '@memoflow/contracts/reminder';
+import { InvalidTimezoneError } from '../errors/reminder-errors';
 
 const REMINDER_CALCULATION_DEBUG =
   typeof process !== 'undefined' && process.env.DEBUG_REMINDER_CALCULATION === 'true';
@@ -211,7 +212,7 @@ export class UpcomingReminderCalculationService {
 
       return null;
     } catch (error) {
-      if (error instanceof Error && error.message.includes('Invalid or unknown timezone')) {
+      if (error instanceof InvalidTimezoneError) {
         throw error;
       }
       console.error(`[UpcomingReminderCalculationService] 计算提醒 ${reminder.id} 失败:`, error);
@@ -230,7 +231,7 @@ export class UpcomingReminderCalculationService {
     try {
       Intl.DateTimeFormat(undefined, { timeZone: timezone });
     } catch {
-      throw new Error(`Invalid or unknown timezone: "${timezone}"`);
+      throw new InvalidTimezoneError(timezone);
     }
   }
 

--- a/packages/schedule/src/server/application/services/__tests__/schedule-domain-event-publisher.spec.ts
+++ b/packages/schedule/src/server/application/services/__tests__/schedule-domain-event-publisher.spec.ts
@@ -6,6 +6,7 @@ import type {
   ScheduleRebuildOutboxDTO,
 } from '../../domain/repositories/i-schedule-repository';
 import type { CalendarEntry } from '../../domain/aggregates/calendar-entry';
+import { ScheduleLeaseLostError } from '../../../infrastructure/lease/schedule-lease-coordinator';
 import {
   ScheduleDomainEventPublisherRuntime,
   ScheduleDomainEventPublisherService,
@@ -100,7 +101,9 @@ class InMemoryDomainEventOutboxRepository implements IScheduleRepository {
   ): Promise<void> {
     const item = this.outbox.find((o) => o.id === id);
     if (!item || item.claimToken !== claimToken || item.status !== 'processing') {
-      throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+      throw new ScheduleLeaseLostError(
+        `Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`,
+      );
     }
     if (!error) {
       item.status = 'completed';
@@ -262,9 +265,7 @@ describe('ScheduleDomainEventPublisherService — durable delivery semantics', (
           ensureHeld: async () => {
             guardCalls += 1;
             if (guardCalls >= 3) {
-              const err = new Error('Schedule host lease ownership was lost');
-              err.name = 'ScheduleLeaseLostError';
-              throw err;
+              throw new ScheduleLeaseLostError();
             }
           },
         });

--- a/packages/schedule/src/server/application/services/__tests__/schedule-domain-event-publisher.spec.ts
+++ b/packages/schedule/src/server/application/services/__tests__/schedule-domain-event-publisher.spec.ts
@@ -6,7 +6,7 @@ import type {
   ScheduleRebuildOutboxDTO,
 } from '../../domain/repositories/i-schedule-repository';
 import type { CalendarEntry } from '../../domain/aggregates/calendar-entry';
-import { ScheduleLeaseLostError } from '../../../infrastructure/lease/schedule-lease-coordinator';
+import { ScheduleLeaseLostError } from '../../../domain/errors/schedule-lease-lost-error';
 import {
   ScheduleDomainEventPublisherRuntime,
   ScheduleDomainEventPublisherService,

--- a/packages/schedule/src/server/application/services/schedule-domain-event-publisher.ts
+++ b/packages/schedule/src/server/application/services/schedule-domain-event-publisher.ts
@@ -5,6 +5,7 @@ import type {
   IScheduleRepository,
   ScheduleDomainEventOutboxDTO,
 } from '../../domain/repositories/i-schedule-repository';
+import { ScheduleLeaseLostError } from '../../infrastructure/lease/schedule-lease-coordinator';
 import type {
   ScheduleLeaseCoordinatorPort,
 } from './schedule-rebuild-worker-service';
@@ -41,13 +42,7 @@ export class PublishBeforeAckFaultError extends Error {
 }
 
 function isLeaseLostError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const message = err.message.toLowerCase();
-  return (
-    err.name === 'ScheduleLeaseLostError' ||
-    message.includes('lease ownership was lost') ||
-    message.includes('lease lost')
-  );
+  return err instanceof ScheduleLeaseLostError;
 }
 
 /**

--- a/packages/schedule/src/server/application/services/schedule-domain-event-publisher.ts
+++ b/packages/schedule/src/server/application/services/schedule-domain-event-publisher.ts
@@ -5,7 +5,7 @@ import type {
   IScheduleRepository,
   ScheduleDomainEventOutboxDTO,
 } from '../../domain/repositories/i-schedule-repository';
-import { ScheduleLeaseLostError } from '../../infrastructure/lease/schedule-lease-coordinator';
+import { ScheduleLeaseLostError } from '../../domain/errors/schedule-lease-lost-error';
 import type {
   ScheduleLeaseCoordinatorPort,
 } from './schedule-rebuild-worker-service';

--- a/packages/schedule/src/server/application/services/schedule-rebuild-worker-service.ts
+++ b/packages/schedule/src/server/application/services/schedule-rebuild-worker-service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { IScheduleRepository } from '../../domain/repositories/i-schedule-repository';
-import { ScheduleLeaseLostError } from '../../infrastructure/lease/schedule-lease-coordinator';
+import { ScheduleLeaseLostError } from '../../domain/errors/schedule-lease-lost-error';
 import { ScheduleConflictCacheService } from './schedule-conflict-cache-service';
 import type { UnifiedOperationMetricsRecorder } from '@memoflow/patterns/operations';
 

--- a/packages/schedule/src/server/application/services/schedule-rebuild-worker-service.ts
+++ b/packages/schedule/src/server/application/services/schedule-rebuild-worker-service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { IScheduleRepository } from '../../domain/repositories/i-schedule-repository';
+import { ScheduleLeaseLostError } from '../../infrastructure/lease/schedule-lease-coordinator';
 import { ScheduleConflictCacheService } from './schedule-conflict-cache-service';
 import type { UnifiedOperationMetricsRecorder } from '@memoflow/patterns/operations';
 
@@ -76,11 +77,7 @@ export class ScheduleRebuildWorkerService {
           this.metrics?.recordOutbox('schedule-rebuild', 'succeeded');
           processedCount++;
         } catch (err: unknown) {
-          const isLeaseLost =
-            err instanceof Error &&
-            (err.name === 'ScheduleLeaseLostError' ||
-              err.message.toLowerCase().includes('lease ownership was lost'));
-          if (isLeaseLost) {
+          if (err instanceof ScheduleLeaseLostError) {
             throw err;
           }
           const errorMessage = err instanceof Error ? err.message : 'Unknown worker error';

--- a/packages/schedule/src/server/domain/errors/index.ts
+++ b/packages/schedule/src/server/domain/errors/index.ts
@@ -1,0 +1,2 @@
+// Schedule errors - business-specific error classes
+export * from './schedule-lease-lost-error';

--- a/packages/schedule/src/server/domain/errors/schedule-lease-lost-error.ts
+++ b/packages/schedule/src/server/domain/errors/schedule-lease-lost-error.ts
@@ -1,0 +1,12 @@
+/**
+ * 调度宿主租约丢失错误
+ *
+ * 跨层类型错误：由基础设施的租约协调器抛出，但应用服务用 `instanceof` 做控制流判断。
+ * 定义在领域层，基础设施与应用层均可依赖（应用 → 领域允许，基础设施 → 领域允许）。
+ */
+export class ScheduleLeaseLostError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Schedule host lease ownership was lost');
+    this.name = 'ScheduleLeaseLostError';
+  }
+}

--- a/packages/schedule/src/server/domain/index.ts
+++ b/packages/schedule/src/server/domain/index.ts
@@ -52,3 +52,6 @@ export * from './services';
 
 // ============ 业务计算器 ============
 export * from './calculators';
+
+// ============ 错误类 ============
+export * from './errors';

--- a/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-powersync.repository.ts
+++ b/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-powersync.repository.ts
@@ -1,6 +1,6 @@
 import type { IScheduleRepository, ScheduleRebuildOutboxDTO } from '../../../domain/repositories/i-schedule-repository';
 import type { CalendarEntry } from '../../../domain/aggregates/calendar-entry';
-import { ScheduleLeaseLostError } from '../../lease/schedule-lease-coordinator';
+import { ScheduleLeaseLostError } from '../../../domain/errors/schedule-lease-lost-error';
 import {
   PowerSyncScheduleMapper,
   type PowerSyncScheduleRow,

--- a/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-powersync.repository.ts
+++ b/packages/schedule/src/server/infrastructure/adapters/powersync/schedule-powersync.repository.ts
@@ -1,5 +1,6 @@
 import type { IScheduleRepository, ScheduleRebuildOutboxDTO } from '../../../domain/repositories/i-schedule-repository';
 import type { CalendarEntry } from '../../../domain/aggregates/calendar-entry';
+import { ScheduleLeaseLostError } from '../../lease/schedule-lease-coordinator';
 import {
   PowerSyncScheduleMapper,
   type PowerSyncScheduleRow,
@@ -542,7 +543,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
       [id, claimToken, 'processing'],
     );
     if (!existing) {
-      throw new Error(`Rebuild outbox item ${id} is not owned by this claim token (lease lost)`);
+      throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is not owned by this claim token (lease lost)`);
     }
 
     if (!error) {
@@ -553,7 +554,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nowIso, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
       return;
     }
@@ -567,7 +568,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nextAttempts, error, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     } else {
       const backoffMs = Math.pow(2, nextAttempts) * 1000;
@@ -579,7 +580,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nextAttempts, nextAttemptIso, error, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     }
   }
@@ -714,7 +715,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
       [id, claimToken, 'processing'],
     );
     if (!existing) {
-      throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+      throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
     }
 
     if (!error) {
@@ -725,7 +726,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nowIso, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
       return;
     }
@@ -739,7 +740,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nextAttempts, error, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     } else {
       const backoffMs = Math.pow(2, nextAttempts) * 1000;
@@ -751,7 +752,7 @@ export class PowerSyncScheduleRepository implements IScheduleRepository {
         [nextAttempts, nextAttemptIso, error, nowIso, id, claimToken],
       );
       if (res.rowsAffected === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     }
   }

--- a/packages/schedule/src/server/infrastructure/adapters/prisma/schedule-prisma.repository.ts
+++ b/packages/schedule/src/server/infrastructure/adapters/prisma/schedule-prisma.repository.ts
@@ -9,6 +9,7 @@
 import type { PrismaClient, Schedule as PrismaSchedule } from '@memoflow/database';
 import type { IScheduleRepository, ScheduleRebuildOutboxDTO } from '../../../domain/repositories/i-schedule-repository';
 import { CalendarEntry } from '../../../domain/aggregates/calendar-entry';
+import { ScheduleLeaseLostError } from '../../lease/schedule-lease-coordinator';
 import { PrismaScheduleMapper } from './mappers/prisma-schedule-mapper';
 import { toResultErrorException } from '@memoflow/contracts/result';
 import type { UnifiedOperationMetricsRecorder } from '@memoflow/patterns/operations';
@@ -437,7 +438,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
       return;
     }
@@ -446,7 +447,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
       where: { id, claimToken, status: 'processing' },
     });
     if (!existing) {
-      throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+      throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
     }
 
     const nextAttempts = existing.attempts + 1;
@@ -461,7 +462,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     } else {
       const backoffMs = Math.pow(2, nextAttempts) * 1000;
@@ -476,7 +477,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Rebuild outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     }
   }
@@ -584,7 +585,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
       return;
     }
@@ -593,7 +594,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
       where: { id, claimToken, status: 'processing' },
     });
     if (!existing) {
-      throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+      throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
     }
 
     const nextAttempts = existing.attempts + 1;
@@ -608,7 +609,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     } else {
       const backoffMs = Math.pow(2, nextAttempts) * 1000;
@@ -623,7 +624,7 @@ export class SchedulePrismaRepository implements IScheduleRepository {
         },
       });
       if (res.count === 0) {
-        throw new Error(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
+        throw new ScheduleLeaseLostError(`Domain event outbox item ${id} is no longer owned by this claim token (lease lost)`);
       }
     }
   }

--- a/packages/schedule/src/server/infrastructure/adapters/prisma/schedule-prisma.repository.ts
+++ b/packages/schedule/src/server/infrastructure/adapters/prisma/schedule-prisma.repository.ts
@@ -9,7 +9,7 @@
 import type { PrismaClient, Schedule as PrismaSchedule } from '@memoflow/database';
 import type { IScheduleRepository, ScheduleRebuildOutboxDTO } from '../../../domain/repositories/i-schedule-repository';
 import { CalendarEntry } from '../../../domain/aggregates/calendar-entry';
-import { ScheduleLeaseLostError } from '../../lease/schedule-lease-coordinator';
+import { ScheduleLeaseLostError } from '../../../domain/errors/schedule-lease-lost-error';
 import { PrismaScheduleMapper } from './mappers/prisma-schedule-mapper';
 import { toResultErrorException } from '@memoflow/contracts/result';
 import type { UnifiedOperationMetricsRecorder } from '@memoflow/patterns/operations';

--- a/packages/schedule/src/server/infrastructure/lease/schedule-lease-coordinator.ts
+++ b/packages/schedule/src/server/infrastructure/lease/schedule-lease-coordinator.ts
@@ -6,8 +6,8 @@ export const SCHEDULE_LEASE_RENEWAL_INTERVAL_MS = 20_000;
 export const SCHEDULE_LEASE_KEY = 'schedule-host';
 
 export class ScheduleLeaseLostError extends Error {
-  constructor() {
-    super('Schedule host lease ownership was lost');
+  constructor(message?: string) {
+    super(message ?? 'Schedule host lease ownership was lost');
     this.name = 'ScheduleLeaseLostError';
   }
 }

--- a/packages/schedule/src/server/infrastructure/lease/schedule-lease-coordinator.ts
+++ b/packages/schedule/src/server/infrastructure/lease/schedule-lease-coordinator.ts
@@ -1,16 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import type { IScheduleLeaseRepository, ScheduleLeaseRequest } from '../../application/ports/schedule-lease.port';
+import { ScheduleLeaseLostError } from '../../domain/errors/schedule-lease-lost-error';
 
 export const SCHEDULE_LEASE_TTL_MS = 60_000;
 export const SCHEDULE_LEASE_RENEWAL_INTERVAL_MS = 20_000;
 export const SCHEDULE_LEASE_KEY = 'schedule-host';
-
-export class ScheduleLeaseLostError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Schedule host lease ownership was lost');
-    this.name = 'ScheduleLeaseLostError';
-  }
-}
 
 export interface ScheduleLeaseGuard {
   ensureHeld(): Promise<void>;


### PR DESCRIPTION
## Summary

Eliminate all 8 FAILURE_MESSAGE_BRANCH findings by upgrading to typed/structured control flow.

## Changes
- **useAIChatSession**: abort detection drops message fallback, keeps name/code/DOMException
- **relation.use-cases**: unique conflict via structured P2002 (isPrismaUniqueConstraintError)
- **wallet.use-cases**: ACCOUNT_NOT_FOUND → typed WalletAccountNotFoundError (repo throws it)
- **reminder**: timezone error → typed InvalidTimezoneError
- **schedule**: 14 lease-lost repo throws → ScheduleLeaseLostError; both services branch on instanceof

## Result
Inventory **76 → 68** (FAILURE_MESSAGE_BRANCH 8→0). Scanner passes. Diagnostic message writes to outbox reason fields retained (not control flow).

## Validation
app-vue 288, goal 329, reminder 218, schedule 145 tests pass; typecheck clean.