### PR TITLE
fix(web): isolate host e2e auth origins

### DIFF
--- a/apps/web/playwright.server.ts
+++ b/apps/web/playwright.server.ts
@@ -148,6 +148,10 @@ export function createApiServer() {
       ...process.env,
       NODE_ENV: 'test',
       RUNTIME_LANE: 'e2e',
+      // Keep the isolated host-E2E auth transaction on the same API/Web pair even
+      // when a machine .env.local points Docker validation at a MagicDNS origin.
+      AUTH_BASE_URL: `${apiOrigin}/api/auth`,
+      MEMOFLOW_WEB_URL: getE2EWebOrigin(),
       CORS_ORIGIN: getCorsOrigins(),
     },
     ...apiServerOptions,
@@ -195,6 +199,8 @@ export function createRealOAuthApiServer() {
       E2E_REAL_GITHUB_OAUTH: '1',
       GITHUB_OAUTH_CLIENT_ID: clientId,
       GITHUB_OAUTH_CLIENT_SECRET: clientSecret,
+      AUTH_BASE_URL: `${apiOrigin}/api/auth`,
+      MEMOFLOW_WEB_URL: getE2EWebOrigin(),
       CORS_ORIGIN: getCorsOrigins(),
     },
     ...apiServerOptions,

--- a/apps/web/src/playwright.server.spec.ts
+++ b/apps/web/src/playwright.server.spec.ts
@@ -66,6 +66,19 @@ describe('playwright.server', () => {
     expect(process.env.E2E_API_FULL_URL).toBe('http://localhost:3000/api/v1');
   });
 
+  it('isolates API canonical auth and web URLs from machine-local Docker origins', async () => {
+    process.env.AUTH_BASE_URL = 'http://gcp-dev-01.example.ts.net:53080/api/auth';
+    process.env.MEMOFLOW_WEB_URL = 'http://gcp-dev-01.example.ts.net:58080';
+    process.env.E2E_API_BASE_URL = 'http://localhost:3000';
+    process.env.E2E_WEB_BASE_URL = 'http://127.0.0.1:5173';
+
+    const { createApiServer } = await import('../playwright.server');
+    const apiServer = createApiServer();
+
+    expect(apiServer.env?.AUTH_BASE_URL).toBe('http://localhost:3000/api/auth');
+    expect(apiServer.env?.MEMOFLOW_WEB_URL).toBe('http://127.0.0.1:5173');
+  });
+
   it('uses overridden E2E origins for both API and web servers', async () => {
     process.env.E2E_API_BASE_URL = 'http://127.0.0.1:3001/';
     process.env.E2E_WEB_BASE_URL = 'http://localhost:4173/';
@@ -158,6 +171,8 @@ describe('playwright.server', () => {
     const realLane = createRealOAuthApiServer();
     expect(realLane.env?.RUNTIME_LANE).toBe('host-dev');
     expect(realLane.env?.E2E_REAL_GITHUB_OAUTH).toBe('1');
+    expect(realLane.env?.AUTH_BASE_URL).toBe('http://localhost:3000/api/auth');
+    expect(realLane.env?.MEMOFLOW_WEB_URL).toBe('http://127.0.0.1:5173');
     expect(realLane.env?.GITHUB_OAUTH_CLIENT_ID).toBe('Ov23test-real-client');
     expect(realLane.env?.GITHUB_OAUTH_CLIENT_SECRET).toBe('real-secret-for-test-only');
   });


### PR DESCRIPTION
## Summary
- force Playwright-managed API processes to derive `AUTH_BASE_URL` from the active E2E API origin
- force `MEMOFLOW_WEB_URL` to the active E2E Web origin for both mock and real-OAuth Playwright lanes
- prevent machine-local Docker/MagicDNS `.env.local` values from leaking into localhost host-E2E auth transactions
- add a regression test for the exact MagicDNS-shadowing scenario

## Root cause
GCP Dev intentionally keeps `.env.local` pointed at the prod-like Docker stack via MagicDNS. `playwright.server.ts` loaded that file and correctly overrode `E2E_*` URLs, but it did not override the API process's canonical Better Auth/Web URLs. Registration therefore happened against the localhost E2E database while the email verification link targeted the MagicDNS Docker API and a different database.

## Validation
- regression test failed before the fix with the MagicDNS `AUTH_BASE_URL`, then passed after the child-env override
- `pnpm exec vitest run apps/web/src/playwright.server.spec.ts --config apps/web/vitest.config.ts` — 10/10 passed
- real host Playwright: `pnpm nx run web:e2e -- --grep "should display task template list" --workers=1` — self-registration + email verification + login + Task page, 1/1 passed
- `pnpm nx run web:test` — 17 files / 73 tests passed
- `pnpm nx affected -t lint typecheck test --base=main`
- `pnpm governance:check`
- `git diff --check`
