### PR TITLE
fix(ci): emit evidence for coverage no-target runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -101,9 +101,14 @@ jobs:
           echo "has_target=$([ -n "$selected_projects" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "projects=$selected_projects" >> "$GITHUB_OUTPUT"
 
-      - name: No coverage targets selected
+      - name: Record no coverage targets selected
         if: steps.detect-coverage.outputs.has_target != 'true'
-        run: echo "No coverage targets selected for this run."
+        env:
+          DELIVERY_LANE: coverage
+          TEST_REPORT_NAME: coverage-no-targets
+        run: >-
+          node ./tools/test-system-v2/run-command.mjs -- node -e
+          "console.log('No governed coverage targets selected for this push.')"
 
       - name: Run governed coverage gates
         if: steps.detect-coverage.outputs.has_target == 'true'

--- a/tools/ci-cd-platform/__tests__/coverage-workflow.test.mjs
+++ b/tools/ci-cd-platform/__tests__/coverage-workflow.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const workflowUrl = new URL('../../../.github/workflows/coverage.yml', import.meta.url);
+
+test('coverage docs-only no-target path emits canonical lane evidence', async () => {
+  const workflow = await readFile(workflowUrl, 'utf8');
+  const noTargetStep = workflow.match(
+    /- name: Record no coverage targets selected[\s\S]*?(?=\n      - name: Run governed coverage gates)/,
+  )?.[0];
+
+  assert.ok(noTargetStep, 'coverage workflow must define a no-target evidence step');
+  assert.match(noTargetStep, /if: steps\.detect-coverage\.outputs\.has_target != 'true'/);
+  assert.match(noTargetStep, /DELIVERY_LANE: coverage/);
+  assert.match(noTargetStep, /TEST_REPORT_NAME: coverage-no-targets/);
+  assert.match(noTargetStep, /tools\/test-system-v2\/run-command\.mjs/);
+});

--- a/tools/test-system-v2/test-inventory.json
+++ b/tools/test-system-v2/test-inventory.json
@@ -9490,6 +9490,14 @@
       "measurementCollectors": []
     },
     {
+      "path": "tools/ci-cd-platform/__tests__/coverage-workflow.test.mjs",
+      "primarySuite": "governance",
+      "collectors": [
+        "ci-cd-platform:test"
+      ],
+      "measurementCollectors": []
+    },
+    {
       "path": "tools/ci-cd-platform/__tests__/failure-matrix.test.mjs",
       "primarySuite": "governance",
       "collectors": [
@@ -10206,7 +10214,7 @@
       "type": "primary",
       "suite": "governance",
       "runner": "node-test",
-      "fileCount": 15
+      "fileCount": 16
     },
     {
       "id": "tools/governance/vitest.config.ts",
@@ -10852,6 +10860,6 @@
     "boundary-main": 5,
     "e2e": 63,
     "perf": 4,
-    "governance": 34
+    "governance": 35
   }
 }


### PR DESCRIPTION
## Summary
- make docs-only/no-target Coverage runs emit canonical lane evidence
- keep governed coverage gates unchanged when targets are selected
- add a regression test for the workflow contract

## Validation
- `node --test tools/ci-cd-platform/__tests__/coverage-workflow.test.mjs`
- `node --test tools/ci-cd-platform/__tests__/*.test.mjs` (37/37 pass)
- `git diff --check`