### PR TITLE
fix(web): stabilize business panel resize gestures

### DIFF
--- a/apps/web/e2e/goal/goal-crud.spec.ts
+++ b/apps/web/e2e/goal/goal-crud.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { TIMEOUT_CONFIG, WEB_CONFIG } from '../config';
 import { registerAndLogin } from '../helpers/testHelpers';
+import { dragBusinessPanel } from '../helpers/business-panel';
 
 const generateTestEmail = () =>
   `e2e-goal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.com`;
@@ -165,21 +166,6 @@ async function expectToolbarToFit(toolbar: Locator): Promise<void> {
     scrollWidth: element.scrollWidth,
   }));
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
-}
-
-async function dragBusinessPanel(page: Page, direction: 'wider' | 'narrower'): Promise<void> {
-  const resizer = page.getByTestId('business-panel-resizer');
-  await expect(resizer).toBeVisible();
-  const box = await resizer.boundingBox();
-  if (!box) throw new Error('business-panel-resizer has no bounding box');
-
-  const startX = box.x + box.width / 2;
-  const startY = box.y + box.height / 2;
-  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
-  await page.mouse.move(startX, startY);
-  await page.mouse.down();
-  await page.mouse.move(endX, startY, { steps: 12 });
-  await page.mouse.up();
 }
 
 async function createGoal(

--- a/apps/web/e2e/helpers/business-panel.ts
+++ b/apps/web/e2e/helpers/business-panel.ts
@@ -1,0 +1,30 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Drag the split-view business panel from a stable, actually hittable resizer position.
+ *
+ * The panel width is animated outside an active drag. Reading a bounding box while that
+ * transition is still settling can leave the pointer at a stale coordinate, so the test
+ * starts by hovering the handle. Playwright's hover action waits for stability and pointer
+ * event reception before we snapshot the geometry used by the low-level drag.
+ */
+export async function dragBusinessPanel(
+  page: Page,
+  direction: 'wider' | 'narrower',
+): Promise<void> {
+  const resizer = page.getByTestId('business-panel-resizer');
+  await expect(resizer).toBeVisible();
+  await resizer.hover();
+
+  const box = await resizer.boundingBox();
+  if (!box) throw new Error('business-panel-resizer has no bounding box');
+
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(endX, startY, { steps: 12 });
+  await page.mouse.up();
+}

--- a/apps/web/e2e/notification/notification-center.spec.ts
+++ b/apps/web/e2e/notification/notification-center.spec.ts
@@ -1,6 +1,7 @@
-import { test, expect, type Locator, type Page } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import { TIMEOUT_CONFIG } from '../config';
 import { registerAndLogin } from '../helpers/testHelpers';
+import { dragBusinessPanel } from '../helpers/business-panel';
 
 const generateTestEmail = () =>
   `e2e-notif-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.com`;
@@ -119,19 +120,4 @@ async function expectElementToFit(locator: Locator): Promise<void> {
     scrollWidth: element.scrollWidth,
   }));
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
-}
-
-async function dragBusinessPanel(page: Page, direction: 'wider' | 'narrower'): Promise<void> {
-  const resizer = page.getByTestId('business-panel-resizer');
-  await expect(resizer).toBeVisible();
-  const box = await resizer.boundingBox();
-  if (!box) throw new Error('business-panel-resizer has no bounding box');
-
-  const startX = box.x + box.width / 2;
-  const startY = box.y + box.height / 2;
-  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
-  await page.mouse.move(startX, startY);
-  await page.mouse.down();
-  await page.mouse.move(endX, startY, { steps: 12 });
-  await page.mouse.up();
 }

--- a/apps/web/e2e/reminder/reminder-template-crud.spec.ts
+++ b/apps/web/e2e/reminder/reminder-template-crud.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
 import { TIMEOUT_CONFIG } from '../config';
 import { registerAndLogin } from '../helpers/testHelpers';
+import { dragBusinessPanel } from '../helpers/business-panel';
 
 const generateTestEmail = () =>
   `e2e-reminder-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.com`;
@@ -51,9 +52,7 @@ test.describe('Reminder Template CRUD Operations', () => {
     const content = page.getByTestId('reminder-content');
     const searchInput = page.getByTestId('reminder-search-input');
     const scrollHost = page.getByTestId('reminder-scroll-host');
-    const primaryCreate = page.locator(
-      '[data-primary-action="create-reminder-template"]:visible',
-    );
+    const primaryCreate = page.locator('[data-primary-action="create-reminder-template"]:visible');
 
     await expect(toolbar).toBeVisible();
     await expect(primaryCreate).toHaveCount(1);
@@ -201,21 +200,6 @@ async function expectElementToFit(locator: Locator): Promise<void> {
     scrollWidth: element.scrollWidth,
   }));
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
-}
-
-async function dragBusinessPanel(page: Page, direction: 'wider' | 'narrower'): Promise<void> {
-  const resizer = page.getByTestId('business-panel-resizer');
-  await expect(resizer).toBeVisible();
-  const box = await resizer.boundingBox();
-  if (!box) throw new Error('business-panel-resizer has no bounding box');
-
-  const startX = box.x + box.width / 2;
-  const startY = box.y + box.height / 2;
-  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
-  await page.mouse.move(startX, startY);
-  await page.mouse.down();
-  await page.mouse.move(endX, startY, { steps: 12 });
-  await page.mouse.up();
 }
 
 async function createReminderTemplate(page: Page, title: string) {

--- a/apps/web/e2e/schedule/schedule-calendar.spec.ts
+++ b/apps/web/e2e/schedule/schedule-calendar.spec.ts
@@ -1,6 +1,7 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator } from '@playwright/test';
 import { TIMEOUT_CONFIG } from '../config';
 import { registerAndLogin } from '../helpers/testHelpers';
+import { dragBusinessPanel } from '../helpers/business-panel';
 
 const testPassword = 'Test123456!';
 
@@ -102,7 +103,10 @@ test.describe('Schedule calendar workspace', () => {
 
     await page.getByTestId('schedule-view-tab-day').click();
     await expect(page.getByTestId('schedule-day-calendar')).toBeVisible();
-    await expect(page.getByTestId('schedule-view-tab-day')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByTestId('schedule-view-tab-day')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
   });
 
   test('[P0] creates a schedule from the only primary action', async ({ page }) => {
@@ -163,19 +167,4 @@ async function expectElementToFit(locator: Locator): Promise<void> {
     scrollWidth: element.scrollWidth,
   }));
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
-}
-
-async function dragBusinessPanel(page: Page, direction: 'wider' | 'narrower'): Promise<void> {
-  const resizer = page.getByTestId('business-panel-resizer');
-  await expect(resizer).toBeVisible();
-  const box = await resizer.boundingBox();
-  if (!box) throw new Error('business-panel-resizer has no bounding box');
-
-  const startX = box.x + box.width / 2;
-  const startY = box.y + box.height / 2;
-  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
-  await page.mouse.move(startX, startY);
-  await page.mouse.down();
-  await page.mouse.move(endX, startY, { steps: 12 });
-  await page.mouse.up();
 }

--- a/apps/web/e2e/shell/shell-geometry.spec.ts
+++ b/apps/web/e2e/shell/shell-geometry.spec.ts
@@ -37,6 +37,7 @@ async function openModuleFromCapsule(page: Page, moduleId: string): Promise<void
 async function dragPanelToExtreme(page: Page, direction: 'max' | 'min'): Promise<void> {
   const resizer = page.getByTestId('business-panel-resizer');
   await expect(resizer).toBeVisible();
+  await resizer.hover();
   const box = await resizer.boundingBox();
   if (!box) throw new Error('business-panel-resizer has no box');
 

--- a/apps/web/e2e/task/task-template-crud.spec.ts
+++ b/apps/web/e2e/task/task-template-crud.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
 import { TIMEOUT_CONFIG } from '../config';
 import { registerAndLogin } from '../helpers/testHelpers';
+import { dragBusinessPanel } from '../helpers/business-panel';
 
 const generateTestEmail = () =>
   `e2e-task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.com`;
@@ -158,21 +159,6 @@ async function expectToolbarToFit(toolbar: Locator): Promise<void> {
     scrollWidth: element.scrollWidth,
   }));
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
-}
-
-async function dragBusinessPanel(page: Page, direction: 'wider' | 'narrower'): Promise<void> {
-  const resizer = page.getByTestId('business-panel-resizer');
-  await expect(resizer).toBeVisible();
-  const box = await resizer.boundingBox();
-  if (!box) throw new Error('business-panel-resizer has no bounding box');
-
-  const startX = box.x + box.width / 2;
-  const startY = box.y + box.height / 2;
-  const endX = direction === 'wider' ? Math.max(40, startX - 160) : startX + 120;
-  await page.mouse.move(startX, startY);
-  await page.mouse.down();
-  await page.mouse.move(endX, startY, { steps: 12 });
-  await page.mouse.up();
 }
 
 async function openCreateTaskDialog(page: Page) {

--- a/docs/plan/active/2026-08-23-release-lifecycle-v2.md
+++ b/docs/plan/active/2026-08-23-release-lifecycle-v2.md
@@ -6,7 +6,7 @@ tags:
   - ci-cd
 description: MemoFlow 0.10.0 发布闭环与 Release Lifecycle V2 实施计划
 created: 2026-08-23T11:48:00+08:00
-updated: 2026-08-23T11:48:00+08:00
+updated: 2026-08-23T12:55:00+08:00
 ---
 
 # Release Lifecycle V2 — 0.10.0 发布闭环
@@ -137,3 +137,16 @@ Verified before PR:
 - standard `validate-local-deploy` verdict: **pass**, `ready for PR: yes`; repository policy classified this workflow-only change as not requiring a Docker runtime rebuild.
 
 Next gate: merge this infrastructure PR, update existing Release PR #196 onto the new main, then exercise the real 0.10.0 Draft → assets/images → postflight → Publish path.
+
+## Implementation checkpoint — #259 merged / 0.10.0 focus-gate repair
+
+- Release Lifecycle V2 infrastructure merged as PR #259 at `main@2c2171905`; the exact-SHA `Release Publish` workflow subsequently ran against that ordinary main commit and correctly completed as a no-op without creating a tag or release.
+- Release PR #196 is rebased directly on `2c2171905` as `f3221c4a3 chore(main): release 0.10.0`; version identity is 0.10.0 across root/Desktop/manifest.
+- #196 exposed an existing Web Flow Shard 4 focus failure in Task/Reminder resize journeys. The same failure reproduced on main, so it is not caused by release metadata.
+- Browser event evidence showed failed drags sometimes read the resizer bounding box while the 200ms panel-width transition was still settling; `pointerdown` then landed on adjacent AI/workspace content, so `startPanelResize()` never owned the gesture and no focus restoration could occur.
+- Focused repair: keep the resize hit target fully inside the clipped business panel with explicit stacking, and centralize Web E2E panel dragging through a helper that calls Playwright `hover()` before reading geometry. `hover()` supplies the missing stable/receives-events actionability gate instead of relying on stale coordinates.
+- Verification so far: Task resize journey 3/3, Reminder resize journey 3/3, Goal/Notification/Schedule resize journeys 3/3 all pass.
+- Package/repository validation: app-vue 183 files / 759 tests, app-vue typecheck, affected lint/typecheck/test, governance, docs, inventory, and diff check all pass.
+- Standard local-deploy validator reran on isolated machine-local ports `63180-63184`: all five Docker services healthy, verdict `pass`, `readyForPr: yes`, no blocking issues or warnings. The canonical main validation stack remained untouched.
+
+Next gate: run package/affected/governance validation, merge the focused repair, rebase #196 onto the repaired main, then resume the real 0.10.0 publish path.

--- a/packages/app-vue/src/layouts/shell/BusinessPanel.spec.ts
+++ b/packages/app-vue/src/layouts/shell/BusinessPanel.spec.ts
@@ -125,6 +125,8 @@ describe('BusinessPanel surfaces', () => {
       'aria-orientation': 'vertical',
       'aria-label': 'Resize business panel',
     });
+    expect(separator.classes()).toEqual(expect.arrayContaining(['left-0', 'z-20']));
+    expect(separator.classes()).not.toContain('-translate-x-1/2');
 
     await separator.trigger('keydown', { key: 'ArrowLeft' });
     await separator.trigger('keydown', { key: 'ArrowRight' });

--- a/packages/app-vue/src/layouts/shell/BusinessPanel.vue
+++ b/packages/app-vue/src/layouts/shell/BusinessPanel.vue
@@ -215,7 +215,7 @@ const isFocused = computed(() => props.layout === 'focus');
       :aria-label="t('shell.panel.resize')"
       :aria-valuemin="BUSINESS_HARD_MIN"
       :aria-valuenow="Math.round(panelContentWidth ?? 720)"
-      class="absolute left-0 top-0 h-full w-2 -translate-x-1/2 cursor-col-resize bg-transparent transition-colors hover:bg-primary/40 focus-visible:bg-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      class="absolute left-0 top-0 z-20 h-full w-2 cursor-col-resize bg-transparent transition-colors hover:bg-primary/40 focus-visible:bg-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       :title="t('shell.panel.resize')"
       @pointerdown="emit('start-resize', $event)"
       @dblclick.stop="emit('reset-width')"


### PR DESCRIPTION
## Summary
- keep the business-panel resize handle fully inside the clipped panel with explicit stacking
- centralize business-panel E2E dragging behind a helper that waits for Playwright hover/actionability before reading geometry
- remove five duplicated stale-bounding-box drag helpers and align the shell geometry drag path
- record the 0.10.0 release-gate diagnosis and repair evidence in the active release plan

## Root cause
The business panel width animates outside an active drag. The duplicated E2E helpers read `boundingBox()` immediately and then moved the mouse to that captured coordinate. While the 200ms width transition was still settling, the coordinate could become stale; `pointerdown` then landed on adjacent AI/workspace content instead of `business-panel-resizer`. In that case `startPanelResize()` never owned the gesture, so Task/Reminder focus restoration could not run.

## Validation
- BusinessPanel focused unit regression: 6/6
- Task resize journey: 3/3 repeated
- Reminder resize journey: 3/3 repeated
- Goal + Notification + Schedule resize journeys: 3/3
- app-vue: 183 files / 759 tests
- app-vue typecheck: pass
- affected lint/typecheck/test: pass
- governance/docs/inventory/diff check: pass
- standard local-deploy validator on isolated ports 63180-63184: PASS / readyForPr=yes; API/Web/PowerSync/Postgres/Redis healthy
