### PR TITLE
refactor(acr-080): migrate goal DomainError subclasses to ResultErrorException (pilot)

### DIFF
--- a/docs/analysis/2026-08-18-acr-080-goal-domainerror-pilot-review.md
+++ b/docs/analysis/2026-08-18-acr-080-goal-domainerror-pilot-review.md
@@ -1,0 +1,48 @@
+# ADR-080 Pilot — Goal DomainError → ResultErrorException Migration Review Evidence
+
+> Date: 2026-08-18
+> Branch: `refactor/acr-080-goal-domainerror-pilot`
+> Base: `c48f8e498` (main, after PR #237)
+> Scope: goal package 16 DomainError subclasses → ResultErrorException (vertical slice of ACR-080).
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review outcome
+
+Goal's 16 DomainError subclasses migrated to the established `ResultErrorException`
+(`@memoflow/contracts/result`) shape:
+
+- `domain/value-objects/errors.ts` (13): GoalNameRequiredError … GoalReviewRatingInvalidError
+- `application/errors/weight-snapshot-errors.ts` (2): GoalNotFoundError, KeyResultNotFoundError
+- `domain/value-objects/weight-errors.ts` (1): InvalidWeightError
+
+Pattern: `extends DomainError` → `extends ResultErrorException`, constructor
+`super(code, message, context?, httpStatus)` → `super(message, code, undefined, context, statusCode)`.
+Messages and codes preserved exactly; `super()` argument positions swapped per
+ResultErrorException signature. Old `.details` object members and `.statusCode` declarations
+removed (ResultErrorException supplies statusCode; object details mapped to `context`).
+
+**Inventory `DOMAIN_ERROR_SUBCLASS` 47 → 31** (goal 16 → 0); total 68 → 52. Scanner `passed`.
+
+## 2. Why safe
+
+- The API pipeline (`extractStructuredResultError` → `mapInfraErrorToFailure` → error
+  middleware) recognizes `ResultErrorException` FIRST — no mapper/middleware change needed.
+- No goal use-case branches on these class names (verified: only tests consume them).
+- `goal.ts` aggregates throw the same classes (types compatible) — no change.
+- Referenced-memory confirms ResultErrorException is the intended ACR-080 replacement.
+
+## 3. Test alignment
+
+- `weight-snapshot-errors.spec.ts`: 2 assertions `error.details` (object) → `error.context`
+  (same information, now on the ResultErrorException.context field). Intent preserved.
+- `instanceof`-based tests (goal-policy, value-objects specs) untouched and pass.
+
+## 4. Validation
+- Goal vitest 18 files / 128 passed; typecheck (tsc --noEmit) clean.
+- goal no longer imports `DomainError` anywhere.
+- Inventory scanner `passed`; 111 stale baseline entries await next rewrite.
+
+## 5. Gate
+Pilot passes. This proves the ResultErrorException migration pattern with zero API-contract
+regression. Remaining DomainError classes (task 10, schedule 7, reminder 4, setting 3, utils 7,
+plus goal's prisma-unique if it still extends DomainError) cleared in follow-on batches.

--- a/packages/goal/src/server/application/errors/weight-snapshot-errors.spec.ts
+++ b/packages/goal/src/server/application/errors/weight-snapshot-errors.spec.ts
@@ -6,7 +6,7 @@ describe('WeightSnapshotErrors', () => {
     const error = new GoalNotFoundError('goal-1');
     expect(error.code).toBe('GOAL_NOT_FOUND');
     expect(error.message).toContain('goal-1');
-    expect(error.details).toEqual({ goalId: 'goal-1' });
+    expect(error.context).toEqual({ goalId: 'goal-1' });
     expect(error.statusCode).toBe(404);
   });
 
@@ -14,7 +14,7 @@ describe('WeightSnapshotErrors', () => {
     const error = new KeyResultNotFoundError('kr-1', 'goal-1');
     expect(error.code).toBe('KEY_RESULT_NOT_FOUND');
     expect(error.message).toContain('kr-1');
-    expect(error.details).toEqual({ krId: 'kr-1', goalId: 'goal-1' });
+    expect(error.context).toEqual({ krId: 'kr-1', goalId: 'goal-1' });
     expect(error.statusCode).toBe(404);
   });
 });

--- a/packages/goal/src/server/application/errors/weight-snapshot-errors.ts
+++ b/packages/goal/src/server/application/errors/weight-snapshot-errors.ts
@@ -3,35 +3,25 @@
  * 权重快照应用层错误
  */
 
-import { DomainError } from '@memoflow/utils/errors';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
 /**
  * Goal 未找到错误
  */
-export class GoalNotFoundError extends DomainError {
-  public readonly details: { goalId: string };
-  public readonly statusCode: number;
-
+export class GoalNotFoundError extends ResultErrorException {
   constructor(goalId: string) {
-    super('GOAL_NOT_FOUND', `Goal not found: ${goalId}`, { goalId }, 404);
-    this.details = { goalId };
-    this.statusCode = 404;
+    super(`Goal not found: ${goalId}`, 'GOAL_NOT_FOUND', undefined, { goalId }, 404);
   }
 }
 
 /**
  * KeyResult 未找到错误
  */
-export class KeyResultNotFoundError extends DomainError {
-  public readonly details: { krId: string; goalId?: string };
-  public readonly statusCode: number;
-
+export class KeyResultNotFoundError extends ResultErrorException {
   constructor(krId: string, goalId?: string) {
     const message = goalId
       ? `KeyResult not found in Goal ${goalId}: ${krId}`
       : `KeyResult not found: ${krId}`;
-    super('KEY_RESULT_NOT_FOUND', message, { krId, goalId }, 404);
-    this.details = { krId, goalId };
-    this.statusCode = 404;
+    super(message, 'KEY_RESULT_NOT_FOUND', undefined, { krId, goalId }, 404);
   }
 }

--- a/packages/goal/src/server/domain/value-objects/errors.ts
+++ b/packages/goal/src/server/domain/value-objects/errors.ts
@@ -3,29 +3,29 @@
  * 目标模块领域错误
  */
 
-import { DomainError } from '@memoflow/utils/errors';
+import { ResultErrorException } from '@memoflow/contracts/result';
 import type { GoalId } from './goal-id';
 
 /**
  * 目标名称必填错误
  */
-export class GoalNameRequiredError extends DomainError {
+export class GoalNameRequiredError extends ResultErrorException {
   constructor() {
-    super('goal_name_required', '目标名称不能为空');
+    super('目标名称不能为空', 'goal_name_required');
   }
 }
 
 /**
  * 目标日期范围无效错误
  */
-export class GoalInvalidDateRangeError extends DomainError {
+export class GoalInvalidDateRangeError extends ResultErrorException {
   constructor(
     public readonly startDate: number,
     public readonly targetDate: number,
   ) {
     super(
-      'goal_invalid_date_range',
       `目标日期范围无效：开始日期 ${startDate} 晚于目标日期 ${targetDate}`,
+      'goal_invalid_date_range',
     );
   }
 }
@@ -33,14 +33,14 @@ export class GoalInvalidDateRangeError extends DomainError {
 /**
  * 目标日期修改无效错误
  */
-export class GoalInvalidDateModificationError extends DomainError {
+export class GoalInvalidDateModificationError extends ResultErrorException {
   constructor(
     public readonly operation: 'Extend' | 'Shorten',
     public readonly days: number,
   ) {
     super(
-      'goal_invalid_date_modification',
       `无效的日期${operation === 'Extend' ? '延长' : '缩短'}操作：天数 ${days} 必须为正数`,
+      'goal_invalid_date_modification',
     );
   }
 }
@@ -48,38 +48,38 @@ export class GoalInvalidDateModificationError extends DomainError {
 /**
  * 目标目标日期未设置错误
  */
-export class GoalTargetDateNotSetError extends DomainError {
+export class GoalTargetDateNotSetError extends ResultErrorException {
   constructor() {
-    super('goal_target_date_not_set', '目标日期未设置');
+    super('目标日期未设置', 'goal_target_date_not_set');
   }
 }
 
 /**
  * 关键结果未找到错误
  */
-export class GoalKeyResultNotFoundError extends DomainError {
+export class GoalKeyResultNotFoundError extends ResultErrorException {
   constructor(keyResultId: string) {
-    super('goal_key_result_not_found', `关键结果未找到：${keyResultId}`);
+    super(`关键结果未找到：${keyResultId}`, 'goal_key_result_not_found');
   }
 }
 
 /**
  * 目标回顾未找到错误
  */
-export class GoalReviewNotFoundError extends DomainError {
+export class GoalReviewNotFoundError extends ResultErrorException {
   constructor(reviewId: string) {
-    super('goal_review_not_found', `目标回顾未找到：${reviewId}`);
+    super(`目标回顾未找到：${reviewId}`, 'goal_review_not_found');
   }
 }
 
 /**
  * 关键结果未在目标中找到错误
  */
-export class KeyResultNotFoundInGoalError extends DomainError {
+export class KeyResultNotFoundInGoalError extends ResultErrorException {
   constructor(keyResultId: string, goalId: GoalId) {
     super(
-      'key_result_not_found_in_goal',
       `关键结果 ${keyResultId} 未在目标 ${goalId.toString()} 中找到`,
+      'key_result_not_found_in_goal',
     );
   }
 }
@@ -87,11 +87,11 @@ export class KeyResultNotFoundInGoalError extends DomainError {
 /**
  * 目标已删除错误
  */
-export class GoalDeletedError extends DomainError {
+export class GoalDeletedError extends ResultErrorException {
   constructor(goalId?: string) {
     super(
-      'goal_deleted',
       goalId ? `目标 ${goalId} 已删除，无法执行此操作` : '目标已删除，无法执行此操作',
+      'goal_deleted',
     );
   }
 }
@@ -99,11 +99,11 @@ export class GoalDeletedError extends DomainError {
 /**
  * 目标已归档错误
  */
-export class GoalArchivedError extends DomainError {
+export class GoalArchivedError extends ResultErrorException {
   constructor(goalId?: string) {
     super(
-      'goal_archived',
       goalId ? `目标 ${goalId} 已归档，无法执行此操作` : '目标已归档，无法执行此操作',
+      'goal_archived',
     );
   }
 }
@@ -111,29 +111,29 @@ export class GoalArchivedError extends DomainError {
 /**
  * 目标标题过长错误
  */
-export class GoalNameTooLongError extends DomainError {
+export class GoalNameTooLongError extends ResultErrorException {
   constructor(maxLength: number = 200) {
-    super('goal_name_too_long', `目标名称过长（最大 ${maxLength} 个字符）`);
+    super(`目标名称过长（最大 ${maxLength} 个字符）`, 'goal_name_too_long');
   }
 }
 
 /**
  * 关键结果权重无效错误
  */
-export class KeyResultWeightInvalidError extends DomainError {
+export class KeyResultWeightInvalidError extends ResultErrorException {
   constructor(weight: number) {
-    super('key_result_weight_invalid', `关键结果权重 ${weight} 无效（必须在 1-5 之间的整数）`);
+    super(`关键结果权重 ${weight} 无效（必须在 1-5 之间的整数）`, 'key_result_weight_invalid');
   }
 }
 
 /**
  * 关键结果权重总和超出错误
  */
-export class KeyResultWeightExceededError extends DomainError {
+export class KeyResultWeightExceededError extends ResultErrorException {
   constructor(currentTotal: number, adding: number) {
     super(
-      'key_result_weight_exceeded',
       `关键结果权重超出范围：当前总计 ${currentTotal}，添加 ${adding}`,
+      'key_result_weight_exceeded',
     );
   }
 }
@@ -141,8 +141,8 @@ export class KeyResultWeightExceededError extends DomainError {
 /**
  * 目标回顾评分无效错误
  */
-export class GoalReviewRatingInvalidError extends DomainError {
+export class GoalReviewRatingInvalidError extends ResultErrorException {
   constructor(rating: number) {
-    super('goal_review_rating_invalid', `目标回顾评分 ${rating} 无效（必须在 1-5 之间）`);
+    super(`目标回顾评分 ${rating} 无效（必须在 1-5 之间）`, 'goal_review_rating_invalid');
   }
 }

--- a/packages/goal/src/server/domain/value-objects/weight-errors.ts
+++ b/packages/goal/src/server/domain/value-objects/weight-errors.ts
@@ -2,13 +2,14 @@
  * Domain errors for Goal value objects
  */
 
-import { DomainError } from '@memoflow/utils/errors';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
-export class InvalidWeightError extends DomainError {
+export class InvalidWeightError extends ResultErrorException {
   constructor(field: string, value: number) {
     super(
-      'VALIDATION_ERROR',
       `Invalid weight value for ${field}: ${value}. Must be between 0 and 100.`,
+      'VALIDATION_ERROR',
+      undefined,
       { field, value },
       422,
     );


### PR DESCRIPTION
## Summary

ACR-080 vertical pilot: migrate goal's 16 DomainError subclasses to ResultErrorException (@memoflow/contracts/result), the established ACR-080 replacement.

## Changes
- 13 value-object errors + 2 weight-snapshot errors + 1 weight error: `extends DomainError` → `extends ResultErrorException` (super arg swap: message,code; object details→context).
- Messages/codes preserved; goal no longer imports DomainError.
- API pipeline (extractStructuredResultError) recognizes ResultErrorException first → no mapper/middleware change, zero API-contract regression.

## Result
Inventory **68 → 52** (DOMAIN_ERROR_SUBCLASS 47→31, goal 16→0). Scanner passes.

## Validation
goal vitest 128, typecheck clean. 1 spec assertion aligned (details object → context).