### PR TITLE
fix(release): isolate desktop release artifacts

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -188,6 +188,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v7
         with:
+          pattern: desktop-*
           path: artifacts
 
       - name: Require an existing draft release

--- a/docs/plan/active/2026-08-23-release-lifecycle-v2.md
+++ b/docs/plan/active/2026-08-23-release-lifecycle-v2.md
@@ -6,7 +6,7 @@ tags:
   - ci-cd
 description: MemoFlow 0.10.0 发布闭环与 Release Lifecycle V2 实施计划
 created: 2026-08-23T11:48:00+08:00
-updated: 2026-08-23T19:15:41+08:00
+updated: 2026-08-23T19:30:55+08:00
 ---
 
 # Release Lifecycle V2 — 0.10.0 发布闭环
@@ -159,6 +159,7 @@ Next gate: run package/affected/governance validation, merge the focused repair,
 - The Windows lane no longer pins `npm_config_msvs_version=2022`; MSBuild discovery is x64 and may select the toolchain installed on the hosted runner.
 - The ACR password secret was refreshed after the failed run. Its value was not exposed; the post-merge retry proved registry authentication succeeds.
 - That retry exposed a separate ACR compatibility boundary: image layers and the normal image manifest uploaded, but the registry rejected BuildKit's `application/vnd.oci.empty.v1+json` SBOM/provenance attestation manifest. Release image builds therefore disable registry-side BuildKit attestations while retaining the canonical Docker/release manifests and GitHub-hosted promotion provenance artifact.
+- The same retry proved both Windows and Linux Desktop build lanes succeed, then the Desktop upload job downloaded every artifact in the parent run and failed while extracting an unrelated Docker build record. Desktop release upload now filters `actions/download-artifact` to `desktop-*`, preserving lane isolation.
 - Verification completed before PR: release workflow contract 5/5, CI/CD platform 45/45, Desktop 40 files / 230 tests, Desktop lint/typecheck, governance/docs/inventory, `actionlint`, and `git diff --check` all pass.
 - A real Linux AppImage was built twice: once from the repaired branch and once from the untouched `v0.10.0` release SHA using the new external packaging configuration. Both produced the `memoflow` ELF executable and verified all 76 packaged runtime dependencies.
 

--- a/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
+++ b/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
@@ -85,6 +85,7 @@ test('desktop packaging has one stable product identity and one native rebuild o
   assert.match(workflow, /Checkout exact release source/);
   assert.match(workflow, /path: release-source/);
   assert.match(workflow, /release-tooling\/apps\/desktop\/electron-builder\.json5/);
+  assert.match(workflow, /name: Download build artifacts[\s\S]*?pattern: desktop-\*/);
   assert.doesNotMatch(workflow, /desktop:dist/);
   assert.doesNotMatch(workflow, /npm_config_msvs_version/);
   assert.match(workflow, /msbuild-architecture: x64/);


### PR DESCRIPTION
## Summary

- download only `desktop-*` artifacts in the Desktop release upload job
- prevent unrelated Docker build records and promotion artifacts from entering Desktop manifest/upload processing
- add a workflow regression contract and record the release checkpoint

## Evidence

Both Windows and Linux build jobs succeeded in Release Publish run 32635793774. The upload job then downloaded all four parent-run artifacts and `actions/download-artifact` failed extracting an unrelated Docker artifact after five retries. The Draft remained unpublished and had no assets.

## Validation

- RED: Desktop workflow contract failed without the artifact pattern
- GREEN: focused contract passes
- CI/CD platform: 46/46 tests
- docs check and diff hygiene pass
