### PR TITLE
fix(release): publish registry-compatible image manifests

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -206,8 +206,10 @@ jobs:
             USE_PREBUILT_ARTIFACT=1
           cache-from: type=gha,scope=api
           cache-to: type=gha,mode=max,scope=api
-          provenance: true
-          sbom: true
+          # This ACR endpoint rejects BuildKit's OCI empty attestation manifests.
+          # Release provenance remains in the GitHub-hosted workflow evidence below.
+          provenance: false
+          sbom: false
 
       - name: Build and push Migrator image
         id: build-migrator
@@ -225,8 +227,8 @@ jobs:
             VERSION=${{ needs.prepare-release.outputs.release_tag }}
             USE_PREBUILT_ARTIFACT=1
           cache-from: type=gha,scope=api
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
 
       - name: Build and push Web image
         id: build-web
@@ -243,8 +245,8 @@ jobs:
             VERSION=${{ needs.prepare-release.outputs.release_tag }}
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
 
       - name: Build Docker release evidence
         env:

--- a/docs/plan/active/2026-08-23-release-lifecycle-v2.md
+++ b/docs/plan/active/2026-08-23-release-lifecycle-v2.md
@@ -6,7 +6,7 @@ tags:
   - ci-cd
 description: MemoFlow 0.10.0 发布闭环与 Release Lifecycle V2 实施计划
 created: 2026-08-23T11:48:00+08:00
-updated: 2026-08-23T18:56:43+08:00
+updated: 2026-08-23T19:15:41+08:00
 ---
 
 # Release Lifecycle V2 — 0.10.0 发布闭环
@@ -157,7 +157,8 @@ Next gate: run package/affected/governance validation, merge the focused repair,
 - Desktop packaging now has a stable `MemoFlow` / `memoflow` product identity, canonical platform icons, one native dependency rebuild owner (`electron-builder`), and an explicit packaged runtime closure for the workspace database package plus `dotenv` / `dotenv-expand`.
 - Manual retries keep the immutable release source at tag SHA `318f5380e04623c5f01f9ada673ee05897159d10` while loading packaging workflow/configuration from the retrying workflow revision. This makes the existing tag repairable without moving or recreating it.
 - The Windows lane no longer pins `npm_config_msvs_version=2022`; MSBuild discovery is x64 and may select the toolchain installed on the hosted runner.
-- The ACR password secret was refreshed after the failed run. Its value was not exposed; registry authentication remains to be proven by the post-merge release retry.
+- The ACR password secret was refreshed after the failed run. Its value was not exposed; the post-merge retry proved registry authentication succeeds.
+- That retry exposed a separate ACR compatibility boundary: image layers and the normal image manifest uploaded, but the registry rejected BuildKit's `application/vnd.oci.empty.v1+json` SBOM/provenance attestation manifest. Release image builds therefore disable registry-side BuildKit attestations while retaining the canonical Docker/release manifests and GitHub-hosted promotion provenance artifact.
 - Verification completed before PR: release workflow contract 5/5, CI/CD platform 45/45, Desktop 40 files / 230 tests, Desktop lint/typecheck, governance/docs/inventory, `actionlint`, and `git diff --check` all pass.
 - A real Linux AppImage was built twice: once from the repaired branch and once from the untouched `v0.10.0` release SHA using the new external packaging configuration. Both produced the `memoflow` ELF executable and verified all 76 packaged runtime dependencies.
 

--- a/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
+++ b/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
@@ -90,6 +90,14 @@ test('desktop packaging has one stable product identity and one native rebuild o
   assert.match(workflow, /msbuild-architecture: x64/);
 });
 
+test('release image publication uses registry-compatible image manifests', async () => {
+  const workflow = await readRepoFile('.github/workflows/publish-images.yml');
+
+  assert.equal(workflow.match(/^\s+provenance: false$/gmu)?.length, 3);
+  assert.equal(workflow.match(/^\s+sbom: false$/gmu)?.length, 3);
+  assert.doesNotMatch(workflow, /^\s+(?:provenance|sbom): true$/mu);
+});
+
 test('release tooling exposes fail-closed identity and evidence builders', async () => {
   const [contract, desktop, docker, aggregate] = await Promise.all([
     readRepoFile('tools/ci-cd-platform/release-tools/release-contract.mjs'),


### PR DESCRIPTION
## Summary

- disable BuildKit SBOM/provenance attestations for release image pushes because this ACR endpoint rejects their OCI empty attestation manifest class
- retain exact-SHA Docker/release manifests and the GitHub-hosted production promotion provenance artifact
- add a workflow regression contract for all three release images

## Evidence

The v0.10.0 retry authenticated to ACR and pushed the API image layers plus ordinary manifest, then ACR rejected the attestation manifest with `unknown manifest class for application/vnd.oci.empty.v1+json`. No secret value was exposed.

## Validation

- RED: new registry-compatibility contract failed against `provenance: true` / `sbom: true`
- GREEN: focused contract passes
- CI/CD platform: 46/46 tests
- docs check and diff hygiene pass

The existing v0.10.0 Draft remains unpublished. After merge, the same tag/SHA will be retried idempotently.
