### PR TITLE
fix(release): reconcile published release PR labels

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,7 +19,7 @@ concurrency:
 permissions:
   contents: write
   actions: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   resolve:
@@ -264,3 +264,61 @@ jobs:
           gh release upload "$RELEASE_TAG" release-manifest.json --clobber
           gh release edit "$RELEASE_TAG" --draft=false --latest
           echo "Published $RELEASE_TAG after exact-SHA CI, Desktop assets, Docker images, and release evidence all passed." >> "$GITHUB_STEP_SUMMARY"
+
+  reconcile-release-pr:
+    name: Mark Release PR Tagged
+    needs:
+      - resolve
+      - prepare
+      - finalize
+    if: >-
+      always() &&
+      needs.resolve.outputs.eligible == 'true' &&
+      needs.prepare.result == 'success' &&
+      (needs.prepare.outputs.already_published == 'true' || needs.finalize.result == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reconcile release-please labels
+        uses: actions/github-script@v8
+        env:
+          RELEASE_SHA: ${{ needs.resolve.outputs.sha }}
+        with:
+          script: |
+            const sha = process.env.RELEASE_SHA;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'closed',
+              base: context.payload.repository.default_branch,
+              per_page: 100,
+            });
+            const releasePr = pulls.find(
+              (pull) => pull.merged_at && pull.merge_commit_sha === sha,
+            );
+            if (!releasePr) {
+              core.setFailed(`No merged release PR found for ${sha}`);
+              return;
+            }
+
+            const labels = releasePr.labels
+              .map((label) => (typeof label === 'string' ? label : label.name))
+              .filter(Boolean);
+            if (!labels.includes('autorelease: tagged')) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: releasePr.number,
+                labels: ['autorelease: tagged'],
+              });
+            }
+            if (labels.includes('autorelease: pending')) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: releasePr.number,
+                name: 'autorelease: pending',
+              });
+            }
+            core.info(`Marked release PR #${releasePr.number} tagged for ${sha}`);

--- a/docs/plan/active/2026-08-23-release-lifecycle-v2.md
+++ b/docs/plan/active/2026-08-23-release-lifecycle-v2.md
@@ -6,7 +6,7 @@ tags:
   - ci-cd
 description: MemoFlow 0.10.0 发布闭环与 Release Lifecycle V2 实施计划
 created: 2026-08-23T11:48:00+08:00
-updated: 2026-08-23T19:30:55+08:00
+updated: 2026-08-23T20:10:29+08:00
 ---
 
 # Release Lifecycle V2 — 0.10.0 发布闭环
@@ -160,6 +160,8 @@ Next gate: run package/affected/governance validation, merge the focused repair,
 - The ACR password secret was refreshed after the failed run. Its value was not exposed; the post-merge retry proved registry authentication succeeds.
 - That retry exposed a separate ACR compatibility boundary: image layers and the normal image manifest uploaded, but the registry rejected BuildKit's `application/vnd.oci.empty.v1+json` SBOM/provenance attestation manifest. Release image builds therefore disable registry-side BuildKit attestations while retaining the canonical Docker/release manifests and GitHub-hosted promotion provenance artifact.
 - The same retry proved both Windows and Linux Desktop build lanes succeed, then the Desktop upload job downloaded every artifact in the parent run and failed while extracting an unrelated Docker build record. Desktop release upload now filters `actions/download-artifact` to `desktop-*`, preserving lane isolation.
+- Final retry `32637603289` completed Desktop, Docker and postflight successfully. GitHub published `v0.10.0` as Latest at immutable SHA `318f5380e04623c5f01f9ada673ee05897159d10` with 12 release assets and no `prod-latest` image tag.
+- Postflight Prepare Release run `32638440022` found `v0.10.0` as the latest release and scanned only the seven subsequent commits, but release-please then stopped because merged PR #196 still carried `autorelease: pending`. Release Publish now reconciles the exact-SHA merged release PR to `autorelease: tagged` after successful publication, including an idempotent already-published retry path.
 - Verification completed before PR: release workflow contract 5/5, CI/CD platform 45/45, Desktop 40 files / 230 tests, Desktop lint/typecheck, governance/docs/inventory, `actionlint`, and `git diff --check` all pass.
 - A real Linux AppImage was built twice: once from the repaired branch and once from the untouched `v0.10.0` release SHA using the new external packaging configuration. Both produced the `memoflow` ELF executable and verified all 76 packaged runtime dependencies.
 

--- a/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
+++ b/tools/ci-cd-platform/__tests__/release-workflows.test.mjs
@@ -27,6 +27,11 @@ test('release publish waits for exact CI then calls both reusable release lanes 
   assert.match(workflow, /draft:\s*true|draft: true/);
   assert.match(workflow, /release-manifest\.json/);
   assert.match(workflow, /--draft=false/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /merge_commit_sha === sha/);
+  assert.match(workflow, /autorelease: pending/);
+  assert.match(workflow, /autorelease: tagged/);
+  assert.match(workflow, /already_published == 'true' \|\| needs\.finalize\.result == 'success'/);
 });
 
 test('desktop assets and image publishing are reusable retryable lanes, not publish-event or tag-push side effects', async () => {


### PR DESCRIPTION
## Summary

- after a successful publish, reconcile the exact-SHA merged release PR from `autorelease: pending` to `autorelease: tagged`
- support idempotent retries when the GitHub Release is already published
- grant only the pull-request write permission needed for label reconciliation

## Evidence

Prepare Release run 32638440022 correctly found v0.10.0 at `318f5380...` and scanned only the seven later commits, then release-please aborted because merged PR #196 still had `autorelease: pending`. Release-please source defines that label as an untagged merged release and `autorelease: tagged` as the completed state.

## Validation

- RED: workflow contract failed without exact-SHA label reconciliation
- GREEN: focused contract passes
- CI/CD platform: 46/46 tests
- docs check and diff hygiene pass

After merge, an already-published v0.10.0 retry will execute only the reconciliation job; then Prepare Release will be rerun to prove it can continue from the v0.10.0 baseline.
