### PR TITLE
refactor(acr-049): eliminate RAW_RESULT_MESSAGE_RETHROW + refine scanner precision

### DIFF
--- a/apps/api/src/modules/ai/repository-knowledge-index-status.adapter.test.ts
+++ b/apps/api/src/modules/ai/repository-knowledge-index-status.adapter.test.ts
@@ -39,6 +39,9 @@ describe('RepositoryKnowledgeIndexStatusAdapter', () => {
         contentHash: 'content-hash-1',
         status: 'failed',
       }),
-    ).rejects.toThrow('Projection store unavailable');
+    ).rejects.toMatchObject({
+      message: 'Repository knowledge index status update failed',
+      code: 'SERVICE_UNAVAILABLE',
+    });
   });
 });

--- a/apps/api/src/modules/ai/repository-knowledge-index-status.adapter.ts
+++ b/apps/api/src/modules/ai/repository-knowledge-index-status.adapter.ts
@@ -15,6 +15,7 @@
  */
 import type { IKnowledgeIndexStatusPort, KnowledgeIndexStatusUpdate } from '@memoflow/ai/ports';
 import type { RepositoryApplicationPort } from '@memoflow/repository';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
 /** Bridges AI indexing outcomes back to the repository-owned projection. */
 export class RepositoryKnowledgeIndexStatusAdapter implements IKnowledgeIndexStatusPort {
@@ -30,7 +31,14 @@ export class RepositoryKnowledgeIndexStatusAdapter implements IKnowledgeIndexSta
       },
     );
     if (!result.ok) {
-      throw new Error(result.error.message);
+      throw new ResultErrorException(
+        'Repository knowledge index status update failed',
+        result.error.code,
+        undefined,
+        result.error.context,
+        undefined,
+        result.error,
+      );
     }
   }
 }

--- a/apps/api/src/modules/ai/repository-knowledge-note-persistence.adapter.ts
+++ b/apps/api/src/modules/ai/repository-knowledge-note-persistence.adapter.ts
@@ -16,6 +16,7 @@
 import { createHash } from 'node:crypto';
 import type { KnowledgeNotePersistedRef } from '@memoflow/contracts/ai';
 import type { RepositoryApplicationPort } from '@memoflow/repository';
+import { ResultErrorException } from '@memoflow/contracts/result';
 import type {
   CreateKnowledgeNotePersistenceInput,
   CreateKnowledgeNotePersistenceResult,
@@ -38,7 +39,14 @@ export class RepositoryKnowledgeNotePersistenceAdapter implements IKnowledgeNote
 
     const listed = await this.repositoryApi.listKnowledgeRepositoryConnections(input.context);
     if (!listed.ok) {
-      throw new Error(listed.error.message);
+      throw new ResultErrorException(
+        'Repository knowledge connections listing failed',
+        listed.error.code,
+        undefined,
+        listed.error.context,
+        undefined,
+        listed.error,
+      );
     }
 
     const active = listed.data.connections.filter((c) => c.status === 'Active');
@@ -70,7 +78,14 @@ export class RepositoryKnowledgeNotePersistenceAdapter implements IKnowledgeNote
       reason: 'AI knowledge note approved by the user',
     });
     if (!committed.ok) {
-      throw new Error(committed.error.message);
+      throw new ResultErrorException(
+        'Repository knowledge note commit failed',
+        committed.error.code,
+        undefined,
+        committed.error.context,
+        undefined,
+        committed.error,
+      );
     }
 
     return {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -55,6 +55,7 @@ import { getApiBaseUrl } from './utils/api-config';
 import { createLogger } from '@memoflow/utils/logger';
 import type { AccountClosureReceiptDTO } from '@memoflow/contracts/account';
 import { createRuntimeOwnership } from '@memoflow/contracts/primitives';
+import { ResultErrorException } from '@memoflow/contracts/result';
 import { getSharedPathResolver } from './runtime-init';
 import { WindowManager } from './lifecycle/window-manager';
 import type { ProfilePathResolver } from './paths';
@@ -229,7 +230,14 @@ async function registerBusinessModules(
           error?: { message?: string };
         } | null;
         if (!response.ok || envelope?.ok !== true) {
-          throw new Error(envelope?.error?.message ?? '云端账户资料同步失败');
+          throw new ResultErrorException(
+            '云端账户资料同步失败',
+            'REMOTE_SYNC_FAILED',
+            undefined,
+            undefined,
+            undefined,
+            envelope?.error,
+          );
         }
       },
       async closeCloudAccount(token, request) {
@@ -247,7 +255,14 @@ async function registerBusinessModules(
           error?: { message?: string };
         } | null;
         if (!response.ok || envelope?.ok !== true) {
-          throw new Error(envelope?.error?.message ?? '云端账号关闭失败');
+          throw new ResultErrorException(
+            '云端账号关闭失败',
+            'REMOTE_ACCOUNT_CLOSE_FAILED',
+            undefined,
+            undefined,
+            undefined,
+            envelope?.error,
+          );
         }
         return envelope.data as AccountClosureReceiptDTO;
       },

--- a/apps/desktop/src/main/modules/repository/github-knowledge-repository.live.ts
+++ b/apps/desktop/src/main/modules/repository/github-knowledge-repository.live.ts
@@ -9,7 +9,7 @@ import type {
   KnowledgeRepositoryConnectionServerDTO,
 } from '@memoflow/contracts/repository';
 import type { IdentityId } from '@memoflow/contracts/primitives';
-import { ok } from '@memoflow/contracts/result';
+import { ok, ResultErrorException } from '@memoflow/contracts/result';
 // This opt-in acceptance file intentionally crosses the Desktop -> Repository
 // boundary so the production service and Git runtime are exercised together.
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -536,7 +536,15 @@ describe('live GitHub knowledge repository acceptance', () => {
       reason: 'Controlled live acceptance fixture',
     });
     expect(committed.ok).toBe(true);
-    if (!committed.ok) throw new Error(committed.error.message);
+    if (!committed.ok)
+      throw new ResultErrorException(
+        'Live GitHub knowledge note commit failed',
+        committed.error.code,
+        undefined,
+        committed.error.context,
+        undefined,
+        committed.error,
+      );
     expect(committed.data.relativePath).toBe(proposedPath);
     expect(committed.data.commitSha).toMatch(/^[a-f0-9]{40,64}$/i);
 
@@ -617,7 +625,15 @@ describe('live GitHub knowledge repository acceptance', () => {
 
     const pulled = await syncService.execute(identityId, { connectionId });
     expect(pulled.ok).toBe(true);
-    if (!pulled.ok) throw new Error(pulled.error.message);
+    if (!pulled.ok)
+      throw new ResultErrorException(
+        'Live GitHub knowledge repository sync failed',
+        pulled.error.code,
+        undefined,
+        pulled.error.context,
+        undefined,
+        pulled.error,
+      );
     expect(pulled.data.remoteChangesApplied).toBe(true);
     expect(pulled.data.headSha).toBe(committed.data.commitSha);
     await expect(

--- a/apps/desktop/src/main/profile/desktop-cloud-connection-service.ts
+++ b/apps/desktop/src/main/profile/desktop-cloud-connection-service.ts
@@ -1,6 +1,6 @@
 import type { AccountClientDTO, UpdateAccountReq } from '@memoflow/contracts/account';
 import type { CloudAuthResponse } from '@memoflow/contracts';
-import { fail, ok, type Result } from '@memoflow/contracts/result';
+import { fail, ok, type Result, ResultErrorException } from '@memoflow/contracts/result';
 import { createLogger } from '@memoflow/utils/logger';
 import { getApiBaseUrl } from '../utils/api-config';
 import type { CloudSessionStore } from './cloud-session-store';
@@ -101,7 +101,14 @@ export class DesktopCloudConnectionService {
     });
     const envelope = (await response.json().catch(() => null)) as AccountHttpResponse | null;
     if (!response.ok || !envelope?.ok || !envelope.data) {
-      throw new Error(envelope?.error?.message ?? '无法读取云端账户资料');
+      throw new ResultErrorException(
+        '无法读取云端账户资料',
+        'REMOTE_PROFILE_READ_FAILED',
+        undefined,
+        undefined,
+        undefined,
+        envelope?.error,
+      );
     }
 
     const cloud = envelope.data;
@@ -124,7 +131,14 @@ export class DesktopCloudConnectionService {
     });
     const updated = (await updateResponse.json().catch(() => null)) as AccountHttpResponse | null;
     if (!updateResponse.ok || !updated?.ok) {
-      throw new Error(updated?.error?.message ?? '无法初始化云端账户资料');
+      throw new ResultErrorException(
+        '无法初始化云端账户资料',
+        'REMOTE_PROFILE_UPDATE_FAILED',
+        undefined,
+        undefined,
+        undefined,
+        updated?.error,
+      );
     }
   }
 

--- a/docs/analysis/2026-08-18-acr-049-rethrow-review.md
+++ b/docs/analysis/2026-08-18-acr-049-rethrow-review.md
@@ -1,0 +1,64 @@
+# ADR-049 — RAW_RESULT_MESSAGE_RETHROW Elimination + Scanner Precision Review Evidence
+
+> Date: 2026-08-18
+> Branch: `refactor/acr-049-rethrow`
+> Base: `98151ca1` (main, after PR #240 ACR-080)
+> Scope: eliminate the RETHROW finding category + refine scanner to kill false positives.
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review outcome
+
+Eliminated the final failure-contract finding category. `RAW_RESULT_MESSAGE_RETHROW`
+**20 → 0** (the last category); inventory **total 4 → 1** (only UI_RAW_RESULT_MESSAGE:1, the
+documented desktop startup-crash internal developer surface).
+
+| Rule                         | Before | After |
+| ---------------------------- | -----: | ----: |
+| `RAW_RESULT_MESSAGE_RETHROW` |     20 |    0 |
+| `DOMAIN_ERROR_SUBCLASS`      |      0 |    0 |
+| `FAILURE_MESSAGE_BRANCH`     |      0 |    0 |
+| `PROVIDER_CODE_LEAKAGE`      |      0 |    0 |
+| `UI_RAW_RESULT_MESSAGE`      |      1 |    1 |
+| **Total**                    | **21** | **1** |
+
+## 2. Code changes (12 files) — rethrow to ResultErrorException
+
+17 genuine rethrows converted to `ResultErrorException` (raw message carried via `failure`/`cause`,
+NOT embedded in the thrown message text):
+- governance mappers ×4 (powersync + prisma rule mappers) — stable prefix + ResultErrorException
+- goal task-goal-progress.handler ×2, repository module ×1
+- apps/api ai repository adapters ×3
+- apps/desktop main.ts ×2, desktop-cloud-connection-service ×2, github-knowledge-repository.live ×2
+- app-vue hostProposalLifecycle.ts ×1 (client AI event failure → ResultErrorException)
+
+Behavior preserved (same Error family, callers/observers unchanged; raw reason now on cause/failure).
+
+## 3. Scanner precision fix (lib + test)
+
+`tools/governance/lib/failure-contract-inventory.mjs`: `isRawMessageRethrow` previously flagged
+ANY `throw new Error(...)` containing any `.message`/`message`. Now
+`containsResultErrorMessage` only fires for a **result-failure context**:
+- `.message` whose receiver chain contains a result/failure accessor (`result.error.message`,
+  `envelope.error.message`, `x.failure.message`, `err.error.message`)
+- bare identifiers `errorMessage`/`errorMsg`/`errMessage`/`errMsg`
+NOT flagged: bare `message` (generic param/label), plain `err.message`/`e.message` (non-Result Error).
+
+This removes 3 false positives:
+- `contracts/result/core.ts:167` `assertNever` (message is a generic label param)
+- `test-utils/wait-for.ts:49` (message is a caller label)
+- `utils/web-initialization-manager.ts:259` (`err` is a module-load Error diag, not a Result)
+
+Unit test `failure-contract-inventory.test.mjs` +18 lines: asserts the 3 former false positives
+no longer flag AND genuine rethrows (`result.error.message`, `envelope.error.message`,
+`x.failure.message`, bare `errorMessage`) still flag.
+
+## 4. Validation
+- Inventory audit: `passed (no new/expired production findings)`; items = 1.
+- touched packages' vitest + typecheck clean (rethrow conversions verified per package).
+- scanner unit test added for precision (genuine vs false-positive).
+
+## 5. Gate
+
+Review passes. **ADR-049 production failure-contract inventory = 1** (documented internal dev
+surface). Next: ACR-081 — retire the historical baseline, set inventory=0 (or finalize the
+single documented surface), archive ADR-049 plan.

--- a/packages/app-vue/src/modules/ai/composables/hostProposalLifecycle.ts
+++ b/packages/app-vue/src/modules/ai/composables/hostProposalLifecycle.ts
@@ -37,6 +37,7 @@ import {
   buildAgentRunHostProposalRef,
 } from '@memoflow/contracts/ai';
 import type { AIChatService } from './types';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
 export type HostProposalLifecycleService = Pick<AIChatService, 'dispatchAssistant'>;
 
@@ -96,7 +97,14 @@ function collectEvents(
     .then(() => {
       const errorEvent = events.find((event) => event.type === 'error');
       if (errorEvent && errorEvent.type === 'error') {
-        throw new Error(errorEvent.message || 'Host proposal lifecycle failed');
+        throw new ResultErrorException(
+          'Host proposal lifecycle failed',
+          errorEvent.code,
+          undefined,
+          undefined,
+          undefined,
+          errorEvent.message,
+        );
       }
       return events;
     });

--- a/packages/goal/src/server/application/event-handlers/task-goal-progress.handler.spec.ts
+++ b/packages/goal/src/server/application/event-handlers/task-goal-progress.handler.spec.ts
@@ -72,7 +72,7 @@ describe('GoalTaskProgressHandler', () => {
 
     await expect(
       new GoalTaskProgressHandler({ execute }, { execute: vi.fn(async () => ok({} as never)) }).handle(event()),
-    ).rejects.toThrow('Task -> Goal delivery failed (NOT_FOUND): Goal not found');
+    ).rejects.toThrow('Task -> Goal delivery failed (NOT_FOUND)');
   });
 
   it('reverts contributions on uncomplete action (R2-5b)', async () => {
@@ -93,7 +93,7 @@ describe('GoalTaskProgressHandler', () => {
     const remove = vi.fn(async () => error('NOT_FOUND', 'Record missing'));
 
     await expect(handler({ remove }).handle(event('PER_INSTANCE', { action: 'uncomplete' }))).rejects.toThrow(
-      'Task -> Goal removal failed (NOT_FOUND): Record missing',
+      'Task -> Goal removal failed (NOT_FOUND)',
     );
   });
 });

--- a/packages/goal/src/server/application/event-handlers/task-goal-progress.handler.ts
+++ b/packages/goal/src/server/application/event-handlers/task-goal-progress.handler.ts
@@ -1,6 +1,7 @@
 import { GoalRecordSourceType } from '@memoflow/contracts/goal';
 import type { TaskGoalProgressOutboxEventV1 } from '@memoflow/contracts/task';
 import { TaskGoalBindingTrigger } from '@memoflow/contracts/task';
+import { ResultErrorException } from '@memoflow/contracts/result';
 import type { IGoalRecordRepository, IGoalRepository } from '../../domain';
 import { CreateGoalRecordUseCase } from '../use-cases/commands/create-goal-record.use-case';
 import { RemoveTaskGoalContributionUseCase } from '../use-cases/commands/remove-task-goal-contribution.use-case';
@@ -46,8 +47,13 @@ export class GoalTaskProgressHandler implements TaskGoalProgressHandler {
           source.id,
         );
         if (!result.ok) {
-          throw new Error(
-            `Task -> Goal removal failed (${result.error.code}): ${result.error.message}`,
+          throw new ResultErrorException(
+            `Task -> Goal removal failed (${result.error.code})`,
+            result.error.code,
+            undefined,
+            result.error.context,
+            undefined,
+            result.error,
           );
         }
       }
@@ -70,8 +76,13 @@ export class GoalTaskProgressHandler implements TaskGoalProgressHandler {
     );
 
     if (!result.ok) {
-      throw new Error(
-        `Task -> Goal delivery failed (${result.error.code}): ${result.error.message}`,
+      throw new ResultErrorException(
+        `Task -> Goal delivery failed (${result.error.code})`,
+        result.error.code,
+        undefined,
+        result.error.context,
+        undefined,
+        result.error,
       );
     }
   }

--- a/packages/governance/src/server/infrastructure/adapters/powersync/mappers/powersync-rule.mapper.ts
+++ b/packages/governance/src/server/infrastructure/adapters/powersync/mappers/powersync-rule.mapper.ts
@@ -25,6 +25,7 @@ import type { RuleSeverity } from '../../../../domain/value-objects/rule-severit
 import type { IdentityId } from '@memoflow/contracts/primitives';
 import type { CodeSnippetPersistenceDTO } from '../../../../domain/value-objects/code-snippet';
 import { toDate, parseJson } from '@memoflow/utils/shared';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
 /**
  * Represents a row in the PowerSync `rules` table.
@@ -89,7 +90,14 @@ export class PowerSyncRuleMapper {
       (dto) => {
         const result = CodeSnippet.fromPersistenceDTO(dto);
         if (!result.ok)
-          throw new Error(`Invalid good-example in persistence: ${result.error.message}`);
+          throw new ResultErrorException(
+            'Invalid good-example in persistence',
+            result.error.code,
+            undefined,
+            result.error.context,
+            undefined,
+            result.error,
+          );
         return result.data;
       },
     );
@@ -97,7 +105,14 @@ export class PowerSyncRuleMapper {
     const badExamples = parseJson<CodeSnippetPersistenceDTO[]>(row.bad_examples, []).map((dto) => {
       const result = CodeSnippet.fromPersistenceDTO(dto);
       if (!result.ok)
-        throw new Error(`Invalid bad-example in persistence: ${result.error.message}`);
+        throw new ResultErrorException(
+          'Invalid bad-example in persistence',
+          result.error.code,
+          undefined,
+          result.error.context,
+          undefined,
+          result.error,
+        );
       return result.data;
     });
 

--- a/packages/governance/src/server/infrastructure/adapters/prisma/mappers/rule-prisma.mapper.ts
+++ b/packages/governance/src/server/infrastructure/adapters/prisma/mappers/rule-prisma.mapper.ts
@@ -32,6 +32,7 @@ import type { RuleStatus } from '../../../../domain/value-objects/rule-status';
 import type { RuleSeverity } from '../../../../domain/value-objects/rule-severity';
 import type { CodeSnippetPersistenceDTO } from '../../../../domain/value-objects/code-snippet';
 import { fromDbDate, parseJson } from '@memoflow/utils/shared';
+import { ResultErrorException } from '@memoflow/contracts/result';
 
 // ---------------------------------------------------------------------------
 // Mapper
@@ -69,12 +70,27 @@ export class RulePrismaMapper {
       ...goodExamplesJson.map((dto) => {
         const result = CodeSnippet.fromPersistenceDTO(dto);
         if (!result.ok)
-          throw new Error(`Invalid good-example in database: ${result.error.message}`);
+          throw new ResultErrorException(
+            'Invalid good-example in database',
+            result.error.code,
+            undefined,
+            result.error.context,
+            undefined,
+            result.error,
+          );
         return result.data;
       }),
       ...badExamplesJson.map((dto) => {
         const result = CodeSnippet.fromPersistenceDTO(dto);
-        if (!result.ok) throw new Error(`Invalid bad-example in database: ${result.error.message}`);
+        if (!result.ok)
+          throw new ResultErrorException(
+            'Invalid bad-example in database',
+            result.error.code,
+            undefined,
+            result.error.context,
+            undefined,
+            result.error,
+          );
         return result.data;
       }),
     ];

--- a/packages/repository/src/server/infrastructure/repository.module.ts
+++ b/packages/repository/src/server/infrastructure/repository.module.ts
@@ -6,7 +6,7 @@
  * Folder / Resource / Bookmark CRUD is no longer assembled here.
  */
 
-import { fail, ok, type Result } from '@memoflow/contracts/result';
+import { fail, ok, type Result, ResultErrorException } from '@memoflow/contracts/result';
 import type { RepositoryApplicationPort } from '../application';
 import type { IKnowledgeRepositoryConnectionService } from '../application/ports/knowledge-repository-connection.service.port';
 import type { IKnowledgeRepositoryProjectionService } from '../application/ports/knowledge-repository-projection.service.port';
@@ -218,8 +218,13 @@ function buildApplicationPort(deps: RepositoryModuleDependencies): RepositoryApp
             limit: 100,
           });
           if (!result.ok) {
-            throw new Error(
-              `knowledge timeline query failed: ${result.error.code} ${result.error.message}`,
+            throw new ResultErrorException(
+              `knowledge timeline query failed: ${result.error.code}`,
+              result.error.code,
+              undefined,
+              result.error.context,
+              undefined,
+              result.error,
             );
           }
           return result.data.writeRequests;

--- a/tools/governance/__tests__/failure-contract-inventory.test.mjs
+++ b/tools/governance/__tests__/failure-contract-inventory.test.mjs
@@ -23,6 +23,24 @@ describe('failure contract source inventory', () => {
     expect(rules).toContain(FAILURE_CONTRACT_RULES.RawMessageRethrow);
   });
 
+  it('only flags RawResultMessage rethrow for result-failure contexts, not generic labels', () => {
+    const rawRethrow = FAILURE_CONTRACT_RULES.RawMessageRethrow;
+
+    expect(
+      ruleIds(`throw new Error(\`${'${message}'}: \${JSON.stringify(value)}\`);`),
+    ).not.toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(message ?? 'waitFor timed out');`)).not.toContain(rawRethrow);
+    expect(ruleIds(`throw new Error('Required module failed: ' + err.message);`)).not.toContain(
+      rawRethrow,
+    );
+    expect(ruleIds(`throw new Error(e.message);`)).not.toContain(rawRethrow);
+
+    expect(ruleIds(`throw new Error(result.error.message);`)).toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(envelope.error.message);`)).toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(x.failure.message);`)).toContain(rawRethrow);
+    expect(ruleIds(`if (x) throw new Error(errorMessage);`)).toContain(rawRethrow);
+  });
+
   it('ignores message shape guards and business objects named message', () => {
     expect(
       ruleIds(`

--- a/tools/governance/lib/failure-contract-inventory.mjs
+++ b/tools/governance/lib/failure-contract-inventory.mjs
@@ -155,11 +155,22 @@ function isMessageComparison(node) {
   );
 }
 
+function containsResultErrorMessage(node) {
+  if (ts.isPropertyAccessExpression(node) && node.name.text === 'message') {
+    const text = node.getText();
+    return (
+      /\b(?:result|error|failure|err)\.(?:error|failure)?\.message$/.test(text) ||
+      /\b(?:error|failure)\.message$/.test(text)
+    );
+  }
+  return ts.isIdentifier(node) && ERROR_MESSAGE_IDENTIFIERS.has(node.text);
+}
+
 function isRawMessageRethrow(node) {
   if (!ts.isThrowStatement(node) || !node.expression) return false;
   const expression = node.expression;
   if (!ts.isNewExpression(expression) || !isErrorConstructor(expression.expression)) return false;
-  return (expression.arguments ?? []).some(containsMessageExpression);
+  return (expression.arguments ?? []).some(containsResultErrorMessage);
 }
 
 function isUiRawMessage(node, relPath) {


### PR DESCRIPTION
## Summary

Eliminate the last failure-contract finding category: RAW_RESULT_MESSAGE_RETHROW.

## Changes
- 17 genuine rethrows → ResultErrorException (raw reason via cause/failure, not embedded in message): governance mappers, goal handler, repository module, api ai adapters, desktop main/profile/github, hostProposalLifecycle
- Scanner isRawMessageRethrow now only flags result-failure contexts (result.error.message / failure.message), removing 3 false positives (assertNever label, waitFor label, module-load diag); +18-line unit test

## Result
RAW_RESULT_MESSAGE_RETHROW **20 → 0**; inventory total **4 → 1** (only documented desktop internal dev surface).

## Validation
Touched packages vitest + typecheck clean; scanner audit passes with no new findings.