### PR TITLE
fix(ui): preserve focus after panel resize

### DIFF
--- a/packages/app-vue/src/layouts/shell/AppShell.spec.ts
+++ b/packages/app-vue/src/layouts/shell/AppShell.spec.ts
@@ -121,7 +121,10 @@ const GoalRouteProbe = defineComponent({
     onMounted(() => {
       goalRouteMountCount += 1;
     });
-    return () => h('div', { 'data-testid': 'goal-draft-probe' });
+    return () =>
+      h('div', { 'data-testid': 'goal-draft-probe' }, [
+        h('input', { 'data-testid': 'shell-resize-focus-probe' }),
+      ]);
   },
 });
 
@@ -157,7 +160,7 @@ const i18n = createI18n({
   },
 });
 
-async function mountShell(initialPath = '/') {
+async function mountShell(initialPath = '/', attachTo?: Element) {
   const pinia = createPinia();
   setActivePinia(pinia);
   const router = createRouter({
@@ -176,6 +179,7 @@ async function mountShell(initialPath = '/') {
   await router.isReady();
 
   const wrapper = mount(AppShell, {
+    attachTo,
     global: {
       plugins: [pinia, router, i18n],
       stubs: {
@@ -227,6 +231,39 @@ describe('AppShell right-panel integration', () => {
     expect(wrapper.get('[data-testid="conversation-sidebar"]').exists()).toBe(true);
     expect(wrapper.get('[data-testid="app-shell"]').attributes('data-shell-state')).toBe('focus');
     wrapper.unmount();
+  });
+
+  it('restores the active input after a panel-resize pointer gesture settles', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const { wrapper } = await mountShell('/goals', host);
+    const input = wrapper.get('[data-testid="shell-resize-focus-probe"]').element as HTMLInputElement;
+    const resizer = wrapper.get('[data-testid="business-panel-resizer"]');
+    const scheduledFrames: FrameRequestCallback[] = [];
+    const animationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
+        scheduledFrames.push(callback);
+        return scheduledFrames.length;
+      });
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    await resizer.trigger('pointerdown', { pointerId: 7, clientX: 700 });
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 7, bubbles: true }));
+
+    // Model the browser's trailing native focus behavior after the pointerup listener.
+    (resizer.element as HTMLElement).focus();
+    expect(document.activeElement).toBe(resizer.element);
+    expect(scheduledFrames).toHaveLength(1);
+
+    scheduledFrames[0]?.(performance.now());
+    expect(document.activeElement).toBe(input);
+
+    animationFrame.mockRestore();
+    wrapper.unmount();
+    host.remove();
   });
 
   it('restores explicit focus/split layout independently for each AI conversation', async () => {

--- a/packages/app-vue/src/layouts/shell/AppShell.vue
+++ b/packages/app-vue/src/layouts/shell/AppShell.vue
@@ -454,7 +454,28 @@ function startPanelResize(e: PointerEvent) {
   document.body.style.cursor = 'col-resize';
   isPanelResizing.value = true;
 
-  const cleanup = (pointerId?: number) => {
+  const restoreFocusedElement = () => {
+    if (!focusedElement) return;
+    if (focusedElement.isConnected) {
+      if (document.activeElement !== focusedElement) {
+        focusedElement.focus({ preventScroll: true });
+      }
+      return;
+    }
+
+    // 拖拽触发布局重渲染导致原元素被替换（如任务搜索框）时，
+    // 按 data-testid 定位新元素恢复焦点，保持用户输入上下文。
+    const testId = focusedElement.getAttribute('data-testid');
+    if (!testId) return;
+    const replacement = document.querySelector<HTMLElement>(
+      `[data-testid="${CSS.escape(testId)}"]`,
+    );
+    if (replacement && document.activeElement !== replacement) {
+      replacement.focus({ preventScroll: true });
+    }
+  };
+
+  const cleanup = (pointerId?: number, restoreFocusAfterGesture = true) => {
     if (typeof pointerId === 'number') {
       try {
         captureTarget?.releasePointerCapture?.(pointerId);
@@ -470,25 +491,17 @@ function startPanelResize(e: PointerEvent) {
     document.body.style.userSelect = previousUserSelect;
     document.body.style.cursor = previousCursor;
     isPanelResizing.value = false;
-    if (focusedElement?.isConnected && document.activeElement !== focusedElement) {
-      focusedElement.focus({ preventScroll: true });
-    } else if (focusedElement && !focusedElement.isConnected) {
-      // 拖拽触发布局重渲染导致原元素被替换（如任务搜索框）时，
-      // 按 data-testid 定位新元素恢复焦点，保持用户输入上下文。
-      const testId = focusedElement.getAttribute('data-testid');
-      if (testId) {
-        const replacement = document.querySelector<HTMLElement>(
-          `[data-testid="${CSS.escape(testId)}"]`,
-        );
-        replacement?.focus({ preventScroll: true });
-      }
+    if (restoreFocusAfterGesture) {
+      // Chromium may apply the native pointer/mouse focus default after pointerup listeners.
+      // Restore on the next frame so the user's active input wins after the full gesture settles.
+      window.requestAnimationFrame(restoreFocusedElement);
     }
   };
 
   const move = (ev: PointerEvent) => {
     const width = panelWidthFromPointer(ev.clientX, window.innerWidth, occupiedSidebarWidth());
     if (shouldCollapsePanelWidth(width)) {
-      cleanup(ev.pointerId);
+      cleanup(ev.pointerId, false);
       void sync.closePanel();
       return;
     }


### PR DESCRIPTION
## Summary
- defer business-panel resize focus restoration until the next animation frame so native pointer focus cannot win after `pointerup`
- preserve the existing replacement-by-`data-testid` behavior when a layout rerender replaces the focused element
- avoid restoring focus when the resize gesture collapses/closes the panel
- add an AppShell regression test that models trailing browser focus after `pointerup`

## Evidence
- reproduced from Web Flow Shard 4/4 on PR #255: task toolbar DOM/value survived resize while `task-search-input` intermittently lost focus
- the same test passed on adjacent runs, confirming a timing-sensitive interaction rather than DOM remount/state loss

## Validation
- `pnpm nx run app-vue:typecheck`
- `pnpm nx run app-vue:test` — 183 files / 759 tests passed
- `pnpm nx affected -t lint typecheck test --base=main`
- `pnpm governance:check`
- `git diff --check`

Direct host `web:e2e` is currently blocked before the task page by the existing local email-verification fixture (`helpers/auth-email-link.ts` waiting for `#email`); CI Web Flow remains the browser-level authority for this repair.
