### PR TITLE
fix(api): align local validation security headers

### DIFF
--- a/apps/api/src/shared/infrastructure/config/web-origin.spec.ts
+++ b/apps/api/src/shared/infrastructure/config/web-origin.spec.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { deriveWebOrigin, getTrustedWebOrigins } from './web-origin.js';
+import {
+  deriveWebOrigin,
+  getTrustedWebOrigins,
+  shouldDisableCrossOriginOpenerPolicyForLocalValidation,
+} from './web-origin.js';
 
 /**
  * O2V-01: the MagicDNS public Web origin is auto-included in the API trusted
@@ -11,9 +15,9 @@ import { deriveWebOrigin, getTrustedWebOrigins } from './web-origin.js';
 
 describe('deriveWebOrigin', () => {
   it('strips the trailing path from a MagicDNS Web URL', () => {
-    expect(
-      deriveWebOrigin('http://oracle.taile92a8e.ts.net:58080/auth/verify'),
-    ).toBe('http://oracle.taile92a8e.ts.net:58080');
+    expect(deriveWebOrigin('http://oracle.taile92a8e.ts.net:58080/auth/verify')).toBe(
+      'http://oracle.taile92a8e.ts.net:58080',
+    );
   });
 
   it('keeps an already-origin URL unchanged', () => {
@@ -27,6 +31,50 @@ describe('deriveWebOrigin', () => {
 
   it('returns undefined for an unparseable URL', () => {
     expect(deriveWebOrigin('not a url')).toBeUndefined();
+  });
+});
+
+describe('shouldDisableCrossOriginOpenerPolicyForLocalValidation', () => {
+  it('disables inert COOP for controlled non-loopback HTTP validation origins', () => {
+    expect(
+      shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+        'http://gcp-dev-01.taile92a8e.ts.net:53080/api/auth',
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('preserves Helmet COOP for HTTPS validation origins', () => {
+    expect(
+      shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+        'https://gcp-dev-01.taile92a8e.ts.net/api/auth',
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves Helmet COOP for potentially trustworthy loopback HTTP', () => {
+    expect(
+      shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+        'http://127.0.0.1:53080/api/auth',
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+        'http://localhost:53080/api/auth',
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('never relaxes COOP outside LOCAL_VALIDATION', () => {
+    expect(
+      shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+        'http://gcp-dev-01.taile92a8e.ts.net:53080/api/auth',
+        false,
+      ),
+    ).toBe(false);
   });
 });
 
@@ -60,10 +108,7 @@ describe('getTrustedWebOrigins', () => {
 
   it('does not mutate the input list', () => {
     const base = ['http://localhost:58080'];
-    const result = getTrustedWebOrigins(
-      base,
-      'http://oracle.taile92a8e.ts.net:58080',
-    );
+    const result = getTrustedWebOrigins(base, 'http://oracle.taile92a8e.ts.net:58080');
     expect(result).not.toBe(base);
     expect(base).toEqual(['http://localhost:58080']);
   });
@@ -83,11 +128,10 @@ describe('O2V-01 machine-public URL wiring', () => {
   });
 
   it('global.ts CORS allowedOrigins includes the derived WEB origin', () => {
-    const globalMiddleware = readFileSync(
-      resolve(__dirname, '../middleware/global.ts'),
-      'utf8',
-    );
+    const globalMiddleware = readFileSync(resolve(__dirname, '../middleware/global.ts'), 'utf8');
     expect(globalMiddleware).toContain('getTrustedWebOrigins');
     expect(globalMiddleware).toContain('env.MEMOFLOW_WEB_URL');
+    expect(globalMiddleware).toContain('shouldDisableCrossOriginOpenerPolicyForLocalValidation');
+    expect(globalMiddleware).toContain('crossOriginOpenerPolicy: false');
   });
 });

--- a/apps/api/src/shared/infrastructure/config/web-origin.ts
+++ b/apps/api/src/shared/infrastructure/config/web-origin.ts
@@ -23,6 +23,37 @@ export function deriveWebOrigin(webUrl: string | undefined): string | undefined 
 }
 
 /**
+ * Plain HTTP is intentionally allowed for controlled local-validation origins,
+ * including Tailscale MagicDNS. Chromium does not treat those non-loopback HTTP
+ * origins as potentially trustworthy, so Helmet's COOP header is ignored and
+ * reported as a console error even though the header has no effect.
+ *
+ * Disable only that inert header in this narrow lane. HTTPS and loopback HTTP
+ * keep Helmet's default COOP protection unchanged.
+ */
+export function shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+  authBaseUrl: string | undefined,
+  localValidation: boolean,
+): boolean {
+  if (!localValidation || !authBaseUrl) return false;
+
+  try {
+    const url = new URL(authBaseUrl);
+    if (url.protocol !== 'http:') return false;
+
+    const hostname = url.hostname.toLowerCase();
+    const loopback =
+      hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1';
+    return !loopback;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Merge the API CORS/trusted-origins list with the MEMOFLOW_WEB_URL-derived
  * origin, deduped. Without MEMOFLOW_WEB_URL the input list is returned
  * unchanged (fresh array copy).

--- a/apps/api/src/shared/infrastructure/middleware/global.ts
+++ b/apps/api/src/shared/infrastructure/middleware/global.ts
@@ -27,7 +27,10 @@ import {
 import type { HttpRequestMetricsRecorder } from '../observability/http-request-metrics';
 import type { HttpRequestTrace } from '../observability/http-request-trace';
 import { getCorsOrigins, isAllCorsOriginsAllowed, env } from '../config/env.js';
-import { getTrustedWebOrigins } from '../config/web-origin.js';
+import {
+  getTrustedWebOrigins,
+  shouldDisableCrossOriginOpenerPolicyForLocalValidation,
+} from '../config/web-origin.js';
 
 export class CorsRejectionError extends Error {
   constructor(readonly origin?: string) {
@@ -65,8 +68,16 @@ export function applyGlobalMiddleware(
     }),
   );
 
-  // Security
-  app.use(helmet());
+  // Security. Controlled HTTP local-validation origins (for example Tailscale
+  // MagicDNS) are not potentially trustworthy in Chromium. COOP is inert there
+  // and Chromium reports it as a console error, so disable only that header in
+  // the narrow local-validation HTTP lane while preserving Helmet defaults for
+  // production HTTPS and loopback development.
+  const disableCrossOriginOpenerPolicy = shouldDisableCrossOriginOpenerPolicyForLocalValidation(
+    env.AUTH_BASE_URL,
+    env.LOCAL_VALIDATION,
+  );
+  app.use(helmet(disableCrossOriginOpenerPolicy ? { crossOriginOpenerPolicy: false } : undefined));
 
   // Body parsing
   app.use(cookieParser());


### PR DESCRIPTION
## Summary
- suppress Helmet COOP only for controlled non-loopback HTTP `LOCAL_VALIDATION` origins
- preserve default COOP behavior for HTTPS, localhost, and non-validation runtime
- keep the existing env-schema trust boundary: arbitrary public HTTP remains rejected

## Why
Tailscale MagicDNS local validation deliberately uses HTTP. Chromium treats non-loopback HTTP as untrustworthy, ignores COOP, and emits a console error. That made otherwise successful local-docker product journeys fail the no-console-error acceptance gate.

## Validation
- focused `web-origin.spec.ts`: 15/15 pass
- `api:typecheck`: pass
- `memoflow:governance-check`: pass
- final GCP prod-like rebuild: Web/API healthy and OCI revision exactly `b97e5e4ad6acda8708e5dc20a1e5bb46decd5ae0`
- MagicDNS probes: Web `/` 200; API `/healthz` 200; PowerSync `/probes/liveness` 200
- final API response preserves CSP/HSTS/X-Frame-Options while omitting only inert COOP in this lane
- `web:e2e:local-docker`: **15/15 pass** on the final revision (8 auth + 7 core-product journeys)
- local-docker evidence: runtime `ok=true`, browser request `ok=true`, `playwrightExitCode=0`, Web/API revision matches exact HEAD