### PR TITLE
fix(acr-049): address GPT-5.6 secondary-review regressions

### DIFF
--- a/docs/analysis/2026-08-19-gpt56-review-fixes.md
+++ b/docs/analysis/2026-08-19-gpt56-review-fixes.md
@@ -1,0 +1,53 @@
+# Post-Review Fixes (GPT-5.6 secondary review findings) Review Evidence
+
+> Date: 2026-08-19
+> Branch: `fix/acr049-gpt56-review-findings`
+> Base: `151e6aec` (main, after PR #242)
+> Trigger: GPT-5.6-sol (worldclawpro, medium) secondary code review of ADR-049 migration found regressions missed by per-batch validation.
+> Implementing agent: opencode-go/deepseek-v4-flash.
+
+## 1. Review trigger & findings
+
+GPT-5.6 secondary review of the DomainError→ResultErrorException migration (Range: #239/#240/#241)
+returned: 1 false-positive P0 (timing artifact — reviewed a pre-#240 diff that still imported
+isDomainError; current main does NOT import it, verified) + 3 real P1 + 1 P2. The real ones are
+fixed here.
+
+## 2. Fixes
+
+### P1a — extractErrorInfo loses structured codes (AI controller regression)
+`packages/utils/src/errors/extract-error-info.ts` returned UNKNOWN_ERROR/500 for every Error
+(including ResultErrorException), so `ai-controller-errors.toAIControllerFailure` flattened
+validation/conflict/not-found → INTERNAL_ERROR.
+→ Added `extractStructuredResultError(error)` branch FIRST that preserves
+`code/message/httpStatus(=statusCode ?? 400)/context`. Generic Error → UNKNOWN_ERROR fallback kept.
+**ai transport 25/25 pass.**
+
+### P1b — HTTP status default 400 → 500 for feature-specific codes
+DomainError default httpStatus was 400; ResultErrorException leaves statusCode undefined, so
+feature-specific codes (not in ResultCodeToHttpStatus) fell to 500.
+→ Added explicit `statusCode: 400` to every migrated feature-specific error class that relied on
+the 400 default (task/schedule/setting/goal domain error classes in value-objects/errors-*.ts).
+Classes already passing explicit status (reminder 404/400/500, PriorityCalculation 400) left as-is.
+ResultCode-mapped classes (VALIDATION_ERROR etc.) left as-is (ResultCodeToHttpStatus handles).
+
+### P1c — hostProposalLifecycle stores raw string as cause
+`packages/app-vue/.../hostProposalLifecycle.ts` passed `errorEvent.message` (raw string) as cause.
+→ Wrapped the event message as an Error for cause (cause is now an Error/structured object), kept
+the thrown message stable. **app-vue hostProposalLifecycle.spec 122/122 pass.**
+
+### P2 — scanner bare `errorMessage` identifier false positive
+`failure-contract-inventory.mjs` flagged any bare `errorMessage`/`errorMsg`/`errMessage`/`errMsg`.
+→ Removed the bare-identifier branch in `containsResultErrorMessage`; only property-access
+`.message` on result/error receivers flags now. Scanner unit test updated (`throw new Error(errorMessage)`
+now NOT flagged; `.error.message` / `.failure.message` still flagged).
+
+## 3. Validation
+- utils 8 files/63, ai transport 25/25, app-vue hostProposal 122/122 pass (orchestrator re-run).
+- Inventory: `{UI_RAW_RESULT_MESSAGE:1}`, `passed`, 0 stale.
+- HTTP statuses for feature-specific errors restored to 400.
+
+## 4. Gate
+
+Review-driven fixes pass. Pre-existing dist/ptypo pnpm environment noise (prisma postinstall
+EPERM) is unrelated. This validates the value of the GPT-5.6 medium secondary review channel.

--- a/packages/app-vue/src/modules/ai/composables/hostProposalLifecycle.ts
+++ b/packages/app-vue/src/modules/ai/composables/hostProposalLifecycle.ts
@@ -103,7 +103,7 @@ function collectEvents(
           undefined,
           undefined,
           undefined,
-          errorEvent.message,
+          new Error(errorEvent.message),
         );
       }
       return events;

--- a/packages/goal/src/server/domain/value-objects/errors.ts
+++ b/packages/goal/src/server/domain/value-objects/errors.ts
@@ -11,7 +11,7 @@ import type { GoalId } from './goal-id';
  */
 export class GoalNameRequiredError extends ResultErrorException {
   constructor() {
-    super('目标名称不能为空', 'goal_name_required');
+    super('目标名称不能为空', 'goal_name_required', undefined, undefined, 400);
   }
 }
 
@@ -26,6 +26,9 @@ export class GoalInvalidDateRangeError extends ResultErrorException {
     super(
       `目标日期范围无效：开始日期 ${startDate} 晚于目标日期 ${targetDate}`,
       'goal_invalid_date_range',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -41,6 +44,9 @@ export class GoalInvalidDateModificationError extends ResultErrorException {
     super(
       `无效的日期${operation === 'Extend' ? '延长' : '缩短'}操作：天数 ${days} 必须为正数`,
       'goal_invalid_date_modification',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -50,7 +56,7 @@ export class GoalInvalidDateModificationError extends ResultErrorException {
  */
 export class GoalTargetDateNotSetError extends ResultErrorException {
   constructor() {
-    super('目标日期未设置', 'goal_target_date_not_set');
+    super('目标日期未设置', 'goal_target_date_not_set', undefined, undefined, 400);
   }
 }
 
@@ -59,7 +65,7 @@ export class GoalTargetDateNotSetError extends ResultErrorException {
  */
 export class GoalKeyResultNotFoundError extends ResultErrorException {
   constructor(keyResultId: string) {
-    super(`关键结果未找到：${keyResultId}`, 'goal_key_result_not_found');
+    super(`关键结果未找到：${keyResultId}`, 'goal_key_result_not_found', undefined, undefined, 400);
   }
 }
 
@@ -68,7 +74,7 @@ export class GoalKeyResultNotFoundError extends ResultErrorException {
  */
 export class GoalReviewNotFoundError extends ResultErrorException {
   constructor(reviewId: string) {
-    super(`目标回顾未找到：${reviewId}`, 'goal_review_not_found');
+    super(`目标回顾未找到：${reviewId}`, 'goal_review_not_found', undefined, undefined, 400);
   }
 }
 
@@ -80,6 +86,9 @@ export class KeyResultNotFoundInGoalError extends ResultErrorException {
     super(
       `关键结果 ${keyResultId} 未在目标 ${goalId.toString()} 中找到`,
       'key_result_not_found_in_goal',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -92,6 +101,9 @@ export class GoalDeletedError extends ResultErrorException {
     super(
       goalId ? `目标 ${goalId} 已删除，无法执行此操作` : '目标已删除，无法执行此操作',
       'goal_deleted',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -104,6 +116,9 @@ export class GoalArchivedError extends ResultErrorException {
     super(
       goalId ? `目标 ${goalId} 已归档，无法执行此操作` : '目标已归档，无法执行此操作',
       'goal_archived',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -113,7 +128,7 @@ export class GoalArchivedError extends ResultErrorException {
  */
 export class GoalNameTooLongError extends ResultErrorException {
   constructor(maxLength: number = 200) {
-    super(`目标名称过长（最大 ${maxLength} 个字符）`, 'goal_name_too_long');
+    super(`目标名称过长（最大 ${maxLength} 个字符）`, 'goal_name_too_long', undefined, undefined, 400);
   }
 }
 
@@ -122,7 +137,13 @@ export class GoalNameTooLongError extends ResultErrorException {
  */
 export class KeyResultWeightInvalidError extends ResultErrorException {
   constructor(weight: number) {
-    super(`关键结果权重 ${weight} 无效（必须在 1-5 之间的整数）`, 'key_result_weight_invalid');
+    super(
+      `关键结果权重 ${weight} 无效（必须在 1-5 之间的整数）`,
+      'key_result_weight_invalid',
+      undefined,
+      undefined,
+      400,
+    );
   }
 }
 
@@ -134,6 +155,9 @@ export class KeyResultWeightExceededError extends ResultErrorException {
     super(
       `关键结果权重超出范围：当前总计 ${currentTotal}，添加 ${adding}`,
       'key_result_weight_exceeded',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -143,6 +167,6 @@ export class KeyResultWeightExceededError extends ResultErrorException {
  */
 export class GoalReviewRatingInvalidError extends ResultErrorException {
   constructor(rating: number) {
-    super(`目标回顾评分 ${rating} 无效（必须在 1-5 之间）`, 'goal_review_rating_invalid');
+    super(`目标回顾评分 ${rating} 无效（必须在 1-5 之间）`, 'goal_review_rating_invalid', undefined, undefined, 400);
   }
 }

--- a/packages/schedule/src/server/domain/value-objects/errors.ts
+++ b/packages/schedule/src/server/domain/value-objects/errors.ts
@@ -22,6 +22,7 @@ export class ScheduleStrategyNotFoundError extends ResultErrorException {
       'schedule_strategy_not_found',
       undefined,
       context,
+      400,
     );
   }
 }
@@ -38,6 +39,9 @@ export class SourceEntityNoScheduleRequiredError extends ResultErrorException {
     super(
       `源实体不需要调度：${sourceModule}/${sourceEntityId}${reason ? ` (${reason})` : ''}`,
       'source_entity_no_schedule_required',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -56,7 +60,7 @@ export class ScheduleTaskCreationError extends ResultErrorException {
       'schedule_task_creation_error',
       undefined,
       undefined,
-      undefined,
+      400,
       originalError,
     );
   }
@@ -75,7 +79,7 @@ export class ScheduleTaskUpdateError extends ResultErrorException {
       'schedule_task_update_error',
       undefined,
       undefined,
-      undefined,
+      400,
       originalError,
     );
   }
@@ -86,7 +90,7 @@ export class ScheduleTaskUpdateError extends ResultErrorException {
  */
 export class ScheduleTaskNotFoundError extends ResultErrorException {
   constructor(taskId: string) {
-    super(`调度任务未找到：${taskId}`, 'schedule_task_not_found');
+    super(`调度任务未找到：${taskId}`, 'schedule_task_not_found', undefined, undefined, 400);
   }
 }
 
@@ -95,7 +99,7 @@ export class ScheduleTaskNotFoundError extends ResultErrorException {
  */
 export class ScheduleTaskDisabledError extends ResultErrorException {
   constructor(taskId: string) {
-    super(`调度任务已禁用：${taskId}`, 'schedule_task_disabled');
+    super(`调度任务已禁用：${taskId}`, 'schedule_task_disabled', undefined, undefined, 400);
   }
 }
 
@@ -107,6 +111,9 @@ export class ScheduleTaskInvalidStatusError extends ResultErrorException {
     super(
       `调度任务状态无效：${taskId} (当前状态: ${currentStatus})`,
       'schedule_task_invalid_status',
+      undefined,
+      undefined,
+      400,
     );
   }
 }

--- a/packages/setting/src/server/domain/errors/setting-errors.ts
+++ b/packages/setting/src/server/domain/errors/setting-errors.ts
@@ -17,6 +17,7 @@ export class UnknownSettingKeyError extends ResultErrorException {
       'setting_unknown_key',
       undefined,
       { key },
+      400,
     );
   }
 }
@@ -31,6 +32,7 @@ export class UnknownSettingCategoryError extends ResultErrorException {
       'setting_unknown_category',
       undefined,
       { category },
+      400,
     );
   }
 }
@@ -45,6 +47,7 @@ export class SettingValidationError extends ResultErrorException {
       'setting_validation_failed',
       undefined,
       { key, reason },
+      400,
     );
   }
 }

--- a/packages/task/src/server/domain/value-objects/task-errors.ts
+++ b/packages/task/src/server/domain/value-objects/task-errors.ts
@@ -10,7 +10,7 @@ import { ResultErrorException } from '@memoflow/contracts/result';
  */
 export class TaskTemplateNotFoundError extends ResultErrorException {
   constructor(templateId: string) {
-    super(`任务模板未找到：${templateId}`, 'task_template_not_found');
+    super(`任务模板未找到：${templateId}`, 'task_template_not_found', undefined, undefined, 400);
   }
 }
 
@@ -23,6 +23,9 @@ export class InvalidTaskTemplateStateError extends ResultErrorException {
     super(
       `${message}${contextStr}`,
       'invalid_task_template_state',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -32,7 +35,7 @@ export class InvalidTaskTemplateStateError extends ResultErrorException {
  */
 export class TaskTemplateArchivedError extends ResultErrorException {
   constructor(templateId: string) {
-    super(`任务模板已归档：${templateId}`, 'task_template_archived');
+    super(`任务模板已归档：${templateId}`, 'task_template_archived', undefined, undefined, 400);
   }
 }
 
@@ -44,6 +47,9 @@ export class RecurrenceRuleNotImplementedError extends ResultErrorException {
     super(
       `重复规则未实现：${ruleType}`,
       'recurrence_rule_not_implemented',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -53,7 +59,7 @@ export class RecurrenceRuleNotImplementedError extends ResultErrorException {
  */
 export class InvalidGoalBindingError extends ResultErrorException {
   constructor(reason: string) {
-    super(`目标绑定无效：${reason}`, 'invalid_goal_binding');
+    super(`目标绑定无效：${reason}`, 'invalid_goal_binding', undefined, undefined, 400);
   }
 }
 
@@ -67,6 +73,9 @@ export class InvalidDateRangeError extends ResultErrorException {
     super(
       `日期范围无效：开始日期 ${start.toISOString()} 晚于结束日期 ${end.toISOString()}`,
       'invalid_date_range',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -79,6 +88,9 @@ export class InstanceGenerationFailedError extends ResultErrorException {
     super(
       `任务实例生成失败：${templateId}${reason ? ` - ${reason}` : ''}`,
       'instance_generation_failed',
+      undefined,
+      undefined,
+      400,
     );
   }
 }
@@ -88,7 +100,7 @@ export class InstanceGenerationFailedError extends ResultErrorException {
  */
 export class TaskInstanceNotFoundError extends ResultErrorException {
   constructor(instanceId: string) {
-    super(`任务实例未找到：${instanceId}`, 'task_instance_not_found');
+    super(`任务实例未找到：${instanceId}`, 'task_instance_not_found', undefined, undefined, 400);
   }
 }
 
@@ -97,6 +109,12 @@ export class TaskInstanceNotFoundError extends ResultErrorException {
  */
 export class TaskInstanceAlreadyCompletedError extends ResultErrorException {
   constructor(instanceId: string) {
-    super(`任务实例已完成：${instanceId}`, 'task_instance_already_completed');
+    super(
+      `任务实例已完成：${instanceId}`,
+      'task_instance_already_completed',
+      undefined,
+      undefined,
+      400,
+    );
   }
 }

--- a/packages/utils/src/errors/extract-error-info.spec.ts
+++ b/packages/utils/src/errors/extract-error-info.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ResultErrorException } from '@memoflow/contracts/result';
+import { extractErrorInfo } from './extract-error-info';
+
+describe('extractErrorInfo', () => {
+  it('preserves structured code/status/context for a ResultErrorException', () => {
+    const ex = new ResultErrorException(
+      'task not found',
+      'task_template_not_found',
+      undefined,
+      { templateId: 't-1' },
+      400,
+    );
+    expect(extractErrorInfo(ex)).toEqual({
+      code: 'task_template_not_found',
+      message: 'task not found',
+      httpStatus: 400,
+      context: { templateId: 't-1' },
+    });
+  });
+
+  it('returns UNKNOWN_ERROR for a plain Error', () => {
+    expect(extractErrorInfo(new Error('boom'))).toEqual({
+      code: 'UNKNOWN_ERROR',
+      message: 'boom',
+      httpStatus: 500,
+    });
+  });
+
+  it('returns UNKNOWN_ERROR for non-error values', () => {
+    expect(extractErrorInfo('nope')).toEqual({
+      code: 'UNKNOWN_ERROR',
+      message: 'An unknown error occurred',
+      httpStatus: 500,
+    });
+  });
+});

--- a/packages/utils/src/errors/extract-error-info.ts
+++ b/packages/utils/src/errors/extract-error-info.ts
@@ -1,12 +1,24 @@
 /**
  * 从未知错误中提取错误信息
  */
+import { extractStructuredResultError } from '@memoflow/contracts/result';
+
 export function extractErrorInfo(error: unknown): {
   code: string;
   message: string;
   httpStatus: number;
   context?: Record<string, unknown>;
 } {
+  const structured = extractStructuredResultError(error);
+  if (structured) {
+    return {
+      code: structured.code,
+      message: structured.message,
+      httpStatus: structured.statusCode ?? 400,
+      context: structured.context,
+    };
+  }
+
   if (error instanceof Error) {
     return {
       code: 'UNKNOWN_ERROR',

--- a/tools/governance/__tests__/failure-contract-inventory.test.mjs
+++ b/tools/governance/__tests__/failure-contract-inventory.test.mjs
@@ -38,7 +38,9 @@ describe('failure contract source inventory', () => {
     expect(ruleIds(`throw new Error(result.error.message);`)).toContain(rawRethrow);
     expect(ruleIds(`throw new Error(envelope.error.message);`)).toContain(rawRethrow);
     expect(ruleIds(`throw new Error(x.failure.message);`)).toContain(rawRethrow);
-    expect(ruleIds(`if (x) throw new Error(errorMessage);`)).toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(exception.failure.message);`)).toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(errorMessage);`)).not.toContain(rawRethrow);
+    expect(ruleIds(`throw new Error(errMsg);`)).not.toContain(rawRethrow);
   });
 
   it('ignores message shape guards and business objects named message', () => {

--- a/tools/governance/lib/failure-contract-inventory.mjs
+++ b/tools/governance/lib/failure-contract-inventory.mjs
@@ -156,14 +156,12 @@ function isMessageComparison(node) {
 }
 
 function containsResultErrorMessage(node) {
-  if (ts.isPropertyAccessExpression(node) && node.name.text === 'message') {
-    const text = node.getText();
-    return (
-      /\b(?:result|error|failure|err)\.(?:error|failure)?\.message$/.test(text) ||
-      /\b(?:error|failure)\.message$/.test(text)
-    );
-  }
-  return ts.isIdentifier(node) && ERROR_MESSAGE_IDENTIFIERS.has(node.text);
+  if (!ts.isPropertyAccessExpression(node) || node.name.text !== 'message') return false;
+  const text = node.getText();
+  return (
+    /\b(?:result|error|failure|err)\.(?:error|failure)?\.message$/.test(text) ||
+    /\b(?:error|failure)\.message$/.test(text)
+  );
 }
 
 function isRawMessageRethrow(node) {

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -9984,6 +9984,14 @@
       "measurementCollectors": []
     },
     {
+      "path": "packages/utils/src/errors/extract-error-info.spec.ts",
+      "primarySuite": "unit",
+      "collectors": [
+        "packages/utils/vitest.config.ts"
+      ],
+      "measurementCollectors": []
+    },
+    {
       "path": "packages/utils/src/errors/result-error-mapper.spec.ts",
       "primarySuite": "unit",
       "collectors": [
@@ -10822,7 +10830,7 @@
       "type": "primary",
       "suite": "unit",
       "runner": "vitest",
-      "fileCount": 16
+      "fileCount": 17
     },
     {
       "id": "memoflow:test:governance",
@@ -11534,7 +11542,7 @@
   "duplicate": [],
   "unexpected": [],
   "counts": {
-    "unit": 990,
+    "unit": 991,
     "integration": 25,
     "smoke": 3,
     "boundary-ipc": 9,


### PR DESCRIPTION
## Summary

GPT-5.6-sol (worldclawpro, medium) secondary review of the DomainError→ResultErrorException migration found regressions that slipped past per-batch CI. Fixed all real findings:

- **P1a** extractErrorInfo flattened ResultErrorException → UNKNOWN_ERROR/500 (AI controller lost structured codes) — restored via extractStructuredResultError (+ new spec)
- **P1b** feature-specific error codes fell 400→500 (DomainError httpStatus default lost) — added explicit statusCode 400 to migrated feature error classes (task/schedule/setting/goal)
- **P1c** hostProposalLifecycle stored raw string as error cause — wrapped as Error
- **P2** scanner bare 'errorMessage' identifier false positive — removed heuristic

## Validation
Inventory stays {UI_RAW:1}/passed. utils 63, ai transport 25, app-vue hostProposal 122 pass. Test inventory regenerated (new spec).