### PR TITLE
fix(ci): serialize Prisma client generation

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -70,16 +70,13 @@
     },
     "typecheck": {
       "executor": "nx:run-commands",
-      "dependsOn": ["prisma:generate", "^build"],
+      "dependsOn": [
+        { "target": "prisma-generate", "projects": ["database"] },
+        "^build"
+      ],
       "options": {
         "command": "tsc --noEmit -p tsconfig.typecheck.json && tsc --noEmit -p tsconfig.typecheck.spec.json",
         "cwd": "apps/api"
-      }
-    },
-    "prisma:generate": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "pnpm nx run database:prisma-generate"
       }
     },
     "prisma:migrate": {

--- a/packages/database/project.json
+++ b/packages/database/project.json
@@ -7,11 +7,11 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/src/generated/prisma", "{projectRoot}/dist"],
-      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist"],
+      "dependsOn": ["^build", "prisma-generate"],
       "options": {
         "cwd": "packages/database",
-        "command": "prisma generate --config ./prisma/prisma.config.ts && node ../../tools/build/normalize-generated-prisma.mjs && tsc --build && node ../../tools/build/copy-with-retry.mjs src/generated/prisma dist/generated/prisma"
+        "command": "tsc --build && node ../../tools/build/copy-with-retry.mjs src/generated/prisma dist/generated/prisma"
       },
       "inputs": [
         "{projectRoot}/prisma/schema/**/*",
@@ -58,6 +58,7 @@
     "typecheck": {
       "executor": "nx:run-commands",
       "cache": true,
+      "dependsOn": ["prisma-generate", "^build"],
       "options": {
         "command": "tsc --noEmit -p tsconfig.json",
         "cwd": "packages/database"

--- a/tools/ci-cd-platform/__tests__/contracts.test.mjs
+++ b/tools/ci-cd-platform/__tests__/contracts.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   buildProvenance,
@@ -156,4 +157,30 @@ test('run summary timing rejects invalid measurements', () => {
   const invalid = { ...summary, timing: { ...summary.timing, setupMs: -1 } };
   invalid.digest = digest(invalid);
   assert.throws(() => validateRunSummary(invalid), /timing\.setupMs must be non-negative/);
+});
+
+test('Prisma client generation has one Nx-owned writer in the typecheck graph', async () => {
+  const [databaseProject, apiProject] = await Promise.all([
+    readFile(new URL('../../../packages/database/project.json', import.meta.url), 'utf8').then(JSON.parse),
+    readFile(new URL('../../../apps/api/project.json', import.meta.url), 'utf8').then(JSON.parse),
+  ]);
+
+  const databaseBuild = databaseProject.targets.build;
+  const databaseTypecheck = databaseProject.targets.typecheck;
+  const apiTypecheck = apiProject.targets.typecheck;
+
+  assert.ok(databaseBuild.dependsOn.includes('prisma-generate'));
+  assert.doesNotMatch(databaseBuild.options.command, /prisma generate/u);
+  assert.ok(databaseTypecheck.dependsOn.includes('prisma-generate'));
+
+  assert.ok(
+    apiTypecheck.dependsOn.some(
+      (dependency) =>
+        typeof dependency === 'object' &&
+        dependency.target === 'prisma-generate' &&
+        Array.isArray(dependency.projects) &&
+        dependency.projects.includes('database'),
+    ),
+  );
+  assert.equal(apiProject.targets['prisma:generate'], undefined);
 });


### PR DESCRIPTION
## Summary

- make `database:prisma-generate` the single Nx-owned Prisma Client writer for build/typecheck
- remove API's nested `pnpm nx run database:prisma-generate` target and express the cross-project dependency directly in the top-level task graph
- add a governance regression test for the single-writer invariant

## Why

Release PR #268 exposed an intermittent `TS2306: generated/prisma/client.d.ts is not a module` failure. The same source state passes on clean reruns, which pointed to a task-graph race rather than a stable type error. Before this change, database build and the API typecheck path could independently regenerate the same tracked Prisma output while typecheck tasks were running in parallel.

## Validation

- red/green regression: `node --test tools/ci-cd-platform/__tests__/contracts.test.mjs`
- Nx graph: one `database:prisma-generate` node shared by database build/typecheck and API typecheck
- uncached `database` + `api` parallel typecheck: pass; generator ran once; legacy nested API generator ran zero times
- full workspace uncached typecheck: 35 projects + 29 dependency tasks passed
- `ci-cd-platform:lint`: pass
- `ci-cd-platform:governance`: 47/47 pass
- `memoflow:governance-check`: pass
- `memoflow:docs-check`: pass
- Test System V2 inventory: 1072 files, unchanged
- repository local deployment validator against `origin/main`: pass / ready for PR yes
  - affected lint/typecheck/test pass
  - isolated Docker ports 63180-63184
  - API/Postgres/PowerSync/Redis/Web healthy
  - API/Web revision evidence matched
