### PR TITLE
fix(release): stabilize v0.10.0 packaging retries

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -84,16 +84,23 @@ jobs:
         include:
           - os: windows-latest
             platform: windows
-            dist_configuration: windows
+            builder_args: --win --x64
           - os: ubuntu-latest
             platform: linux
-            dist_configuration: linux
+            builder_args: --linux AppImage deb rpm --x64
 
     steps:
-      - name: Checkout exact release SHA
+      - name: Checkout release packaging tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: release-tooling
+
+      - name: Checkout exact release source
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare-release.outputs.release_sha }}
+          path: release-source
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -109,11 +116,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: apps/desktop/.python-version
+          python-version-file: release-source/apps/desktop/.python-version
 
       - name: Setup MSBuild (Windows)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
 
       - name: Install Linux packaging dependencies
         if: runner.os == 'Linux'
@@ -122,41 +131,44 @@ jobs:
           sudo apt-get install -y rpm fakeroot
 
       - name: Install dependencies
+        working-directory: release-source
         env:
           PYTHON: ${{ env.pythonLocation }}/python
           npm_config_python: ${{ env.pythonLocation }}/python
-          npm_config_msvs_version: 2022
         run: pnpm install --frozen-lockfile --reporter=append-only
 
       - name: Validate release contract
+        working-directory: release-source
         shell: bash
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: node ./tools/ci-cd-platform/release-tools/release-contract.mjs --require-release --expected-tag "$RELEASE_TAG"
 
       - name: Build desktop application
+        working-directory: release-source
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
+          NODE_OPTIONS: --require=${{ github.workspace }}/release-source/tools/ci/node-process-bootstrap.cjs
           PYTHON: ${{ env.pythonLocation }}/python
           npm_config_python: ${{ env.pythonLocation }}/python
-          npm_config_msvs_version: 2022
         run: pnpm nx run desktop:build:production --outputStyle=static
 
       - name: Package desktop application
+        working-directory: release-source/apps/desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_OPTIONS: --require=${{ github.workspace }}/tools/ci/node-process-bootstrap.cjs
+          NODE_OPTIONS: --require=${{ github.workspace }}/release-source/tools/ci/node-process-bootstrap.cjs
           PYTHON: ${{ env.pythonLocation }}/python
           npm_config_python: ${{ env.pythonLocation }}/python
-          npm_config_msvs_version: 2022
-        run: pnpm nx run desktop:dist:${{ matrix.dist_configuration }} --outputStyle=static
+        run: |
+          pnpm exec electron-builder ${{ matrix.builder_args }} --publish never --config ../../../release-tooling/apps/desktop/electron-builder.json5
+          node ./scripts/verify-packaged-runtime-deps.mjs
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
           name: desktop-${{ matrix.platform }}
-          path: apps/desktop/dist-package
+          path: release-source/apps/desktop/dist-package
           if-no-files-found: error
           compression-level: 9
 
@@ -171,7 +183,7 @@ jobs:
       - name: Checkout release tooling
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.workflow_sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v7

--- a/apps/desktop/electron-builder.json5
+++ b/apps/desktop/electron-builder.json5
@@ -16,6 +16,11 @@
   ],
   "electronVersion": "43.1.0",
   "productName": "MemoFlow",
+  "executableName": "memoflow",
+  "extraMetadata": {
+    "productName": "MemoFlow",
+    "desktopName": "memoflow.desktop"
+  },
   "directories": {
     "output": "dist-package",
     "buildResources": "build" // 添加资源目录配置
@@ -23,7 +28,22 @@
   "files": [
     "dist-renderer/**/*",
     "dist-electron/**/*",
-    "package.json"
+    "package.json",
+    {
+      "from": "../../packages/database",
+      "to": "node_modules/@memoflow/database",
+      "filter": ["package.json", "dist/**/*"]
+    },
+    {
+      "from": "../../node_modules/dotenv",
+      "to": "node_modules/dotenv",
+      "filter": ["**/*"]
+    },
+    {
+      "from": "../../node_modules/dotenv-expand",
+      "to": "node_modules/dotenv-expand",
+      "filter": ["**/*"]
+    }
   ],
   "extraResources": [
     {
@@ -36,7 +56,7 @@
     }
   ],
   "mac": {
-    "icon": "build/icon.icns",
+    "icon": "../../packages/assets/dist/images/logos/MemoFlow.icns",
     "target": [
       "dmg",
       "zip"  // 添加 zip 格式支持自动更新
@@ -45,7 +65,7 @@
     "category": "public.app-category.productivity" // 添加应用类别
   },
   "win": {
-    "icon": "build/icon.ico",
+    "icon": "../../packages/assets/dist/images/logos/MemoFlow.ico",
     "target": [
       {
         "target": "nsis",
@@ -75,7 +95,8 @@
     ],
   },
   "linux": {
-    "icon": "build/icon.png",
+    "icon": "../../packages/assets/dist/images/logos/MemoFlow-512.png",
+    "syncDesktopName": true,
     "target": [
       "AppImage",
       "deb",  // 添加 deb 格式
@@ -91,5 +112,5 @@
     "releaseType": "release" // 配置发布选项
   },
   "generateUpdatesFilesForAllChannels": true, // 为所有渠道生成更新文件
-  "npmRebuild": false // 禁用自动原生模块重编译，由 package/dist 命令显式重编译 better-sqlite3
+  "npmRebuild": true // electron-builder owns the Electron ABI rebuild for packaged native dependencies
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@memoflow/desktop",
+  "productName": "MemoFlow",
+  "desktopName": "memoflow.desktop",
   "author": {
     "name": "bakersean",
     "email": "lulouhao@stu.sicau.edu.cn"
@@ -25,6 +27,8 @@
     "@memoflow/domain-shared": "workspace:*",
     "@memoflow/goal": "workspace:*",
     "date-fns": "^4.1.0",
+    "dotenv": "^16.4.0",
+    "dotenv-expand": "13.0.0",
     "gray-matter": "4.0.3",
     "@memoflow/governance": "workspace:*",
     "@memoflow/ipc-client": "workspace:*",
@@ -79,7 +83,6 @@
     "xtend": "4.0.2"
   },
   "devDependencies": {
-    "@electron/rebuild": "4.2.0",
     "@eslint/js": "^10.0.1",
     "@eslint/markdown": "^7.1.0",
     "@types/uuid": "^11.0.0",

--- a/apps/desktop/project.json
+++ b/apps/desktop/project.json
@@ -64,7 +64,7 @@
     },
     "package": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build", "native-rebuild"],
+      "dependsOn": ["build"],
       "options": {
         "commands": ["electron-builder --dir", "node ./scripts/verify-packaged-runtime-deps.mjs"],
         "cwd": "apps/desktop",
@@ -75,13 +75,13 @@
       "executor": "nx:run-commands",
       "cache": false,
       "options": {
-        "command": "pnpm exec electron-rebuild -f -o better-sqlite3",
+        "command": "pnpm exec electron-builder install-app-deps",
         "cwd": "apps/desktop"
       }
     },
     "dist": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build", "native-rebuild"],
+      "dependsOn": ["build"],
       "options": {
         "commands": [
           "electron-builder --publish never",

--- a/docs/plan/active/2026-08-23-release-lifecycle-v2.md
+++ b/docs/plan/active/2026-08-23-release-lifecycle-v2.md
@@ -6,7 +6,7 @@ tags:
   - ci-cd
 description: MemoFlow 0.10.0 发布闭环与 Release Lifecycle V2 实施计划
 created: 2026-08-23T11:48:00+08:00
-updated: 2026-08-23T12:55:00+08:00
+updated: 2026-08-23T18:56:43+08:00
 ---
 
 # Release Lifecycle V2 — 0.10.0 发布闭环
@@ -150,3 +150,15 @@ Next gate: merge this infrastructure PR, update existing Release PR #196 onto th
 - Standard local-deploy validator reran on isolated machine-local ports `63180-63184`: all five Docker services healthy, verdict `pass`, `readyForPr: yes`, no blocking issues or warnings. The canonical main validation stack remained untouched.
 
 Next gate: run package/affected/governance validation, merge the focused repair, rebase #196 onto the repaired main, then resume the real 0.10.0 publish path.
+
+## Implementation checkpoint — v0.10.0 packaging retry repair
+
+- The first real `Release Publish` run preserved `v0.10.0` as a Draft and exposed three release-lane blockers: Linux derived an invalid scoped-package executable name, Windows forced a Visual Studio 2022 toolchain on the newer hosted image, and ACR rejected the stored login credential.
+- Desktop packaging now has a stable `MemoFlow` / `memoflow` product identity, canonical platform icons, one native dependency rebuild owner (`electron-builder`), and an explicit packaged runtime closure for the workspace database package plus `dotenv` / `dotenv-expand`.
+- Manual retries keep the immutable release source at tag SHA `318f5380e04623c5f01f9ada673ee05897159d10` while loading packaging workflow/configuration from the retrying workflow revision. This makes the existing tag repairable without moving or recreating it.
+- The Windows lane no longer pins `npm_config_msvs_version=2022`; MSBuild discovery is x64 and may select the toolchain installed on the hosted runner.
+- The ACR password secret was refreshed after the failed run. Its value was not exposed; registry authentication remains to be proven by the post-merge release retry.
+- Verification completed before PR: release workflow contract 5/5, CI/CD platform 45/45, Desktop 40 files / 230 tests, Desktop lint/typecheck, governance/docs/inventory, `actionlint`, and `git diff --check` all pass.
+- A real Linux AppImage was built twice: once from the repaired branch and once from the untouched `v0.10.0` release SHA using the new external packaging configuration. Both produced the `memoflow` ELF executable and verified all 76 packaged runtime dependencies.
+
+Next gate: merge the packaging repair, rerun the existing Draft release, confirm Desktop and immutable Docker assets plus postflight evidence, publish `v0.10.0`, verify Prepare Release uses it as the new baseline, then archive this plan.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,6 +619,12 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
+      dotenv-expand:
+        specifier: 13.0.0
+        version: 13.0.0
       event-iterator:
         specifier: ^2.0.0
         version: 2.0.0
@@ -698,9 +704,6 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
     devDependencies:
-      '@electron/rebuild':
-        specifier: 4.2.0
-        version: 4.2.0(supports-color@10.2.2)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0(jiti@2.4.2)(supports-color@10.2.2))

--- a/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
+++ b/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
@@ -47,6 +47,49 @@ test('desktop assets and image publishing are reusable retryable lanes, not publ
   assert.match(images, /requested SHA was/);
 });
 
+test('desktop packaging has one stable product identity and one native rebuild owner', async () => {
+  const [packageText, builder, projectText, workflow] = await Promise.all([
+    readRepoFile('apps/desktop/package.json'),
+    readRepoFile('apps/desktop/electron-builder.json5'),
+    readRepoFile('apps/desktop/project.json'),
+    readRepoFile('.github/workflows/release-assets.yml'),
+  ]);
+  const packageJson = JSON.parse(packageText);
+  const project = JSON.parse(projectText);
+
+  assert.equal(packageJson.productName, 'MemoFlow');
+  assert.equal(packageJson.desktopName, 'memoflow.desktop');
+  assert.equal(packageJson.dependencies['dotenv-expand'], '13.0.0');
+  assert.equal(packageJson.devDependencies['@electron/rebuild'], undefined);
+  assert.match(builder, /"appId": "com\.memoflow\.app"/);
+  assert.match(builder, /"productName": "MemoFlow"/);
+  assert.match(builder, /"executableName": "memoflow"/);
+  assert.match(builder, /"desktopName": "memoflow\.desktop"/);
+  assert.match(builder, /"syncDesktopName": true/);
+  assert.match(builder, /"npmRebuild": true/);
+  assert.match(builder, /\.\.\/\.\.\/packages\/assets\/dist\/images\/logos\/MemoFlow\.ico/);
+  assert.match(builder, /\.\.\/\.\.\/packages\/assets\/dist\/images\/logos\/MemoFlow-512\.png/);
+  assert.match(builder, /"from": "\.\.\/\.\.\/packages\/database"/);
+  assert.match(builder, /"to": "node_modules\/@memoflow\/database"/);
+  assert.match(builder, /"from": "\.\.\/\.\.\/node_modules\/dotenv-expand"/);
+  assert.deepEqual(project.targets.package.dependsOn, ['build']);
+  assert.deepEqual(project.targets.dist.dependsOn, ['build']);
+  assert.match(
+    project.targets['native-rebuild'].options.command,
+    /electron-builder install-app-deps/,
+  );
+
+  assert.match(workflow, /Checkout release packaging tooling/);
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /path: release-tooling/);
+  assert.match(workflow, /Checkout exact release source/);
+  assert.match(workflow, /path: release-source/);
+  assert.match(workflow, /release-tooling\/apps\/desktop\/electron-builder\.json5/);
+  assert.doesNotMatch(workflow, /desktop:dist/);
+  assert.doesNotMatch(workflow, /npm_config_msvs_version/);
+  assert.match(workflow, /msbuild-architecture: x64/);
+});
+
 test('release tooling exposes fail-closed identity and evidence builders', async () => {
   const [contract, desktop, docker, aggregate] = await Promise.all([
     readRepoFile('tools/ci-cd-platform/release-tools/release-contract.mjs'),


### PR DESCRIPTION
## Summary

- keep the immutable v0.10.0 release source checkout while loading retryable packaging tooling from the current workflow revision
- give Desktop a stable MemoFlow/memoflow identity, canonical icons, one native rebuild owner, and a complete packaged runtime closure
- remove the stale Visual Studio 2022 pin and use x64 MSBuild discovery on Windows runners

## Root causes

- Linux derived an illegal executable name from the scoped package name
- Windows hosted runners moved to a VS 2026 image while the workflow forced VS 2022
- retrying the old workflow could never consume a packaging fix without moving the immutable tag
- the first successful package attempt exposed missing workspace database and dotenv runtime files

## Validation

- untouched v0.10.0 SHA packaged successfully with this branch configuration; 76 runtime packages verified
- Desktop: lint, typecheck, 40 files / 230 tests
- CI/CD platform: 45/45 tests
- release workflow contract: 5/5
- governance, docs, inventory, actionlint and diff hygiene pass

The ACR password secret was refreshed after the failed release run; its value was not exposed. Registry authentication remains fail-closed and will be proven by the post-merge retry of the existing Draft release.
